### PR TITLE
Allow DOIIdentifier to handle DOI URLs

### DIFF
--- a/libs/sdk/src/destiny_sdk/identifiers.py
+++ b/libs/sdk/src/destiny_sdk/identifiers.py
@@ -3,7 +3,7 @@
 from enum import StrEnum
 from typing import Annotated, Literal
 
-from pydantic import UUID4, BaseModel, Field
+from pydantic import UUID4, BaseModel, BeforeValidator, Field
 
 
 class ExternalIdentifierType(StrEnum):
@@ -27,10 +27,17 @@ class ExternalIdentifierType(StrEnum):
     OTHER = "other"
 
 
+def remove_doi_url(value: str) -> str:
+    """Remove the URL part of the DOI if it exists."""
+    return (
+        value.removeprefix("http://doi.org/").removeprefix("https://doi.org/").strip()
+    )
+
+
 class DOIIdentifier(BaseModel):
     """An external identifier representing a DOI."""
 
-    identifier: str = Field(
+    identifier: Annotated[str, BeforeValidator(remove_doi_url)] = Field(
         description="The DOI of the reference.",
         pattern=r"^10\.\d{4,9}/[-._;()/:a-zA-Z0-9%<>\[\]+&]+$",
     )

--- a/tests/unit/sdk/test_identifiers.py
+++ b/tests/unit/sdk/test_identifiers.py
@@ -19,6 +19,15 @@ def test_invalid_doi():
         )
 
 
+def test_fix_doi():
+    """Test that a DOI with a URL is fixed to just the DOI part."""
+    obj = destiny_sdk.identifiers.DOIIdentifier(
+        identifier_type=destiny_sdk.identifiers.ExternalIdentifierType.DOI,
+        identifier="http://doi.org/10.1000/xyz123",
+    )
+    assert obj.identifier == "10.1000/xyz123"
+
+
 def test_valid_pmid():
     obj = destiny_sdk.identifiers.PubMedIdentifier(
         identifier_type=destiny_sdk.identifiers.ExternalIdentifierType.PM_ID,


### PR DESCRIPTION
Add a `BeforeValidator` to DOIIdentifier which removes the URL scheme and host leaving just the DOI path. This maintains our DOI format and validation, but normalises inputs.