### PR TITLE
Add a DenseEmbeddings enhancement to the SDK

### DIFF
--- a/libs/sdk/src/destiny_sdk/enhancements.py
+++ b/libs/sdk/src/destiny_sdk/enhancements.py
@@ -352,7 +352,7 @@ class DenseEmbeddingsEnhancement(BaseModel):
     enhancement_type: Literal[EnhancementType.DENSE_EMBEDDINGS] = (
         EnhancementType.DENSE_EMBEDDINGS
     )
-    embedding: list[DenseEmbedding] = Field(
+    embeddings: list[DenseEmbedding] = Field(
         description="A list of embeddings for the reference."
     )
     model_version: str = Field(

--- a/libs/sdk/src/destiny_sdk/enhancements.py
+++ b/libs/sdk/src/destiny_sdk/enhancements.py
@@ -29,6 +29,7 @@ class EnhancementType(StrEnum):
     ANNOTATION = auto()
     LOCATION = auto()
     FULL_TEXT = auto()
+    DENSE_EMBEDDINGS = auto()
 
 
 class AuthorPosition(StrEnum):
@@ -303,12 +304,69 @@ class LocationEnhancement(BaseModel):
     )
 
 
+class DenseEmbedding(BaseModel):
+    """
+    A dense embedding of some part or parts of a reference.
+
+    These may be use for semantic search, classification, or other applications.
+
+    The `identifier` is free text and should be used to group like embeddings across
+    references. For example, if you have an embedding for the title of a reference,
+    you might use `title_embedding` as the identifier. You do not need to include model
+    details in the identifier, as these are captured in the `model_version` field of the
+    enhancement.
+    """
+
+    embedding: list[float] = Field(
+        description="A list of floats representing the dense embedding."
+    )
+    num_dimensions: int = Field(
+        description="The number of dimensions in the dense embedding."
+    )
+    identifier: str = Field(
+        description="""
+An arbitrary identifier for the embedding to collect like embeddings across references
+""",
+    )
+    description: str | None = Field(
+        default=None,
+        description="""
+A description of the embedding, such as the part of the reference it represents.
+""",
+    )
+
+
+class DenseEmbeddingsEnhancement(BaseModel):
+    """
+    An enhancement which contains a dense embedding of the reference.
+
+    This is used for semantic search and other applications.
+
+    A single enhancement may contain multiple embeddings, which may be derived
+    from different parts of the reference, such as the title, abstract, or full text
+    (or even parts of the full text to support RAG approaches).
+
+    All embeddings included should be from a single model version.
+    """
+
+    enhancement_type: Literal[EnhancementType.DENSE_EMBEDDINGS] = (
+        EnhancementType.DENSE_EMBEDDINGS
+    )
+    embedding: list[DenseEmbedding] = Field(
+        description="A list of embeddings for the reference."
+    )
+    model_version: str = Field(
+        description="The version of the model used to generate the embedding."
+    )
+
+
 #: Union type for all enhancement content types.
 EnhancementContent = Annotated[
     BibliographicMetadataEnhancement
     | AbstractContentEnhancement
     | AnnotationEnhancement
-    | LocationEnhancement,
+    | LocationEnhancement
+    | DenseEmbeddingsEnhancement,
     Field(discriminator="enhancement_type"),
 ]
 

--- a/libs/sdk/tests/unit/test_enhancements.py
+++ b/libs/sdk/tests/unit/test_enhancements.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import date
 
 import destiny_sdk
+from destiny_sdk.visibility import Visibility
 
 
 def test_bibliographic_metadata_enhancement_valid():
@@ -100,3 +101,26 @@ def test_location_enhancement_valid():
         reference_id=uuid.uuid4(),
     )
     assert enhancement.content.locations[0].license == "cc-by"
+
+
+def test_dense_embeddings_enhancement_valid():
+    embedding1 = destiny_sdk.enhancements.DenseEmbedding(
+        embedding=[0.1, 0.2, 0.3],
+        num_dimensions=3,
+        identifier="title_embedding",
+        description="Title embedding",
+    )
+    dense_embeddings_content = destiny_sdk.enhancements.DenseEmbeddingsEnhancement(
+        enhancement_type=destiny_sdk.enhancements.EnhancementType.DENSE_EMBEDDINGS,
+        embeddings=[embedding1],
+        model_version="My Great Model 2025-07-09",
+    )
+    enhancement = destiny_sdk.enhancements.Enhancement(
+        id=uuid.uuid4(),
+        source="test_source",
+        visibility=Visibility.PUBLIC,
+        robot_version="1.3",
+        content=dense_embeddings_content,
+        reference_id=uuid.uuid4(),
+    )
+    assert enhancement.content.embeddings[0].identifier == "title_embedding"


### PR DESCRIPTION
This allows for multiple embeddings to be created across a single enhancement, supporting document chunking or embedding fields separately.