### PR TITLE
Remove redundant async on translation methods

### DIFF
--- a/app/domain/imports/models/sql.py
+++ b/app/domain/imports/models/sql.py
@@ -1,6 +1,5 @@
 """Objects used to interface with SQL implementations."""
 
-import asyncio
 import datetime
 import uuid
 from typing import Self
@@ -83,7 +82,7 @@ class ImportBatch(GenericSQLPersistence[DomainImportBatch]):
     )
 
     @classmethod
-    async def from_domain(cls, domain_obj: DomainImportBatch) -> Self:
+    def from_domain(cls, domain_obj: DomainImportBatch) -> Self:
         """Create a persistence model from a domain ImportBatch object."""
         return cls(
             id=domain_obj.id,
@@ -96,7 +95,7 @@ class ImportBatch(GenericSQLPersistence[DomainImportBatch]):
             else None,
         )
 
-    async def to_domain(self, preload: list[str] | None = None) -> DomainImportBatch:
+    def to_domain(self, preload: list[str] | None = None) -> DomainImportBatch:
         """Convert the persistence model into an Domain ImportBatch object."""
         return DomainImportBatch(
             id=self.id,
@@ -105,12 +104,10 @@ class ImportBatch(GenericSQLPersistence[DomainImportBatch]):
             status=self.status,
             storage_url=HttpUrl(self.storage_url),
             callback_url=HttpUrl(self.callback_url) if self.callback_url else None,
-            import_record=await self.import_record.to_domain()
+            import_record=self.import_record.to_domain()
             if "import_record" in (preload or [])
             else None,
-            import_results=await asyncio.gather(
-                *(result.to_domain() for result in self.import_results)
-            )
+            import_results=[result.to_domain() for result in self.import_results]
             if "import_results" in (preload or [])
             else None,
         )
@@ -150,7 +147,7 @@ class ImportRecord(GenericSQLPersistence[DomainImportRecord]):
     )
 
     @classmethod
-    async def from_domain(cls, domain_obj: DomainImportRecord) -> Self:
+    def from_domain(cls, domain_obj: DomainImportRecord) -> Self:
         """Create a persistence model from a domain ImportRecord object."""
         return cls(
             id=domain_obj.id,
@@ -164,7 +161,7 @@ class ImportRecord(GenericSQLPersistence[DomainImportRecord]):
             status=domain_obj.status,
         )
 
-    async def to_domain(self, preload: list[str] | None = None) -> DomainImportRecord:
+    def to_domain(self, preload: list[str] | None = None) -> DomainImportRecord:
         """Convert the persistence model into an Domain ImportRecord object."""
         return DomainImportRecord(
             id=self.id,
@@ -176,7 +173,7 @@ class ImportRecord(GenericSQLPersistence[DomainImportRecord]):
             expected_reference_count=self.expected_reference_count,
             source_name=self.source_name,
             status=self.status,
-            batches=await asyncio.gather(*(batch.to_domain() for batch in self.batches))
+            batches=[batch.to_domain() for batch in self.batches]
             if "batches" in (preload or [])
             else None,
         )
@@ -208,7 +205,7 @@ class ImportResult(GenericSQLPersistence[DomainImportResult]):
     __table_args__ = (Index("ix_import_result_import_batch_id", "import_batch_id"),)
 
     @classmethod
-    async def from_domain(cls, domain_obj: DomainImportResult) -> Self:
+    def from_domain(cls, domain_obj: DomainImportResult) -> Self:
         """Create a persistence model from a domain ImportResult object."""
         return cls(
             id=domain_obj.id,
@@ -218,7 +215,7 @@ class ImportResult(GenericSQLPersistence[DomainImportResult]):
             failure_details=domain_obj.failure_details,
         )
 
-    async def to_domain(self, preload: list[str] | None = None) -> DomainImportResult:
+    def to_domain(self, preload: list[str] | None = None) -> DomainImportResult:
         """Convert the persistence model into an Domain ImportResult object."""
         return DomainImportResult(
             id=self.id,
@@ -226,7 +223,7 @@ class ImportResult(GenericSQLPersistence[DomainImportResult]):
             status=self.status,
             reference_id=self.reference_id,
             failure_details=self.failure_details,
-            import_batch=await self.import_batch.to_domain()
+            import_batch=self.import_batch.to_domain()
             if "import_batch" in (preload or [])
             else None,
         )

--- a/app/domain/imports/repository.py
+++ b/app/domain/imports/repository.py
@@ -1,6 +1,5 @@
 """Repositories for imports and associated models."""
 
-import asyncio
 import uuid
 from abc import ABC
 
@@ -100,6 +99,4 @@ class ImportResultSQLRepository(
         if status:
             query = query.where(SQLImportResult.status == status)
         results = await self._session.execute(query)
-        return await asyncio.gather(
-            *(result.to_domain() for result in results.scalars().all())
-        )
+        return [result.to_domain() for result in results.scalars().all()]

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -351,7 +351,7 @@ class GenericExternalIdentifier(DomainBaseModel):
     )
 
     @classmethod
-    async def from_specific(
+    def from_specific(
         cls,
         external_identifier: ExternalIdentifier,
     ) -> Self:

--- a/app/domain/references/models/sql.py
+++ b/app/domain/references/models/sql.py
@@ -1,6 +1,5 @@
 """Objects used to interface with SQL implementations."""
 
-import asyncio
 import uuid
 from typing import Any, Self
 
@@ -66,38 +65,30 @@ class Reference(GenericSQLPersistence[DomainReference]):
     )
 
     @classmethod
-    async def from_domain(cls, domain_obj: DomainReference) -> Self:
+    def from_domain(cls, domain_obj: DomainReference) -> Self:
         """Create a persistence model from a domain Reference object."""
         return cls(
             id=domain_obj.id,
             visibility=domain_obj.visibility,
-            identifiers=await asyncio.gather(
-                *(
-                    ExternalIdentifier.from_domain(identifier)
-                    for identifier in domain_obj.identifiers or []
-                )
-            ),
-            enhancements=await asyncio.gather(
-                *(
-                    Enhancement.from_domain(enhancement)
-                    for enhancement in domain_obj.enhancements or []
-                )
-            ),
+            identifiers=[
+                ExternalIdentifier.from_domain(identifier)
+                for identifier in domain_obj.identifiers or []
+            ],
+            enhancements=[
+                Enhancement.from_domain(enhancement)
+                for enhancement in domain_obj.enhancements or []
+            ],
         )
 
-    async def to_domain(self, preload: list[str] | None = None) -> DomainReference:
+    def to_domain(self, preload: list[str] | None = None) -> DomainReference:
         """Convert the persistence model into a Domain Reference object."""
         return DomainReference(
             id=self.id,
             visibility=self.visibility,
-            identifiers=await asyncio.gather(
-                *(identifier.to_domain() for identifier in self.identifiers)
-            )
+            identifiers=[identifier.to_domain() for identifier in self.identifiers]
             if "identifiers" in (preload or [])
             else None,
-            enhancements=await asyncio.gather(
-                *(enhancement.to_domain() for enhancement in self.enhancements)
-            )
+            enhancements=[enhancement.to_domain() for enhancement in self.enhancements]
             if "enhancements" in (preload or [])
             else None,
         )
@@ -144,7 +135,7 @@ class ExternalIdentifier(GenericSQLPersistence[DomainExternalIdentifier]):
     )
 
     @classmethod
-    async def from_domain(cls, domain_obj: DomainExternalIdentifier) -> Self:
+    def from_domain(cls, domain_obj: DomainExternalIdentifier) -> Self:
         """Create a persistence model from a domain ExternalIdentifier object."""
         return cls(
             id=domain_obj.id,
@@ -156,9 +147,7 @@ class ExternalIdentifier(GenericSQLPersistence[DomainExternalIdentifier]):
             else None,
         )
 
-    async def to_domain(
-        self, preload: list[str] | None = None
-    ) -> DomainExternalIdentifier:
+    def to_domain(self, preload: list[str] | None = None) -> DomainExternalIdentifier:
         """Convert the persistence model into a Domain ExternalIdentifier object."""
         return DomainExternalIdentifier(
             id=self.id,
@@ -170,7 +159,7 @@ class ExternalIdentifier(GenericSQLPersistence[DomainExternalIdentifier]):
                     "other_identifier_name": self.other_identifier_name,
                 }
             ),
-            reference=await self.reference.to_domain()
+            reference=self.reference.to_domain()
             if "reference" in (preload or [])
             else None,
         )
@@ -220,7 +209,7 @@ class Enhancement(GenericSQLPersistence[DomainEnhancement]):
     )
 
     @classmethod
-    async def from_domain(cls, domain_obj: DomainEnhancement) -> Self:
+    def from_domain(cls, domain_obj: DomainEnhancement) -> Self:
         """Create a persistence model from a domain Enhancement object."""
         return cls(
             id=domain_obj.id,
@@ -233,7 +222,7 @@ class Enhancement(GenericSQLPersistence[DomainEnhancement]):
             content=domain_obj.content.model_dump(mode="json"),
         )
 
-    async def to_domain(self, preload: list[str] | None = None) -> DomainEnhancement:
+    def to_domain(self, preload: list[str] | None = None) -> DomainEnhancement:
         """Convert the persistence model into a Domain Enhancement object."""
         return DomainEnhancement(
             id=self.id,
@@ -243,7 +232,7 @@ class Enhancement(GenericSQLPersistence[DomainEnhancement]):
             robot_version=self.robot_version,
             derived_from=self.derived_from,
             content=self.content,
-            reference=await self.reference.to_domain()
+            reference=self.reference.to_domain()
             if "reference" in (preload or [])
             else None,
         )
@@ -283,7 +272,7 @@ class EnhancementRequest(GenericSQLPersistence[DomainEnhancementRequest]):
     reference: Mapped["Reference"] = relationship("Reference")
 
     @classmethod
-    async def from_domain(cls, domain_obj: DomainEnhancementRequest) -> Self:
+    def from_domain(cls, domain_obj: DomainEnhancementRequest) -> Self:
         """Create a persistence model from a domain Enhancement object."""
         return cls(
             id=domain_obj.id,
@@ -297,9 +286,7 @@ class EnhancementRequest(GenericSQLPersistence[DomainEnhancementRequest]):
             error=domain_obj.error,
         )
 
-    async def to_domain(
-        self, preload: list[str] | None = None
-    ) -> DomainEnhancementRequest:
+    def to_domain(self, preload: list[str] | None = None) -> DomainEnhancementRequest:
         """Convert the persistence model into a Domain Enhancement object."""
         return DomainEnhancementRequest(
             id=self.id,
@@ -311,7 +298,7 @@ class EnhancementRequest(GenericSQLPersistence[DomainEnhancementRequest]):
             if self.enhancement_parameters
             else {},
             error=self.error,
-            reference=await self.reference.to_domain()
+            reference=self.reference.to_domain()
             if "reference" in (preload or [])
             else None,
         )
@@ -351,7 +338,7 @@ class BatchEnhancementRequest(GenericSQLPersistence[DomainBatchEnhancementReques
     error: Mapped[str | None] = mapped_column(String, nullable=True)
 
     @classmethod
-    async def from_domain(cls, domain_obj: DomainBatchEnhancementRequest) -> Self:
+    def from_domain(cls, domain_obj: DomainBatchEnhancementRequest) -> Self:
         """Create a persistence model from a domain Enhancement object."""
         return cls(
             id=domain_obj.id,
@@ -363,18 +350,18 @@ class BatchEnhancementRequest(GenericSQLPersistence[DomainBatchEnhancementReques
             if domain_obj.enhancement_parameters
             else None,
             error=domain_obj.error,
-            reference_data_file=await domain_obj.reference_data_file.to_sql()
+            reference_data_file=domain_obj.reference_data_file.to_sql()
             if domain_obj.reference_data_file
             else None,
-            result_file=await domain_obj.result_file.to_sql()
+            result_file=domain_obj.result_file.to_sql()
             if domain_obj.result_file
             else None,
-            validation_result_file=await domain_obj.validation_result_file.to_sql()
+            validation_result_file=domain_obj.validation_result_file.to_sql()
             if domain_obj.validation_result_file
             else None,
         )
 
-    async def to_domain(
+    def to_domain(
         self,
         preload: list[str] | None = None,  # noqa: ARG002
     ) -> DomainBatchEnhancementRequest:
@@ -389,15 +376,13 @@ class BatchEnhancementRequest(GenericSQLPersistence[DomainBatchEnhancementReques
             if self.enhancement_parameters
             else {},
             error=self.error,
-            reference_data_file=await BlobStorageFile.from_sql(self.reference_data_file)
+            reference_data_file=BlobStorageFile.from_sql(self.reference_data_file)
             if self.reference_data_file
             else None,
-            result_file=await BlobStorageFile.from_sql(self.result_file)
+            result_file=BlobStorageFile.from_sql(self.result_file)
             if self.result_file
             else None,
-            validation_result_file=await BlobStorageFile.from_sql(
-                self.validation_result_file
-            )
+            validation_result_file=BlobStorageFile.from_sql(self.validation_result_file)
             if self.validation_result_file
             else None,
         )
@@ -428,7 +413,7 @@ class RobotAutomation(GenericSQLPersistence[DomainRobotAutomation]):
     )
 
     @classmethod
-    async def from_domain(cls, domain_obj: DomainRobotAutomation) -> Self:
+    def from_domain(cls, domain_obj: DomainRobotAutomation) -> Self:
         """Create a persistence model from a domain RobotAutomation object."""
         return cls(
             id=domain_obj.id,
@@ -436,7 +421,7 @@ class RobotAutomation(GenericSQLPersistence[DomainRobotAutomation]):
             query=domain_obj.query,
         )
 
-    async def to_domain(
+    def to_domain(
         self,
         preload: list[str] | None = None,  # noqa: ARG002
     ) -> DomainRobotAutomation:

--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -111,7 +111,7 @@ class ReferenceSQLRepository(
         result = await self._session.execute(query)
         db_references = result.unique().scalars().all()
         return [
-            await db_reference.to_domain(preload=["enhancements", "identifiers"])
+            db_reference.to_domain(preload=["enhancements", "identifiers"])
             for db_reference in db_references
         ]
 
@@ -199,7 +199,7 @@ class ExternalIdentifierSQLRepository(
                 lookup_value=(identifier_type, identifier, other_identifier_name),
             )
 
-        return await db_identifier.to_domain(preload=preload)
+        return db_identifier.to_domain(preload=preload)
 
     async def get_by_identifiers(
         self,
@@ -234,7 +234,7 @@ class ExternalIdentifierSQLRepository(
         result = await self._session.execute(query)
         db_identifiers = result.unique().scalars().all()
 
-        return [await db_identifier.to_domain() for db_identifier in db_identifiers]
+        return [db_identifier.to_domain() for db_identifier in db_identifiers]
 
 
 class EnhancementRepositoryBase(
@@ -355,9 +355,7 @@ class RobotAutomationESRepository(
         """
         documents = [
             (
-                await self._persistence_cls.percolatable_document_from_domain(
-                    percolatable
-                )
+                self._persistence_cls.percolatable_document_from_domain(percolatable)
             ).to_dict()
             for percolatable in percolatables
         ]

--- a/app/domain/references/services/batch_enhancement_service.py
+++ b/app/domain/references/services/batch_enhancement_service.py
@@ -63,7 +63,7 @@ class BatchEnhancementService(GenericService):
         """Add a validation result file to a batch enhancement request."""
         return await self.sql_uow.batch_enhancement_requests.update_by_pk(
             pk=batch_enhancement_request_id,
-            validation_result_file=await validation_result_file.to_sql(),
+            validation_result_file=validation_result_file.to_sql(),
         )
 
     async def build_robot_request(
@@ -90,8 +90,8 @@ class BatchEnhancementService(GenericService):
 
         batch_enhancement_request = await self.sql_uow.batch_enhancement_requests.update_by_pk(  # noqa: E501
             batch_enhancement_request.id,
-            reference_data_file=await batch_enhancement_request.reference_data_file.to_sql(),  # noqa: E501
-            result_file=await batch_enhancement_request.result_file.to_sql(),
+            reference_data_file=batch_enhancement_request.reference_data_file.to_sql(),
+            result_file=batch_enhancement_request.result_file.to_sql(),
         )
 
         return await batch_enhancement_request.to_batch_robot_request_sdk(

--- a/app/domain/references/services/ingestion_service.py
+++ b/app/domain/references/services/ingestion_service.py
@@ -63,7 +63,7 @@ class IngestionService(GenericService):
 
         collided_identifiers = await self.fetch_collided_identifiers(
             [
-                await GenericExternalIdentifier.from_specific(identifier)
+                GenericExternalIdentifier.from_specific(identifier)
                 for identifier in reference.identifiers
             ],
         )

--- a/app/domain/robots/models/sql.py
+++ b/app/domain/robots/models/sql.py
@@ -39,7 +39,7 @@ class Robot(GenericSQLPersistence[DomainRobot]):
     )
 
     @classmethod
-    async def from_domain(cls, domain_obj: DomainRobot) -> Self:
+    def from_domain(cls, domain_obj: DomainRobot) -> Self:
         """Create a persistence model from a domain Robot object."""
         if not domain_obj.client_secret:
             msg = "Cannot convert domain robot without client secret for persistence."
@@ -53,7 +53,7 @@ class Robot(GenericSQLPersistence[DomainRobot]):
             owner=domain_obj.owner,
         )
 
-    async def to_domain(
+    def to_domain(
         self,
         preload: list[str] | None = None,  # noqa: ARG002
     ) -> DomainRobot:

--- a/app/domain/robots/repository.py
+++ b/app/domain/robots/repository.py
@@ -84,4 +84,4 @@ class RobotSQLRepository(
             ) from e
 
         await self._session.refresh(persistence)
-        return await persistence.to_domain()
+        return persistence.to_domain()

--- a/app/persistence/blob/models.py
+++ b/app/persistence/blob/models.py
@@ -61,12 +61,12 @@ class BlobStorageFile(BaseModel):
                 logger.warning(msg, extra={"blob_filename": self.filename})
                 return "application/octet-stream"
 
-    async def to_sql(self) -> str:
+    def to_sql(self) -> str:
         """Return the SQL persistence representation of the file."""
         return f"{self.location}://{self.container}/{self.path}/{self.filename}"
 
     @classmethod
-    async def from_sql(cls, sql: str) -> Self:
+    def from_sql(cls, sql: str) -> Self:
         """Populate the model from a SQL representation."""
         location, url = sql.split("://")
         parts = url.split("/")

--- a/app/persistence/es/persistence.py
+++ b/app/persistence/es/persistence.py
@@ -29,11 +29,11 @@ class GenericESPersistence(
 
     @classmethod
     @abstractmethod
-    async def from_domain(cls, domain_obj: GenericDomainModelType) -> Self:
+    def from_domain(cls, domain_obj: GenericDomainModelType) -> Self:
         """Create a persistence model from a domain model."""
 
     @abstractmethod
-    async def to_domain(self) -> GenericDomainModelType:
+    def to_domain(self) -> GenericDomainModelType:
         """Create a domain model from this persistence model."""
 
     class Index:

--- a/app/persistence/es/repository.py
+++ b/app/persistence/es/repository.py
@@ -77,7 +77,7 @@ class GenericAsyncESRepository(
                 lookup_type="id",
                 lookup_value=pk,
             )
-        return await result.to_domain()
+        return result.to_domain()
 
     async def add(self, record: GenericDomainModelType) -> GenericDomainModelType:
         """
@@ -88,7 +88,7 @@ class GenericAsyncESRepository(
         :return: The persisted record.
         :rtype: GenericDomainModelType
         """
-        es_record = await self._persistence_cls.from_domain(record)
+        es_record = self._persistence_cls.from_domain(record)
         try:
             await es_record.save(using=self._client)
         except (BadRequestError, UnknownDslObject) as exc:
@@ -114,7 +114,7 @@ class GenericAsyncESRepository(
         ):
             """Translate domain records to Elasticsearch records."""
             async for record in get_records:
-                yield await self._persistence_cls.from_domain(record)
+                yield self._persistence_cls.from_domain(record)
 
         await self._persistence_cls.bulk(
             es_record_translation_generator(), using=self._client

--- a/app/persistence/persistence.py
+++ b/app/persistence/persistence.py
@@ -22,9 +22,9 @@ class GenericPersistence(Generic[GenericDomainModelType], ABC):
 
     @classmethod
     @abstractmethod
-    async def from_domain(cls, domain_obj: GenericDomainModelType) -> Self:
+    def from_domain(cls, domain_obj: GenericDomainModelType) -> Self:
         """Create a persistence model from a domain model."""
 
     @abstractmethod
-    async def to_domain(self) -> GenericDomainModelType:
+    def to_domain(self) -> GenericDomainModelType:
         """Create a domain model from this persistence model."""

--- a/app/persistence/sql/persistence.py
+++ b/app/persistence/sql/persistence.py
@@ -48,11 +48,9 @@ class GenericSQLPersistence(
 
     @classmethod
     @abstractmethod
-    async def from_domain(cls, domain_obj: GenericDomainModelType) -> Self:
+    def from_domain(cls, domain_obj: GenericDomainModelType) -> Self:
         """Create a persistence model from a domain model."""
 
     @abstractmethod
-    async def to_domain(
-        self, preload: list[str] | None = None
-    ) -> GenericDomainModelType:
+    def to_domain(self, preload: list[str] | None = None) -> GenericDomainModelType:
         """Create a domain model from this persistence model."""

--- a/app/persistence/sql/repository.py
+++ b/app/persistence/sql/repository.py
@@ -73,7 +73,7 @@ class GenericAsyncSqlRepository(
                 lookup_type="id",
                 lookup_value=pk,
             )
-        return await result.to_domain(preload=preload)
+        return result.to_domain(preload=preload)
 
     async def get_by_pks(
         self, pks: list[UUID4], preload: list[str] | None = None
@@ -119,7 +119,7 @@ class GenericAsyncSqlRepository(
                 lookup_value=missing_pks,
             )
 
-        return [await ref.to_domain(preload=preload) for ref in db_references]
+        return [ref.to_domain(preload=preload) for ref in db_references]
 
     async def verify_pk_existence(self, pks: list[UUID4]) -> None:
         """
@@ -183,7 +183,7 @@ class GenericAsyncSqlRepository(
             ) from e
 
         await self._session.refresh(persistence)
-        return await persistence.to_domain()
+        return persistence.to_domain()
 
     async def delete_by_pk(self, pk: UUID4) -> None:
         """
@@ -223,7 +223,7 @@ class GenericAsyncSqlRepository(
         instead of added. Consider renaming to upsert().
 
         """
-        persistence = await self._persistence_cls.from_domain(record)
+        persistence = self._persistence_cls.from_domain(record)
         try:
             self._session.add(persistence)
             await self._session.flush()
@@ -233,7 +233,7 @@ class GenericAsyncSqlRepository(
             ) from e
 
         await self._session.refresh(persistence)
-        return await persistence.to_domain()
+        return persistence.to_domain()
 
     async def merge(self, record: GenericDomainModelType) -> GenericDomainModelType:
         """
@@ -251,7 +251,7 @@ class GenericAsyncSqlRepository(
         database and violate a unique constraint.
 
         """
-        persistence = await self._persistence_cls.from_domain(record)
+        persistence = self._persistence_cls.from_domain(record)
         try:
             persistence = await self._session.merge(persistence)
             await self._session.flush()
@@ -261,7 +261,7 @@ class GenericAsyncSqlRepository(
             ) from e
 
         await self._session.refresh(persistence)
-        return await persistence.to_domain()
+        return persistence.to_domain()
 
     async def get_all_pks(self) -> list[UUID4]:
         """

--- a/tests/integration/test_sql_models.py
+++ b/tests/integration/test_sql_models.py
@@ -18,7 +18,7 @@ async def test_enhancement_interface(
     session: AsyncSession,
 ):
     """Test that the enhancement content type is set correctly."""
-    reference = await SQLReference.from_domain(
+    reference = SQLReference.from_domain(
         Reference(
             id=uuid.uuid4(),
         )
@@ -42,7 +42,7 @@ async def test_enhancement_interface(
             ],
         },
     )
-    sql_enhancement = await SQLEnhancement.from_domain(enhancement_in)
+    sql_enhancement = SQLEnhancement.from_domain(enhancement_in)
     session.add(sql_enhancement)
     await session.commit()
 
@@ -66,5 +66,5 @@ async def test_enhancement_interface(
         sql_enhancement.id,
     )
     assert loaded_enhancement
-    enhancement = await loaded_enhancement.to_domain()
+    enhancement = loaded_enhancement.to_domain()
     assert enhancement == enhancement_in

--- a/tests/routers/test_references.py
+++ b/tests/routers/test_references.py
@@ -283,9 +283,7 @@ async def test_fulfill_enhancement_request_happy_path(
 ) -> None:
     """Test creating an enhancement from a robot."""
     reference = await add_reference(session)
-    await (await ReferenceDocument.from_domain(await reference.to_domain())).save(
-        using=es_client
-    )
+    await (ReferenceDocument.from_domain(reference.to_domain())).save(using=es_client)
     robot = await add_robot(session)
 
     enhancement_request = SQLEnhancementRequest(

--- a/tests/unit/domain/references/models/test_models.py
+++ b/tests/unit/domain/references/models/test_models.py
@@ -20,7 +20,7 @@ async def test_generic_external_identifier_from_specific_without_other():
     doi = destiny_sdk.identifiers.DOIIdentifier(
         identifier="10.1000/abc123", identifier_type="doi"
     )
-    gen = await GenericExternalIdentifier.from_specific(doi)
+    gen = GenericExternalIdentifier.from_specific(doi)
     assert gen.identifier == "10.1000/abc123"
     assert gen.identifier_type == "doi"
     assert gen.other_identifier_name is None
@@ -30,7 +30,7 @@ async def test_generic_external_identifier_from_specific_with_other():
     other = destiny_sdk.identifiers.OtherIdentifier(
         identifier="123", identifier_type="other", other_identifier_name="isbn"
     )
-    gen = await GenericExternalIdentifier.from_specific(other)
+    gen = GenericExternalIdentifier.from_specific(other)
     assert gen.identifier == "123"
     assert gen.identifier_type == "other"
     assert gen.other_identifier_name == "isbn"

--- a/tests/unit/domain/references/models/test_sql.py
+++ b/tests/unit/domain/references/models/test_sql.py
@@ -117,12 +117,12 @@ async def test_reference_from_and_to_domain_without_preload():
     dummy_ref = DummyDomainReference(id=ref_id, visibility=Visibility.PUBLIC)
 
     # Convert from domain to SQL model
-    sql_ref = await Reference.from_domain(dummy_ref)
+    sql_ref = Reference.from_domain(dummy_ref)
     assert sql_ref.id == dummy_ref.id
     assert sql_ref.visibility == dummy_ref.visibility
 
     # When no preload is requested, to_domain should yield None for relationships
-    domain_ref = await sql_ref.to_domain(preload=[])
+    domain_ref = sql_ref.to_domain(preload=[])
     assert domain_ref.id == dummy_ref.id
     assert domain_ref.visibility == dummy_ref.visibility
     assert domain_ref.identifiers is None
@@ -143,7 +143,7 @@ async def test_external_identifier_from_and_to_domain():
     )
 
     # Convert from domain to SQL model
-    sql_ext = await ExternalIdentifier.from_domain(dummy_ext)
+    sql_ext = ExternalIdentifier.from_domain(dummy_ext)
     assert sql_ext.id == dummy_ext.id
     assert sql_ext.reference_id == dummy_ext.reference_id
     assert sql_ext.identifier_type == dummy_ext.identifier.identifier_type
@@ -154,7 +154,7 @@ async def test_external_identifier_from_and_to_domain():
     sql_ext.reference = dummy_sql_ref
 
     # Convert back to domain with preload reference
-    domain_ext = await sql_ext.to_domain(preload=["reference"])
+    domain_ext = sql_ext.to_domain(preload=["reference"])
     assert domain_ext.id == dummy_ext.id
     assert domain_ext.reference_id == dummy_ext.reference_id
     assert domain_ext.identifier.identifier_type == dummy_ext.identifier.identifier_type
@@ -180,7 +180,7 @@ async def test_enhancement_from_and_to_domain():
     )
 
     # Convert from domain to SQL model
-    sql_enh = await Enhancement.from_domain(dummy_enh)
+    sql_enh = Enhancement.from_domain(dummy_enh)
     assert sql_enh.id == dummy_enh.id
     assert sql_enh.reference_id == dummy_enh.reference_id
     assert sql_enh.enhancement_type == dummy_enh.content.enhancement_type
@@ -196,7 +196,7 @@ async def test_enhancement_from_and_to_domain():
     sql_enh.reference = dummy_sql_ref
 
     # Convert back to domain with preload reference
-    domain_enh = await sql_enh.to_domain(preload=["reference"])
+    domain_enh = sql_enh.to_domain(preload=["reference"])
     assert domain_enh.id == dummy_enh.id
     assert domain_enh.reference_id == dummy_enh.reference_id
     assert domain_enh.content.enhancement_type == dummy_enh.content.enhancement_type
@@ -225,7 +225,7 @@ async def test_enhancement_request_from_and_to_domain():
     )
 
     # # Convert from domain to SQL model
-    sql_enh_req = await EnhancementRequest.from_domain(dummy_enh_req)
+    sql_enh_req = EnhancementRequest.from_domain(dummy_enh_req)
     assert sql_enh_req.id == dummy_enh_req.id
     assert sql_enh_req.reference_id == dummy_enh_req.reference_id
     assert sql_enh_req.robot_id == dummy_enh_req.robot_id
@@ -240,7 +240,7 @@ async def test_enhancement_request_from_and_to_domain():
     )
 
     # # Convert back to domain with preload reference
-    domain_enh_req = await sql_enh_req.to_domain(preload=["reference"])
+    domain_enh_req = sql_enh_req.to_domain(preload=["reference"])
     assert domain_enh_req.id == dummy_enh_req.id
     assert domain_enh_req.reference_id == dummy_enh_req.reference_id
     assert domain_enh_req.robot_id == dummy_enh_req.robot_id
@@ -277,15 +277,15 @@ async def test_reference_with_relationships():
         enhancements=[dummy_enh],
     )
     # Convert the reference from domain
-    sql_ref = await Reference.from_domain(dummy_ref)
+    sql_ref = Reference.from_domain(dummy_ref)
     # Manually assign SQL models for relationships
-    sql_ext = await ExternalIdentifier.from_domain(dummy_ext)
-    sql_enh = await Enhancement.from_domain(dummy_enh)
+    sql_ext = ExternalIdentifier.from_domain(dummy_ext)
+    sql_enh = Enhancement.from_domain(dummy_enh)
     sql_ref.identifiers = [sql_ext]
     sql_ref.enhancements = [sql_enh]
 
     # Convert back to domain with preload relationships
-    domain_ref = await sql_ref.to_domain(preload=["identifiers", "enhancements"])
+    domain_ref = sql_ref.to_domain(preload=["identifiers", "enhancements"])
     assert domain_ref.id == dummy_ref.id
     assert domain_ref.visibility == dummy_ref.visibility
     # Check identifiers conversion

--- a/tests/unit/domain/robots/test_sql.py
+++ b/tests/unit/domain/robots/test_sql.py
@@ -30,7 +30,7 @@ async def test_robot_to_and_from_domain():
     )
 
     # Convert from domain to SQL model
-    sql_robot = await Robot.from_domain(dummy_robot)
+    sql_robot = Robot.from_domain(dummy_robot)
     assert sql_robot.id == dummy_robot.id
     assert sql_robot.base_url == str(dummy_robot.base_url)
     assert sql_robot.client_secret == dummy_robot.client_secret.get_secret_value()
@@ -39,7 +39,7 @@ async def test_robot_to_and_from_domain():
     assert sql_robot.owner == dummy_robot.owner
 
     # Convert from SQL model to domain
-    domain_ref = await sql_robot.to_domain()
+    domain_ref = sql_robot.to_domain()
     assert domain_ref.id == dummy_robot.id
     assert domain_ref.base_url == dummy_robot.base_url
     assert domain_ref.client_secret == dummy_robot.client_secret

--- a/tests/unit/persistence/blob/test_blob.py
+++ b/tests/unit/persistence/blob/test_blob.py
@@ -149,9 +149,9 @@ async def test_blobstoragefile_to_sql_and_from_sql():
         path="some/path",
         filename="file.txt",
     )
-    sql = await file.to_sql()
+    sql = file.to_sql()
     assert sql == "azure://cont/some/path/file.txt"
-    new_file = await BlobStorageFile.from_sql(sql)
+    new_file = BlobStorageFile.from_sql(sql)
     assert new_file.location == "azure"
     assert new_file.container == "cont"
     assert new_file.path == "some/path"


### PR DESCRIPTION
Sidecar PR to #192 #193 #194.

The above PRs remove `async` from translation functions unless there's an obvious performance improvement (network call). This PR performs that same change across translation functions not touched by the anti-corruption layer.