### PR TITLE
Added default value for annotation types in sdk

### DIFF
--- a/libs/sdk/src/destiny_sdk/enhancements.py
+++ b/libs/sdk/src/destiny_sdk/enhancements.py
@@ -161,7 +161,7 @@ class ScoreAnnotation(BaseModel):
     as to the application of the label.
     """
 
-    annotation_type: Literal[AnnotationType.SCORE]
+    annotation_type: Literal[AnnotationType.SCORE] = AnnotationType.SCORE
     scheme: str = Field(
         description="An identifier for the scheme of annotation",
         examples=["openalex:topic", "pubmed:mesh"],
@@ -186,7 +186,7 @@ class BooleanAnnotation(BaseModel):
     initial cases.
     """
 
-    annotation_type: Literal[AnnotationType.BOOLEAN]
+    annotation_type: Literal[AnnotationType.BOOLEAN] = AnnotationType.BOOLEAN
     scheme: str = Field(
         description="An identifier for the scheme of the annotation",
         examples=["openalex:topic", "pubmed:mesh"],


### PR DESCRIPTION
This means that we don't need to set the annotation type when creating an annotation enhancement, same as how we do enhancement type. 