### PR TITLE
Enforcing order on production deployment jobs

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -50,6 +50,7 @@ jobs:
     if: github.ref == 'refs/heads/main' # Only run on main
     name: "Deploy Container"
     runs-on: ubuntu-latest
+    needs: [tag-image-for-prod]
     environment: production
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Make sure we tag the init container _before_ we push out a new revision