### PR TITLE
165 make sdk publishing a GitHub action

### DIFF
--- a/.github/workflows/release-sdk-to-pypi.yml
+++ b/.github/workflows/release-sdk-to-pypi.yml
@@ -3,14 +3,14 @@ name: Release SDK to PyPI
 on:
   workflow_dispatch:
     inputs:
-      pypi_registry:
-        description: "PyPI Registry"
+      environment:
+        description: "Deployment Environment"
         required: true
-        default: "test-pypi"
+        default: "staging"
         type: choice
         options:
-          - test-pypi
-          - pypi
+          - staging
+          - production
       branch:
         description: "Branch to deploy from"
         required: true
@@ -21,8 +21,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     environment:
-      name: ${{ inputs.pypi_registry }}
-      url: ${{ inputs.pypi_registry == 'test-pypi' && 'https://test.pypi.org' || 'https://pypi.org' }}
+      name: ${{ inputs.environment }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -49,22 +48,21 @@ jobs:
         with:
           virtualenvs-create: false
 
-      - name: Build and publish package
-        env:
-          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
-          POETRY_PYPI_TOKEN_TESTPYPI: ${{ secrets.TEST_PYPI_API_TOKEN }}
+      - name: Configure PyPI repositories
+        if: ${{ vars.PYPI_REPOSITORY == 'testpypi' }}
         run: |
           cd libs/sdk
+          poetry config repositories.testpypi https://test.pypi.org/legacy/
+
+      - name: Build and publish package
+        run: |
+          cd libs/sdk
+          export POETRY_PYPI_TOKEN_$(echo "${{ vars.PYPI_REPOSITORY }}" | tr '[:lower:]' '[:upper:]')="${{ secrets.PYPI_TOKEN }}"
           poetry build
-          if [ "${{ inputs.pypi_registry }}" = "test-pypi" ]; then
-            poetry config repositories.testpypi https://test.pypi.org/legacy/
-            poetry publish --repository testpypi
-          else
-            poetry publish
-          fi
+          poetry publish --repository ${{ vars.PYPI_REPOSITORY }}
 
       - name: Create GitHub Release
-        if: ${{ inputs.pypi_registry == 'pypi' }}
+        if: ${{ vars.PYPI_REPOSITORY == 'pypi' }}
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-sdk-to-pypi.yml
+++ b/.github/workflows/release-sdk-to-pypi.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: "Deployment Environment"
+        description: "Deployment Environment. Staging deploys to testpypi."
         required: true
         default: "staging"
         type: choice

--- a/.github/workflows/release-sdk-to-pypi.yml
+++ b/.github/workflows/release-sdk-to-pypi.yml
@@ -1,0 +1,85 @@
+name: Release SDK to PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      pypi_registry:
+        description: "PyPI Registry"
+        required: true
+        default: "test-pypi"
+        type: choice
+        options:
+          - test-pypi
+          - pypi
+      branch:
+        description: "Branch to deploy from"
+        required: true
+        default: "main"
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.pypi_registry }}
+      url: ${{ inputs.pypi_registry == 'test-pypi' && 'https://test.pypi.org' || 'https://pypi.org' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Extract version from pyproject.toml
+        id: extract-version
+        run: |
+          cd libs/sdk
+          VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          PACKAGE_NAME=$(grep '^name = ' pyproject.toml | sed 's/name = "\(.*\)"/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "package_name=$PACKAGE_NAME" >> $GITHUB_OUTPUT
+          echo "📦 Package: $PACKAGE_NAME v$VERSION"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: false
+
+      - name: Build and publish package
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
+          POETRY_PYPI_TOKEN_TESTPYPI: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        run: |
+          cd libs/sdk
+          poetry build
+          if [ "${{ inputs.pypi_registry }}" = "test-pypi" ]; then
+            poetry config repositories.testpypi https://test.pypi.org/legacy/
+            poetry publish --repository testpypi
+          else
+            poetry publish
+          fi
+
+      - name: Create GitHub Release
+        if: ${{ inputs.pypi_registry == 'pypi' }}
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: sdk-v${{ steps.extract-version.outputs.version }}
+          release_name: SDK Release v${{ steps.extract-version.outputs.version }}
+          body: |
+            Released ${{ steps.extract-version.outputs.package_name }} v${{ steps.extract-version.outputs.version }} from `${{ inputs.branch }}`
+
+            ## 📦 Package
+            - [View on PyPI](https://pypi.org/project/${{ steps.extract-version.outputs.package_name }}/${{ steps.extract-version.outputs.version }}/)
+
+            ## 🚀 Installation
+            ```bash
+            pip install ${{ steps.extract-version.outputs.package_name }}==${{ steps.extract-version.outputs.version }}
+            ```
+          draft: false
+          prerelease: false

--- a/.github/workflows/release-sdk-to-pypi.yml
+++ b/.github/workflows/release-sdk-to-pypi.yml
@@ -11,11 +11,6 @@ on:
         options:
           - staging
           - production
-      branch:
-        description: "Branch to deploy from"
-        required: true
-        default: "main"
-        type: string
 
 jobs:
   release:

--- a/.github/workflows/release-sdk-to-pypi.yml
+++ b/.github/workflows/release-sdk-to-pypi.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.branch }}
 
       - name: Extract version from pyproject.toml
         id: extract-version

--- a/infra/app/github_actions.tf
+++ b/infra/app/github_actions.tf
@@ -87,3 +87,17 @@ resource "github_actions_environment_variable" "resource_group" {
   variable_name = "RESOURCE_GROUP"
   value         = azurerm_resource_group.this.name
 }
+
+resource "github_actions_environment_variable" "pypi_repository" {
+  repository    = github_repository_environment.environment.repository
+  environment   = github_repository_environment.environment.environment
+  variable_name = "PYPI_REPOSITORY"
+  value         = var.pypi_repository
+}
+
+resource "github_actions_environment_secret" "pypi_token" {
+  repository      = github_repository_environment.environment.repository
+  environment     = github_repository_environment.environment.environment
+  secret_name     = "PYPI_TOKEN"
+  plaintext_value = var.pypi_token
+}

--- a/infra/app/variables.tf
+++ b/infra/app/variables.tf
@@ -186,3 +186,16 @@ variable "elastic_cloud_apikey" {
   type        = string
   sensitive   = true
 }
+
+
+variable "pypi_token" {
+  description = "API token for PyPI"
+  type        = string
+  sensitive   = true
+}
+
+
+variable "pypi_repository" {
+  description = "PyPI repository to publish to, either 'pypi' or 'testpypi'"
+  type        = string
+}

--- a/tests/e2e/enhancements/test_batch_enhancements.py
+++ b/tests/e2e/enhancements/test_batch_enhancements.py
@@ -161,7 +161,7 @@ def test_complete_batch_enhancement_workflow():  # noqa: C901, PLR0912, PLR0915
             msg = "Expected toy robot enhancements not found in reference."
             raise AssertionError(msg)
 
-    time.sleep(1)
+    time.sleep(3)
     es = Elasticsearch(
         os.environ["ES_URL"],
         basic_auth=(os.environ["ES_USER"], os.environ["ES_PASS"]),


### PR DESCRIPTION
Implements #165 - click-ops action to deploy SDK to pypi & add a github release for it.

Staging env will deploy to test.pypi, production to pypi. TF handles the respective vars.

See successful testpypi run here: https://github.com/destiny-evidence/destiny-repository/actions/runs/16212066273.