### PR TITLE
Add cluster:monitor permissions to elasticsearch read-only api key

### DIFF
--- a/infra/app/main.tf
+++ b/infra/app/main.tf
@@ -407,6 +407,7 @@ resource "elasticstack_elasticsearch_security_api_key" "read_only" {
   name = "${var.app_name}-${var.environment}-read-only"
   role_descriptors = jsonencode({
     app_access = {
+      cluster = ["monitor"]
       indices = [
         {
           names      = ["${var.app_name}-*"]


### PR DESCRIPTION
cluster:monitor permissions are needed by [ping()](https://github.com/destiny-evidence/demonstrator-ui/pull/13/files#diff-28c13b1196e36fd800bbc32afc4bd84a12d6c433cbd78c80f5d5756d3025cf12R41).