### PR TITLE
Bump container-app module to 1.6.0

### DIFF
--- a/infra/app/main.tf
+++ b/infra/app/main.tf
@@ -104,7 +104,7 @@ locals {
 
 module "container_app" {
   source                          = "app.terraform.io/destiny-evidence/container-app/azure"
-  version                         = "1.5.0"
+  version                         = "1.6.0"
   app_name                        = var.app_name
   cpu                             = var.container_app_cpu
   environment                     = var.environment
@@ -170,7 +170,7 @@ module "container_app" {
 
 module "container_app_tasks" {
   source                          = "app.terraform.io/destiny-evidence/container-app/azure"
-  version                         = "1.5.0"
+  version                         = "1.6.0"
   app_name                        = "${var.app_name}-task"
   cpu                             = var.container_app_tasks_cpu
   environment                     = var.environment


### PR DESCRIPTION
Bump container-app module to 1.6.0 to support authentication in custom scale rules.

https://github.com/futureevidence/terraform-azure-container-app/compare/1.5.0...1.6.0