### PR TITLE
122 references acl

### DIFF
--- a/app/domain/base.py
+++ b/app/domain/base.py
@@ -2,9 +2,7 @@
 
 import datetime
 import uuid
-from abc import ABC, abstractmethod
 
-from destiny_sdk.core import _JsonlFileInputMixIn
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -65,16 +63,3 @@ class SQLTimestampMixin(SQLAttributeMixin):
         default_factory=utc_now,
         description="The timestamp at which the object was last updated.",
     )
-
-
-class SDKJsonlMixin(BaseModel, ABC):
-    """
-    Mixin for SDK JSONL attributes.
-
-    This flags that the model is used by the SDK to marshal
-    data in and out of JSONL files.
-    """
-
-    @abstractmethod
-    async def to_sdk(self) -> _JsonlFileInputMixIn:
-        """Convert the model to an SDK JSONL input mixin."""

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -1,7 +1,6 @@
 """Models associated with references."""
 
 import uuid
-from collections.abc import Awaitable, Callable
 from enum import StrEnum, auto
 from typing import Any, Self
 
@@ -14,16 +13,13 @@ from pydantic import (
     UUID4,
     BaseModel,
     Field,
-    HttpUrl,
     TypeAdapter,
-    ValidationError,
 )
 
-from app.core.exceptions import SDKToDomainError
 from app.core.logger import get_logger
 from app.domain.base import DomainBaseModel, SDKJsonlMixin, SQLAttributeMixin
 from app.domain.imports.models.models import CollisionStrategy
-from app.persistence.blob.models import BlobSignedUrlType, BlobStorageFile
+from app.persistence.blob.models import BlobStorageFile
 
 logger = get_logger()
 

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -17,7 +17,7 @@ from pydantic import (
 )
 
 from app.core.logger import get_logger
-from app.domain.base import DomainBaseModel, SDKJsonlMixin, SQLAttributeMixin
+from app.domain.base import DomainBaseModel, SQLAttributeMixin
 from app.domain.imports.models.models import CollisionStrategy
 from app.persistence.blob.models import BlobStorageFile
 
@@ -399,7 +399,7 @@ Errors for individual references are provided <TBC>.
         return len(self.reference_ids)
 
 
-class BatchRobotResultValidationEntry(DomainBaseModel, SDKJsonlMixin):
+class BatchRobotResultValidationEntry(DomainBaseModel):
     """A single entry in the validation result file for a batch enhancement request."""
 
     reference_id: uuid.UUID | None = Field(

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -101,7 +101,6 @@ class Visibility(StrEnum):
 
 class Reference(
     DomainBaseModel,
-    SDKJsonlMixin,
     SQLAttributeMixin,
 ):
     """Core reference model with database attributes included."""
@@ -118,55 +117,6 @@ class Reference(
         default=None,
         description="A list of enhancements for the reference",
     )
-
-    async def to_sdk(self) -> destiny_sdk.references.Reference:
-        """Convert the reference to the SDK model."""
-        try:
-            return destiny_sdk.references.Reference(
-                id=self.id,
-                visibility=self.visibility,
-                identifiers=[
-                    (await identifier.to_sdk()).identifier
-                    for identifier in self.identifiers or []
-                ],
-                enhancements=[
-                    await enhancement.to_sdk()
-                    for enhancement in self.enhancements or []
-                ],
-            )
-        except ValidationError as exception:
-            raise SDKToDomainError(errors=exception.errors()) from exception
-
-    @classmethod
-    async def from_file_input(
-        cls,
-        reference_in: destiny_sdk.references.ReferenceFileInput,
-        reference_id: uuid.UUID | None = None,
-    ) -> Self:
-        """Create a reference including id hydration."""
-        try:
-            reference = cls(
-                visibility=reference_in.visibility,
-            )
-            if reference_id:
-                reference.id = reference_id
-            reference.identifiers = [
-                LinkedExternalIdentifier(
-                    reference_id=reference.id, identifier=identifier
-                )
-                for identifier in reference_in.identifiers or []
-            ]
-            reference.enhancements = [
-                Enhancement.model_validate(
-                    enhancement.model_dump() | {"reference_id": reference.id}
-                )
-                for enhancement in reference_in.enhancements or []
-            ]
-            reference.check_serializability()
-        except ValidationError as exception:
-            raise SDKToDomainError(errors=exception.errors()) from exception
-        else:
-            return reference
 
     async def merge(  # noqa: PLR0912
         self,
@@ -305,32 +255,6 @@ class LinkedExternalIdentifier(DomainBaseModel, SQLAttributeMixin):
         description="The reference this identifier identifies.",
     )
 
-    @classmethod
-    async def from_sdk(
-        cls,
-        external_identifier: destiny_sdk.identifiers.LinkedExternalIdentifier,
-    ) -> Self:
-        """Create an external identifier from the SDK model."""
-        try:
-            c = cls.model_validate(
-                external_identifier.model_dump(),
-            )
-            c.check_serializability()
-        except ValidationError as exception:
-            raise SDKToDomainError(errors=exception.errors()) from exception
-        else:
-            return c
-
-    async def to_sdk(self) -> destiny_sdk.identifiers.LinkedExternalIdentifier:
-        """Convert the external identifier to the SDK model."""
-        try:
-            return destiny_sdk.identifiers.LinkedExternalIdentifier(
-                identifier=ExternalIdentifierAdapter.validate_python(self.identifier),
-                reference_id=self.reference_id,
-            )
-        except ValidationError as exception:
-            raise SDKToDomainError(errors=exception.errors()) from exception
-
 
 class GenericExternalIdentifier(DomainBaseModel):
     """
@@ -351,7 +275,7 @@ class GenericExternalIdentifier(DomainBaseModel):
     )
 
     @classmethod
-    async def from_specific(
+    def from_specific(
         cls,
         external_identifier: ExternalIdentifier,
     ) -> Self:
@@ -399,38 +323,6 @@ class Enhancement(DomainBaseModel, SQLAttributeMixin):
         description="The reference this enhancement is associated with.",
     )
 
-    @classmethod
-    async def from_sdk(
-        cls,
-        enhancement: destiny_sdk.enhancements.Enhancement,
-        reference_id: uuid.UUID | None = None,
-    ) -> Self:
-        """Create an enhancement from the SDK model."""
-        try:
-            enhancement_model = enhancement.model_dump()
-
-            ## The SDK isn't allowed to pass in ids, so ignore this.
-            enhancement_model.pop("id", None)
-
-            c = cls.model_validate(
-                enhancement_model
-                | ({"reference_id": reference_id} if reference_id else {})
-            )
-            c.check_serializability()
-        except ValidationError as exception:
-            raise SDKToDomainError(errors=exception.errors()) from exception
-        else:
-            return c
-
-    async def to_sdk(self) -> destiny_sdk.enhancements.Enhancement:
-        """Convert the enhancement to the SDK model."""
-        try:
-            return destiny_sdk.enhancements.Enhancement.model_validate(
-                self.model_dump(),
-            )
-        except ValidationError as exception:
-            raise SDKToDomainError(errors=exception.errors()) from exception
-
 
 class EnhancementRequest(DomainBaseModel, SQLAttributeMixin):
     """Request to add an enhancement to a specific reference."""
@@ -462,31 +354,6 @@ class EnhancementRequest(DomainBaseModel, SQLAttributeMixin):
         None,
         description="The reference this enhancement is associated with.",
     )
-
-    @classmethod
-    async def from_sdk(
-        cls,
-        enhancement_request: destiny_sdk.robots.EnhancementRequestIn,
-    ) -> Self:
-        """Create an enhancement request from the SDK model."""
-        try:
-            c = cls.model_validate(
-                enhancement_request.model_dump(),
-            )
-            c.check_serializability()
-        except ValidationError as exception:
-            raise SDKToDomainError(errors=exception.errors()) from exception
-        else:
-            return c
-
-    async def to_sdk(self) -> destiny_sdk.robots.EnhancementRequestRead:
-        """Convert the enhancement request to the SDK model."""
-        try:
-            return destiny_sdk.robots.EnhancementRequestRead.model_validate(
-                self.model_dump(),
-            )
-        except ValidationError as exception:
-            raise SDKToDomainError(errors=exception.errors()) from exception
 
 
 class BatchEnhancementRequest(DomainBaseModel, SQLAttributeMixin):
@@ -535,75 +402,6 @@ Errors for individual references are provided <TBC>.
         """The number of references in the request."""
         return len(self.reference_ids)
 
-    @classmethod
-    async def from_sdk(
-        cls,
-        enhancement_request: destiny_sdk.robots.BatchEnhancementRequestIn,
-    ) -> Self:
-        """Create an enhancement request from the SDK model."""
-        try:
-            c = cls.model_validate(enhancement_request.model_dump())
-            c.check_serializability()
-        except ValidationError as exception:
-            raise SDKToDomainError(errors=exception.errors()) from exception
-        else:
-            return c
-
-    async def to_sdk(
-        self,
-        to_signed_url: Callable[
-            [BlobStorageFile, BlobSignedUrlType], Awaitable[HttpUrl]
-        ],
-    ) -> destiny_sdk.robots.BatchEnhancementRequestRead:
-        """Convert the enhancement request to the SDK model."""
-        try:
-            return destiny_sdk.robots.BatchEnhancementRequestRead.model_validate(
-                self.model_dump()
-                | {
-                    "reference_data_url": await to_signed_url(
-                        self.reference_data_file, BlobSignedUrlType.DOWNLOAD
-                    )
-                    if self.reference_data_file
-                    else None,
-                    "result_storage_url": await to_signed_url(
-                        self.result_file, BlobSignedUrlType.UPLOAD
-                    )
-                    if self.result_file
-                    else None,
-                    "validation_result_url": await to_signed_url(
-                        self.validation_result_file, BlobSignedUrlType.DOWNLOAD
-                    )
-                    if self.validation_result_file
-                    else None,
-                },
-            )
-        except ValidationError as exception:
-            raise SDKToDomainError(errors=exception.errors()) from exception
-
-    async def to_batch_robot_request_sdk(
-        self,
-        to_signed_url: Callable[
-            [BlobStorageFile, BlobSignedUrlType], Awaitable[HttpUrl]
-        ],
-    ) -> destiny_sdk.robots.BatchRobotRequest:
-        """Convert the enhancement request to the SDK robot request model."""
-        try:
-            return destiny_sdk.robots.BatchRobotRequest(
-                id=self.id,
-                reference_storage_url=await to_signed_url(
-                    self.reference_data_file, BlobSignedUrlType.DOWNLOAD
-                )
-                if self.reference_data_file
-                else None,
-                result_storage_url=await to_signed_url(
-                    self.result_file, BlobSignedUrlType.UPLOAD
-                )
-                if self.result_file
-                else None,
-            )
-        except ValidationError as exception:
-            raise SDKToDomainError(errors=exception.errors()) from exception
-
 
 class BatchRobotResultValidationEntry(DomainBaseModel, SDKJsonlMixin):
     """A single entry in the validation result file for a batch enhancement request."""
@@ -623,17 +421,6 @@ class BatchRobotResultValidationEntry(DomainBaseModel, SDKJsonlMixin):
         ),
     )
 
-    async def to_sdk(
-        self,
-    ) -> destiny_sdk.robots.BatchRobotResultValidationEntry:
-        """Convert the validation entry to the SDK model."""
-        try:
-            return destiny_sdk.robots.BatchRobotResultValidationEntry.model_validate(
-                self.model_dump(),
-            )
-        except ValidationError as exception:
-            raise SDKToDomainError(errors=exception.errors()) from exception
-
 
 class RobotAutomation(DomainBaseModel, SQLAttributeMixin):
     """
@@ -650,26 +437,6 @@ class RobotAutomation(DomainBaseModel, SQLAttributeMixin):
     query: dict[str, Any] = Field(
         description="The query that will be used to match references against."
     )
-
-    @classmethod
-    async def from_sdk(
-        cls, data: destiny_sdk.robots.RobotAutomationIn, robot_id: uuid.UUID
-    ) -> Self:
-        """Create a RobotAutomation from the SDK input model."""
-        try:
-            c = cls.model_validate(data.model_dump() | {"robot_id": robot_id})
-            c.check_serializability()
-        except ValidationError as exception:
-            raise SDKToDomainError(errors=exception.errors()) from exception
-        else:
-            return c
-
-    async def to_sdk(self) -> destiny_sdk.robots.RobotAutomation:
-        """Convert the RobotAutomation to a RobotAutomation SDK model."""
-        try:
-            return destiny_sdk.robots.RobotAutomation.model_validate(self.model_dump())
-        except ValidationError as exception:
-            raise SDKToDomainError(errors=exception.errors()) from exception
 
 
 class RobotAutomationPercolationResult(BaseModel):

--- a/app/domain/references/routes.py
+++ b/app/domain/references/routes.py
@@ -32,6 +32,9 @@ from app.domain.references.tasks import (
 )
 from app.domain.robots.robot_request_dispatcher import RobotRequestDispatcher
 from app.domain.robots.service import RobotService
+from app.domain.robots.services.anti_corruption_service import (
+    RobotAntiCorruptionService,
+)
 from app.persistence.blob.repository import BlobRepository
 from app.persistence.es.client import get_client
 from app.persistence.es.uow import AsyncESUnitOfWork
@@ -73,9 +76,15 @@ def reference_service(
 
 def robot_service(
     sql_uow: Annotated[AsyncSqlUnitOfWork, Depends(sql_unit_of_work)],
+    robot_anti_corruption_service: Annotated[
+        RobotAntiCorruptionService, Depends(RobotAntiCorruptionService)
+    ],
 ) -> RobotService:
     """Return the robot service using the provided unit of work dependencies."""
-    return RobotService(sql_uow=sql_uow)
+    return RobotService(
+        sql_uow=sql_uow,
+        anti_corruption_service=robot_anti_corruption_service,
+    )
 
 
 def robot_request_dispatcher() -> RobotRequestDispatcher:

--- a/app/domain/references/routes.py
+++ b/app/domain/references/routes.py
@@ -261,7 +261,7 @@ async def request_batch_enhancement(
     ],
 ) -> destiny_sdk.robots.BatchEnhancementRequestRead:
     """Request the creation of an enhancement against a provided reference id."""
-    enhancement_request = await reference_service.register_batch_reference_enhancement_request(
+    enhancement_request = await reference_service.register_batch_reference_enhancement_request(  # noqa: E501
         enhancement_request=anti_corruption_service.batch_enhancement_request_from_sdk(
             enhancement_request_in
         ),

--- a/app/domain/references/service.py
+++ b/app/domain/references/service.py
@@ -21,7 +21,6 @@ from app.core.exceptions import (
     WrongReferenceError,
 )
 from app.core.logger import get_logger
-from app.domain.base import SDKJsonlMixin
 from app.domain.imports.models.models import CollisionStrategy
 from app.domain.references.models.models import (
     BatchEnhancementRequest,

--- a/app/domain/references/service.py
+++ b/app/domain/references/service.py
@@ -64,7 +64,7 @@ logger = get_logger()
 settings = get_settings()
 
 
-class ReferenceService(GenericService):
+class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
     """The service which manages our references."""
 
     def __init__(
@@ -74,10 +74,11 @@ class ReferenceService(GenericService):
         es_uow: AsyncESUnitOfWork | None = None,
     ) -> None:
         """Initialize the service with a unit of work."""
-        super().__init__(sql_uow, es_uow)
-        self._ingestion_service = IngestionService(sql_uow)
-        self._batch_enhancement_service = BatchEnhancementService(sql_uow)
-        self._anti_corruption_service = anti_corruption_service
+        super().__init__(anti_corruption_service, sql_uow, es_uow)
+        self._ingestion_service = IngestionService(anti_corruption_service, sql_uow)
+        self._batch_enhancement_service = BatchEnhancementService(
+            anti_corruption_service, sql_uow
+        )
 
     @sql_unit_of_work
     async def get_reference(self, reference_id: UUID4) -> Reference:

--- a/app/domain/references/services/anti_corruption_service.py
+++ b/app/domain/references/services/anti_corruption_service.py
@@ -1,0 +1,253 @@
+"""Anti-corruption service for references domain."""
+
+import uuid
+
+import destiny_sdk
+from pydantic import ValidationError
+
+from app.core.exceptions import DomainToSDKError, SDKToDomainError
+from app.domain.references.models.models import (
+    BatchEnhancementRequest,
+    BatchRobotResultValidationEntry,
+    Enhancement,
+    EnhancementRequest,
+    LinkedExternalIdentifier,
+    Reference,
+    RobotAutomation,
+)
+from app.domain.service import AntiCorruptionService
+from app.persistence.blob.client import GenericBlobStorageClient
+from app.persistence.blob.models import BlobSignedUrlType
+
+
+class ReferenceAntiCorruptionService(AntiCorruptionService):
+    """Anti-corruption service for translating between Reference domain and SDK."""
+
+    def __init__(self, blob_client: GenericBlobStorageClient) -> None:
+        """Initialize the anti-corruption service."""
+        self._blob_client = blob_client
+        super().__init__()
+
+    def reference_from_file_input(
+        self,
+        data: destiny_sdk.references.ReferenceFileInput,
+        reference_id: uuid.UUID | None = None,
+    ) -> Reference:
+        """Create a reference from a file input including id hydration."""
+        try:
+            reference = Reference(
+                visibility=data.visibility,
+            )
+            if reference_id:
+                reference.id = reference_id
+            reference.identifiers = [
+                LinkedExternalIdentifier(
+                    reference_id=reference.id, identifier=identifier
+                )
+                for identifier in data.identifiers or []
+            ]
+            reference.enhancements = [
+                Enhancement.model_validate(
+                    enhancement.model_dump() | {"reference_id": reference.id}
+                )
+                for enhancement in data.enhancements or []
+            ]
+            reference.check_serializability()
+        except ValidationError as exception:
+            raise SDKToDomainError(errors=exception.errors()) from exception
+        else:
+            return reference
+
+    def reference_to_sdk(
+        self, reference: Reference
+    ) -> destiny_sdk.references.Reference:
+        """Convert the reference to a Reference SDK model."""
+        try:
+            return destiny_sdk.references.Reference.model_validate(
+                reference.model_dump()
+            )
+        except ValidationError as exception:
+            raise DomainToSDKError(errors=exception.errors()) from exception
+
+    def external_identifier_to_sdk(
+        self, identifier: LinkedExternalIdentifier
+    ) -> destiny_sdk.identifiers.LinkedExternalIdentifier:
+        """Convert the external identifier to a LinkedExternalIdentifier SDK model."""
+        try:
+            return destiny_sdk.identifiers.LinkedExternalIdentifier.model_validate(
+                identifier.model_dump()
+            )
+        except ValidationError as exception:
+            raise DomainToSDKError(errors=exception.errors()) from exception
+
+    def external_identifier_from_sdk(
+        self, data: destiny_sdk.identifiers.LinkedExternalIdentifier
+    ) -> LinkedExternalIdentifier:
+        """Create a LinkedExternalIdentifier from the SDK model."""
+        try:
+            identifier = LinkedExternalIdentifier.model_validate(data.model_dump())
+            identifier.check_serializability()
+        except ValidationError as exception:
+            raise SDKToDomainError(errors=exception.errors()) from exception
+        else:
+            return identifier
+
+    def enhancement_to_sdk(
+        self, enhancement: Enhancement
+    ) -> destiny_sdk.references.Enhancement:
+        """Convert the enhancement to an Enhancement SDK model."""
+        try:
+            return destiny_sdk.references.Enhancement.model_validate(
+                enhancement.model_dump()
+            )
+        except ValidationError as exception:
+            raise DomainToSDKError(errors=exception.errors()) from exception
+
+    def enhancement_from_sdk(
+        self,
+        data: destiny_sdk.references.Enhancement,
+        reference_id: uuid.UUID | None = None,
+    ) -> Enhancement:
+        """Create an Enhancement from the SDK model with optional ID grafting."""
+        try:
+            enhancement_model = data.model_dump()
+
+            ## The SDK isn't allowed to pass in ids, so ignore this.
+            enhancement_model.pop("id", None)
+
+            enhancement = Enhancement.model_validate(
+                enhancement_model
+                | ({"reference_id": reference_id} if reference_id else {})
+            )
+            enhancement.check_serializability()
+        except ValidationError as exception:
+            raise SDKToDomainError(errors=exception.errors()) from exception
+        else:
+            return enhancement
+
+    def enhancement_request_to_sdk(
+        self, enhancement_request: EnhancementRequest
+    ) -> destiny_sdk.robots.EnhancementRequestRead:
+        """Convert the enhancement request to a BatchEnhancementRequest SDK model."""
+        try:
+            return destiny_sdk.robots.EnhancementRequestRead.model_validate(
+                enhancement_request.model_dump()
+            )
+        except ValidationError as exception:
+            raise DomainToSDKError(errors=exception.errors()) from exception
+
+    def enhancement_request_from_sdk(
+        self,
+        data: destiny_sdk.robots.EnhancementRequestIn,
+    ) -> EnhancementRequest:
+        """Create a BatchEnhancementRequest from the SDK model."""
+        try:
+            enhancement_request = EnhancementRequest.model_validate(data.model_dump())
+            enhancement_request.check_serializability()
+        except ValidationError as exception:
+            raise SDKToDomainError(errors=exception.errors()) from exception
+        else:
+            return enhancement_request
+
+    def batch_enhancement_request_from_sdk(
+        self,
+        data: destiny_sdk.robots.BatchEnhancementRequestIn,
+    ) -> BatchEnhancementRequest:
+        """Create a BatchEnhancementRequest from the SDK model."""
+        try:
+            enhancement_request = BatchEnhancementRequest.model_validate(
+                data.model_dump()
+            )
+            enhancement_request.check_serializability()
+        except ValidationError as exception:
+            raise SDKToDomainError(errors=exception.errors()) from exception
+        else:
+            return enhancement_request
+
+    async def batch_enhancement_request_to_sdk(
+        self,
+        enhancement_request: BatchEnhancementRequest,
+    ) -> destiny_sdk.robots.BatchEnhancementRequestRead:
+        """Convert the batch enhancement request to the SDK model."""
+        try:
+            return destiny_sdk.robots.BatchEnhancementRequestRead.model_validate(
+                enhancement_request.model_dump()
+                | {
+                    "reference_data_url": await self._blob_client.generate_signed_url(
+                        enhancement_request.reference_data_file,
+                        BlobSignedUrlType.DOWNLOAD,
+                    )
+                    if enhancement_request.reference_data_file
+                    else None,
+                    "result_storage_url": await self._blob_client.generate_signed_url(
+                        enhancement_request.result_file, BlobSignedUrlType.UPLOAD
+                    )
+                    if enhancement_request.result_file
+                    else None,
+                    "validation_result_url": await self._blob_client.generate_signed_url(
+                        enhancement_request.validation_result_file,
+                        BlobSignedUrlType.DOWNLOAD,
+                    )
+                    if enhancement_request.validation_result_file
+                    else None,
+                },
+            )
+        except ValidationError as exception:
+            raise DomainToSDKError(errors=exception.errors()) from exception
+
+    async def batch_robot_request_to_sdk(
+        self,
+        enhancement_request: BatchEnhancementRequest,
+    ) -> destiny_sdk.robots.BatchRobotRequest:
+        """Convert the batch robot request to the SDK model."""
+        try:
+            return destiny_sdk.robots.BatchRobotRequest(
+                id=enhancement_request.id,
+                reference_storage_url=await self._blob_client.generate_signed_url(
+                    enhancement_request.reference_data_file, BlobSignedUrlType.DOWNLOAD
+                )
+                if enhancement_request.reference_data_file
+                else None,
+                result_storage_url=await self._blob_client.generate_signed_url(
+                    enhancement_request.result_file, BlobSignedUrlType.UPLOAD
+                )
+                if enhancement_request.result_file
+                else None,
+            )
+        except ValidationError as exception:
+            raise DomainToSDKError(errors=exception.errors()) from exception
+
+    def batch_robot_result_validation_entry_to_sdk(
+        self, entry: BatchRobotResultValidationEntry
+    ) -> destiny_sdk.robots.BatchRobotResultValidationEntry:
+        """Convert the batch robot result validation entry to the SDK model."""
+        try:
+            return destiny_sdk.robots.BatchRobotResultValidationEntry.model_validate(
+                entry.model_dump()
+            )
+        except ValidationError as exception:
+            raise DomainToSDKError(errors=exception.errors()) from exception
+
+    def robot_automation_from_sdk(
+        self,
+        data: destiny_sdk.robots.RobotAutomationIn,
+    ) -> RobotAutomation:
+        """Create a RobotAutomation from the SDK model."""
+        try:
+            robot_automation = RobotAutomation.model_validate(data.model_dump())
+            robot_automation.check_serializability()
+        except ValidationError as exception:
+            raise SDKToDomainError(errors=exception.errors()) from exception
+        else:
+            return robot_automation
+
+    def robot_automation_to_sdk(
+        self, robot_automation: RobotAutomation
+    ) -> destiny_sdk.robots.RobotAutomation:
+        """Convert the robot automation to a RobotAutomation SDK model."""
+        try:
+            return destiny_sdk.robots.RobotAutomation.model_validate(
+                robot_automation.model_dump()
+            )
+        except ValidationError as exception:
+            raise DomainToSDKError(errors=exception.errors()) from exception

--- a/app/domain/references/services/anti_corruption_service.py
+++ b/app/domain/references/services/anti_corruption_service.py
@@ -15,12 +15,12 @@ from app.domain.references.models.models import (
     Reference,
     RobotAutomation,
 )
-from app.domain.service import AntiCorruptionService
+from app.domain.service import GenericAntiCorruptionService
 from app.persistence.blob.models import BlobSignedUrlType
 from app.persistence.blob.repository import BlobRepository
 
 
-class ReferenceAntiCorruptionService(AntiCorruptionService):
+class ReferenceAntiCorruptionService(GenericAntiCorruptionService):
     """Anti-corruption service for translating between Reference domain and SDK."""
 
     def __init__(self, blob_repository: BlobRepository) -> None:

--- a/app/domain/robots/routes.py
+++ b/app/domain/robots/routes.py
@@ -33,16 +33,21 @@ def sql_unit_of_work(
     return AsyncSqlUnitOfWork(session=session)
 
 
-def robot_service(
-    sql_uow: Annotated[AsyncSqlUnitOfWork, Depends(sql_unit_of_work)],
-) -> RobotService:
-    """Return the robot service using the provided unit of work dependencies."""
-    return RobotService(sql_uow=sql_uow)
-
-
 def robot_anti_corruption_service() -> RobotAntiCorruptionService:
     """Return the robot anti-corruption service."""
     return RobotAntiCorruptionService()
+
+
+def robot_service(
+    anti_corruption_service: Annotated[
+        RobotAntiCorruptionService, Depends(robot_anti_corruption_service)
+    ],
+    sql_uow: Annotated[AsyncSqlUnitOfWork, Depends(sql_unit_of_work)],
+) -> RobotService:
+    """Return the robot service using the provided unit of work dependencies."""
+    return RobotService(
+        anti_corruption_service=anti_corruption_service, sql_uow=sql_uow
+    )
 
 
 def choose_auth_strategy_robot_writer() -> AuthMethod:

--- a/app/domain/robots/service.py
+++ b/app/domain/robots/service.py
@@ -5,6 +5,9 @@ import secrets
 from pydantic import UUID4, SecretStr
 
 from app.domain.robots.models.models import Robot
+from app.domain.robots.services.anti_corruption_service import (
+    RobotAntiCorruptionService,
+)
 from app.domain.service import GenericService
 from app.persistence.sql.uow import AsyncSqlUnitOfWork
 from app.persistence.sql.uow import unit_of_work as sql_unit_of_work
@@ -12,11 +15,16 @@ from app.persistence.sql.uow import unit_of_work as sql_unit_of_work
 ENOUGH_BYTES_FOR_SAFETY = 32
 
 
-class RobotService(GenericService):
+class RobotService(GenericService[RobotAntiCorruptionService]):
     """Service for creating and managing robots."""
 
-    def __init__(self, sql_uow: AsyncSqlUnitOfWork) -> None:
+    def __init__(
+        self,
+        anti_corruption_service: RobotAntiCorruptionService,
+        sql_uow: AsyncSqlUnitOfWork,
+    ) -> None:
         """Initialize the robots."""
+        self._anti_corruption_service = anti_corruption_service
         self.sql_uow = sql_uow
 
     async def get_robot(self, robot_id: UUID4) -> Robot:

--- a/app/domain/robots/services/anti_corruption_service.py
+++ b/app/domain/robots/services/anti_corruption_service.py
@@ -5,10 +5,10 @@ from pydantic import ValidationError
 
 from app.core.exceptions import DomainToSDKError, SDKToDomainError
 from app.domain.robots.models.models import Robot
-from app.domain.service import AntiCorruptionService
+from app.domain.service import GenericAntiCorruptionService
 
 
-class RobotAntiCorruptionService(AntiCorruptionService):
+class RobotAntiCorruptionService(GenericAntiCorruptionService):
     """Anti-corruption service for translating between Robot domain and SDK models."""
 
     def robot_from_sdk(

--- a/app/domain/service.py
+++ b/app/domain/service.py
@@ -1,36 +1,50 @@
 """Base service class for domain business logic."""
 
+from typing import Generic, TypeVar
+
 from app.persistence.es.uow import AsyncESUnitOfWork
 from app.persistence.sql.uow import AsyncSqlUnitOfWork
 
 
-class GenericService:
-    """Base class for domain services."""
-
-    def __init__(
-        self, sql_uow: AsyncSqlUnitOfWork, es_uow: AsyncESUnitOfWork | None = None
-    ) -> None:
-        """
-        Initialize the service with a unit of work.
-
-        :param sql_uow: The SQL unit of work for database operations. This is the source
-            of truth and is required.
-        :type sql_uow: AsyncSqlUnitOfWork
-        :param es_uow: The Elasticsearch unit of work for search operations, optional.
-        :type es_uow: AsyncESUnitOfWork | None
-        """
-        self.sql_uow = sql_uow
-
-        # This helps the static type checker understand that es_uow is not None if
-        # we access it.
-        if es_uow:
-            self.es_uow: AsyncESUnitOfWork = es_uow
-
-
-class AntiCorruptionService:
+class GenericAntiCorruptionService:
     """
     Base class for anti-corruption services that handle external system translations.
 
     This service acts as a boundary between the domain and external systems (like SDKs),
     ensuring that external concerns don't leak into the domain models.
     """
+
+
+GenericAntiCorruptionServiceType = TypeVar(
+    "GenericAntiCorruptionServiceType", bound=GenericAntiCorruptionService
+)
+
+
+class GenericService(Generic[GenericAntiCorruptionServiceType]):
+    """Base class for domain services."""
+
+    def __init__(
+        self,
+        anti_corruption_service: GenericAntiCorruptionServiceType,
+        sql_uow: AsyncSqlUnitOfWork,
+        es_uow: AsyncESUnitOfWork | None = None,
+    ) -> None:
+        """
+        Initialize the service with a unit of work.
+
+        :param anti_corruption_service: The anti-corruption service for external
+            system translations.
+        :type anti_corruption_service: GenericAntiCorruptionServiceType
+        :param sql_uow: The SQL unit of work for database operations. This is the source
+            of truth and is required.
+        :type sql_uow: AsyncSqlUnitOfWork
+        :param es_uow: The Elasticsearch unit of work for search operations, optional.
+        :type es_uow: AsyncESUnitOfWork | None
+        """
+        self._anti_corruption_service = anti_corruption_service
+        self.sql_uow = sql_uow
+
+        # This helps the static type checker understand that es_uow is not None if
+        # we access it.
+        if es_uow:
+            self.es_uow: AsyncESUnitOfWork = es_uow

--- a/docs/codebase/persistence/blob.rst
+++ b/docs/codebase/persistence/blob.rst
@@ -52,9 +52,6 @@ When getting, the file content is streamed line-by-line to the caller, allowing 
 
 When putting, files can either be streamed with the :class:`FileStream <app.persistence.blob.stream.FileStream>` class or compiled into an in-memory ``BytesIO`` object for simpler cases.
 
-.. autoclass:: app.domain.base.SDKJsonlMixin
-    :members:
-
 .. autoclass:: app.persistence.blob.stream.FileStream
     :members:
 

--- a/tests/unit/persistence/blob/test_blob.py
+++ b/tests/unit/persistence/blob/test_blob.py
@@ -8,7 +8,6 @@ from unittest.mock import patch
 
 import pytest
 
-from app.domain.base import SDKJsonlMixin
 from app.persistence.blob.client import GenericBlobStorageClient
 from app.persistence.blob.models import (
     BlobSignedUrlType,
@@ -70,16 +69,8 @@ async def test_get_signed_url():
 
 @pytest.mark.asyncio
 async def test_filestream_stream_and_read_fn():
-    class DummySDK:
-        def to_jsonl(self):
-            return '{"foo": "bar"}'
-
-    class Dummy(SDKJsonlMixin):
-        async def to_sdk(self):
-            return DummySDK()
-
     async def fake_fn(_dummy):
-        return Dummy()
+        return "dummy"
 
     fs = FileStream(
         fn=fake_fn,
@@ -92,17 +83,9 @@ async def test_filestream_stream_and_read_fn():
 
 @pytest.mark.asyncio
 async def test_filestream_stream_and_read_gen():
-    class DummySDK:
-        def to_jsonl(self):
-            return '{"foo": "bar"}'
-
-    class Dummy(SDKJsonlMixin):
-        async def to_sdk(self):
-            return DummySDK()
-
     async def fake_gen():
-        yield Dummy()
-        yield Dummy()
+        yield "dummy1"
+        yield "dummy2"
 
     fs = FileStream(
         generator=fake_gen(),


### PR DESCRIPTION
This is the most complex domain so I'm afraid comes with the most involved refactor.

- Added anti-corruption layer for references.
- Added service-level use of anti-corruption layers for outgoing requests.
- Removed domain awareness from blob layer. This was forced as there was no longer a clean inheritance for "streamable" domain objects, but I think makes sense in any case.
