### PR TITLE
made workflow more explicit, docced in readme

### DIFF
--- a/.github/workflows/release-sdk-to-pypi.yml
+++ b/.github/workflows/release-sdk-to-pypi.yml
@@ -41,18 +41,18 @@ jobs:
         with:
           virtualenvs-create: false
 
-      - name: Configure PyPI repositories
-        if: ${{ vars.PYPI_REPOSITORY == 'testpypi' }}
-        run: |
-          cd libs/sdk
-          poetry config repositories.testpypi https://test.pypi.org/legacy/
-
       - name: Build and publish package
         run: |
           cd libs/sdk
-          export POETRY_PYPI_TOKEN_$(echo "${{ vars.PYPI_REPOSITORY }}" | tr '[:lower:]' '[:upper:]')="${{ secrets.PYPI_TOKEN }}"
           poetry build
-          poetry publish --repository ${{ vars.PYPI_REPOSITORY }}
+          if [ "${{ vars.PYPI_REPOSITORY }}" = "testpypi" ]; then
+            poetry config repositories.testpypi https://test.pypi.org/legacy/
+            poetry config pypi-token.testpypi ${{ secrets.PYPI_TOKEN }}
+            poetry publish --repository testpypi
+          else
+            poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
+            poetry publish
+          fi
 
       - name: Create GitHub Release
         if: ${{ vars.PYPI_REPOSITORY == 'pypi' }}

--- a/.github/workflows/release-sdk-to-pypi.yml
+++ b/.github/workflows/release-sdk-to-pypi.yml
@@ -12,6 +12,8 @@ on:
           - staging
           - production
 
+permissions:
+  contents: write
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/libs/sdk/README.md
+++ b/libs/sdk/README.md
@@ -53,20 +53,9 @@ poetry build
 poetry add ./PATH/TO/WHEEL.whl
 ```
 
-### Publishing to test pypi
+### Publishing
 
-```sh
-poetry config repositories.testpypi https://test.pypi.org/legacy/
-poetry config pypi-token.testpypi [YOUR_TESTPYPI_TOKEN]
-poetry publish --repository testpypi
-```
-
-## Publishing
-
-```sh
-poetry config pypi-token.pypi [YOUR_PYPI_TOKEN]
-poetry publish
-```
+Once the package change is merged to main with an iterated `libs/sdk/pyproject.toml` version number, you can run the [github action](https://github.com/destiny-evidence/destiny-repository/actions/workflows/release-sdk-to-pypi.yml) to publish to the test pypi and then production pypi registries.
 
 ### Versioning
 


### PR DESCRIPTION
Was a little too generalised, branched publishing logic for testpypi vs pypi.

Successful prod run: https://github.com/destiny-evidence/destiny-repository/actions/runs/16282297772