### PR TITLE
Remove azurerm_resource_provider_registration

### DIFF
--- a/infra/app/main.tf
+++ b/infra/app/main.tf
@@ -362,10 +362,6 @@ resource "azurerm_role_assignment" "blob_storage_rw" {
   principal_id         = each.value
 }
 
-resource "azurerm_resource_provider_registration" "elastic" {
-  name = "Microsoft.Elastic"
-}
-
 resource "ec_deployment" "cluster" {
   name = "${var.app_name}-${substr(var.environment, 0, 4)}-es"
   region                 = var.elasticsearch_region


### PR DESCRIPTION
We're no longer managing the azure elastic subscription via Terraform, since it doesn't allow us to manage deployments.

See https://github.com/destiny-evidence/destiny-repository/pull/143#discussion_r2154382679