### PR TITLE
Hotfix/terminal retrying state

### DIFF
--- a/app/domain/imports/routes.py
+++ b/app/domain/imports/routes.py
@@ -108,6 +108,7 @@ async def enqueue_batch(
     logger.info("Enqueueing import batch", extra={"import_batch_id": import_batch.id})
     await process_import_batch.kiq(
         import_batch_id=import_batch.id,
+        remaining_retries=settings.import_batch_retry_count,
     )
     return await import_batch.to_sdk()
 

--- a/app/domain/imports/service.py
+++ b/app/domain/imports/service.py
@@ -1,7 +1,7 @@
 """The service for interacting with and managing imports."""
 
 import httpx
-from asyncpg.exceptions import DeadlockDetectedError
+from asyncpg.exceptions import DeadlockDetectedError  # type: ignore[import-untyped]
 from pydantic import UUID4
 
 from app.core.exceptions import SQLIntegrityError

--- a/app/domain/imports/tasks.py
+++ b/app/domain/imports/tasks.py
@@ -35,9 +35,15 @@ async def get_import_service(
 
 
 @broker.task
-async def process_import_batch(import_batch_id: UUID4) -> None:
+async def process_import_batch(import_batch_id: UUID4, remaining_retries: int) -> None:
     """Async logic for processing an import batch."""
-    logger.info("Processing import batch", extra={"import_batch_id": import_batch_id})
+    logger.info(
+        "Processing import batch",
+        extra={
+            "import_batch_id": import_batch_id,
+            "remaining_retries": remaining_retries,
+        },
+    )
     import_service = await get_import_service()
 
     import_batch = await import_service.get_import_batch(import_batch_id)
@@ -54,4 +60,26 @@ async def process_import_batch(import_batch_id: UUID4) -> None:
         )
         return
 
-    await import_service.process_batch(import_batch)
+    status = await import_service.process_batch(import_batch)
+    if status == ImportBatchStatus.RETRYING:
+        remaining_retries -= 1
+        if remaining_retries >= 0:
+            logger.info(
+                "Retrying import batch.",
+                extra={
+                    "import_batch_id": import_batch_id,
+                    "remaining_retries": remaining_retries,
+                },
+            )
+            await process_import_batch.kiq(import_batch.id, remaining_retries)
+        else:
+            logger.info(
+                "No remaining retries for import batch, marking as failed.",
+                extra={
+                    "import_batch_id": import_batch_id,
+                    "remaining_retries": remaining_retries,
+                },
+            )
+            await import_service.update_import_batch_status(
+                import_batch.id, ImportBatchStatus.FAILED
+            )

--- a/app/domain/imports/tasks.py
+++ b/app/domain/imports/tasks.py
@@ -62,8 +62,7 @@ async def process_import_batch(import_batch_id: UUID4, remaining_retries: int) -
 
     status = await import_service.process_batch(import_batch)
     if status == ImportBatchStatus.RETRYING:
-        remaining_retries -= 1
-        if remaining_retries >= 0:
+        if remaining_retries:
             logger.info(
                 "Retrying import batch.",
                 extra={
@@ -71,7 +70,7 @@ async def process_import_batch(import_batch_id: UUID4, remaining_retries: int) -
                     "remaining_retries": remaining_retries,
                 },
             )
-            await process_import_batch.kiq(import_batch.id, remaining_retries)
+            await process_import_batch.kiq(import_batch.id, remaining_retries - 1)
         else:
             logger.info(
                 "No remaining retries for import batch, marking as failed.",

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -5,6 +5,7 @@ from taskiq_aio_pika import AioPikaBroker
 
 from app.core.azure_service_bus_broker import AzureServiceBusBroker
 from app.core.config import Environment, get_settings
+from app.core.logger import configure_logger
 from app.persistence.sql.session import db_manager
 
 settings = get_settings()
@@ -19,6 +20,8 @@ if settings.env == Environment.LOCAL:
     broker = AioPikaBroker(settings.message_broker_url)
 elif settings.env == "test":
     broker = InMemoryBroker()
+
+configure_logger(rich_rendering=settings.running_locally)
 
 
 @broker.on_event(TaskiqEvents.WORKER_STARTUP)


### PR DESCRIPTION
- Set state to Failed when retries are all out.
- Move retries to task queue - better implementation and also hopefully more resilient to transient failure with a break in between runs.
- Catch and retry on deadlock.