### PR TITLE
implemented union type with type adapters

### DIFF
--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -61,7 +61,7 @@ class ExternalIdentifierSQLRepository(
         """Initialize the repository with the database session."""
         super().__init__(
             session,
-            DomainExternalIdentifier,
+            DomainExternalIdentifier,  # type:ignore[arg-type]
             SQLExternalIdentifier,
         )
 

--- a/tests/unit/domain/references/models/test_models.py
+++ b/tests/unit/domain/references/models/test_models.py
@@ -12,7 +12,7 @@ from app.domain.references.models.models import (
     BibliographicMetadataEnhancement,
     Enhancement,
     EnhancementType,
-    ExternalIdentifierBase,
+    ExternalIdentifierCreateAdapter,
     ExternalIdentifierType,
     Location,
     LocationEnhancement,
@@ -132,90 +132,78 @@ def test_mismatched_enhancement_type():
 
 
 def test_valid_doi():
-    obj = ExternalIdentifierBase(
-        identifier_type=ExternalIdentifierType.DOI,
-        identifier="10.1000/xyz123",
-        other_identifier_name=None,
+    obj = ExternalIdentifierCreateAdapter.validate_python(
+        {
+            "identifier_type": ExternalIdentifierType.DOI,
+            "identifier": "10.1000/xyz123",
+            "other_identifier_name": None,
+        },
     )
     assert obj.identifier == "10.1000/xyz123"
 
 
 def test_invalid_doi():
-    with pytest.raises(ValueError, match="The provided DOI is not in a valid format."):
-        ExternalIdentifierBase(
-            identifier_type=ExternalIdentifierType.DOI,
-            identifier="invalid_doi",
-            other_identifier_name=None,
+    with pytest.raises(ValidationError):
+        ExternalIdentifierCreateAdapter.validate_python(
+            {
+                "identifier_type": ExternalIdentifierType.DOI,
+                "identifier": "invalid_doi",
+                "other_identifier_name": None,
+            }
         )
 
 
 def test_valid_pmid():
-    obj = ExternalIdentifierBase(
-        identifier_type=ExternalIdentifierType.PM_ID,
-        identifier="123456",
-        other_identifier_name=None,
+    obj = ExternalIdentifierCreateAdapter.validate_python(
+        {
+            "identifier_type": ExternalIdentifierType.PM_ID,
+            "identifier": "123456",
+            "other_identifier_name": None,
+        }
     )
-    assert obj.identifier == "123456"
+    assert obj.identifier == 123456
 
 
 def test_invalid_pmid():
-    with pytest.raises(ValueError, match="PM ID must be an integer."):
-        ExternalIdentifierBase(
-            identifier_type=ExternalIdentifierType.PM_ID,
-            identifier="abc123",
-            other_identifier_name=None,
+    with pytest.raises(ValidationError):
+        ExternalIdentifierCreateAdapter.validate_python(
+            {
+                "identifier_type": ExternalIdentifierType.PM_ID,
+                "identifier": "abc123",
+                "other_identifier_name": None,
+            }
         )
 
 
 def test_valid_open_alex():
     valid_openalex = "W123456789"
-    obj = ExternalIdentifierBase(
-        identifier_type=ExternalIdentifierType.OPEN_ALEX,
-        identifier=valid_openalex,
-        other_identifier_name=None,
+    obj = ExternalIdentifierCreateAdapter.validate_python(
+        {
+            "identifier_type": ExternalIdentifierType.OPEN_ALEX,
+            "identifier": valid_openalex,
+            "other_identifier_name": None,
+        }
     )
     assert obj.identifier == valid_openalex
 
 
 def test_invalid_open_alex():
-    with pytest.raises(
-        ValueError, match="The provided OpenAlex ID is not in a valid format."
-    ):
-        ExternalIdentifierBase(
-            identifier_type=ExternalIdentifierType.OPEN_ALEX,
-            identifier="invalid-openalex",
-            other_identifier_name=None,
+    with pytest.raises(ValidationError):
+        ExternalIdentifierCreateAdapter.validate_python(
+            {
+                "identifier_type": ExternalIdentifierType.OPEN_ALEX,
+                "identifier": "invalid-openalex",
+                "other_identifier_name": None,
+            }
         )
 
 
 def test_valid_other_identifier():
-    obj = ExternalIdentifierBase(
-        identifier_type=ExternalIdentifierType.OTHER,
-        identifier="custom_identifier",
-        other_identifier_name="custom_type",
+    obj = ExternalIdentifierCreateAdapter.validate_python(
+        {
+            "identifier_type": ExternalIdentifierType.OTHER,
+            "identifier": "custom_identifier",
+            "other_identifier_name": "custom_type",
+        }
     )
     assert obj.other_identifier_name == "custom_type"
-
-
-def test_invalid_other_identifier_missing_name():
-    with pytest.raises(
-        ValueError,
-        match="other_identifier_name must be provided when identifier_type is 'other'",
-    ):
-        ExternalIdentifierBase(
-            identifier_type=ExternalIdentifierType.OTHER,
-            identifier="custom_identifier",
-            other_identifier_name=None,
-        )
-
-
-def test_invalid_other_identifier_provided_when_not_other():
-    with pytest.raises(
-        ValueError,
-        match="other_identifier_name must be empty when identifier_type is not 'other'",
-    ):
-        ExternalIdentifierBase(
-            identifier_type=ExternalIdentifierType.DOI,
-            identifier="10.1000/xyz123",
-            other_identifier_name="unexpected",
-        )

--- a/tests/unit/domain/references/test_service.py
+++ b/tests/unit/domain/references/test_service.py
@@ -7,7 +7,7 @@ import pytest
 from app.domain.references.models.models import (
     AnnotationEnhancement,
     EnhancementCreate,
-    ExternalIdentifierCreate,
+    ExternalIdentifierCreateAdapter,
     Reference,
 )
 from app.domain.references.service import ReferenceService
@@ -54,7 +54,9 @@ async def test_add_identifier_happy_path(fake_repository, fake_uow):
     uow = fake_uow(references=repo_refs, external_identifiers=repo_ids)
     service = ReferenceService(uow)
     identifier_data = {"identifier": "W1234", "identifier_type": "open_alex"}
-    fake_identifier_create = ExternalIdentifierCreate(**identifier_data)
+    fake_identifier_create = ExternalIdentifierCreateAdapter.validate_python(
+        identifier_data
+    )
     returned_identifier = await service.add_identifier(dummy_id, fake_identifier_create)
     assert getattr(returned_identifier, "reference_id", None) == dummy_id
     for k, v in identifier_data.items():
@@ -104,8 +106,8 @@ async def test_add_identifier_reference_not_found(fake_repository, fake_uow):
     uow = fake_uow(references=repo_refs, external_identifiers=repo_ids)
     service = ReferenceService(uow)
     dummy_id = uuid.uuid4()
-    fake_identifier_create = ExternalIdentifierCreate(
-        identifier="W1234", identifier_type="open_alex"
+    fake_identifier_create = ExternalIdentifierCreateAdapter.validate_python(
+        {"identifier": "W1234", "identifier_type": "open_alex"}
     )
     with pytest.raises(RuntimeError):
         await service.add_identifier(dummy_id, fake_identifier_create)


### PR DESCRIPTION
Further eg of some union types parsing JSON - from this, I think 5 is best to go down the union type route, but I have probably missed something! This PR is a very brief implementation of 5.

```python
from pydantic import BaseModel, HttpUrl, Field, TypeAdapter
from typing import Annotated, Literal


class DOI(BaseModel):
    id: HttpUrl
    type: Literal["doi"] = "doi"


class PM_ID(BaseModel):
    id: int
    type: Literal["pmid"] = "pmid"


if __name__ == "__main__":
    json_payload = {
        "id": 12345,
        "type": "pmid",
    }

    # 1: Naive union
    EX_ID = DOI | PM_ID
    # id = EX_ID(id=json_payload["id"], type=json_payload["type"])
    # TypeError: 'types.UnionType' object is not callable

    # 2: Attempt at top-level discriminated union
    EX_ID = Annotated[DOI | PM_ID, Field(discriminator="type")]
    # id = EX_ID(id=json_payload["id"], type=json_payload["type"])
    # TypeError: 'types.UnionType' object is not callable

    # 3: Discriminated union in a nested model
    class EX_ID(BaseModel):
        id: DOI | PM_ID = Field(discriminator="type")
    id = EX_ID(id=json_payload)
    # This works - but the nesting is not ideal IMO

    # 4: Union with custom parsing
    if json_payload["type"] == "doi":
        id = DOI(id=json_payload["id"])
    elif json_payload["type"] == "pmid":
        id = PM_ID(id=json_payload["id"])
    # Of course this works too - but IMO it is nicer to have this branching in
    # the model itself rather than in code

    # 5: Use a type adapter
    EX_ID = TypeAdapter(DOI | PM_ID)
    id = EX_ID.validate_python(json_payload)
    print(id)
```