### PR TITLE
added fastapi middleware to log query and path parameters

### DIFF
--- a/app/core/telemetry/attributes.py
+++ b/app/core/telemetry/attributes.py
@@ -42,6 +42,10 @@ class Attributes(StrEnum):
     # Deployment attributes
     DEPLOYMENT_ENVIRONMENT = _deployment_attributes.DEPLOYMENT_ENVIRONMENT
 
+    # HTTP attributes
+    HTTP_REQUEST_QUERY_PARAMS = "http.request.query"
+    HTTP_REQUEST_PATH_PARAMS = "http.request.path"
+
     # Messaging attributes
     MESSAGING_SYSTEM = _messaging_attributes.MESSAGING_SYSTEM
     MESSAGING_DESTINATION_NAME = _messaging_attributes.MESSAGING_DESTINATION_NAME

--- a/app/core/telemetry/fastapi.py
+++ b/app/core/telemetry/fastapi.py
@@ -1,0 +1,66 @@
+"""Middleware for OpenTelemetry tracing in FastAPI applications."""
+
+from collections.abc import Awaitable, Callable
+
+from fastapi import Request, Response
+from opentelemetry import trace
+from starlette.applications import Starlette
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.routing import Match
+
+from app.core.telemetry.attributes import Attributes
+
+
+class FastAPITracingMiddleware(BaseHTTPMiddleware):
+    """Middleware class to add query and path parameters to OpenTelemetry spans."""
+
+    def __init__(self, app: Starlette) -> None:
+        """
+        Initialize the tracing middleware.
+
+        Args:
+            app: The Starlette application instance.
+
+        """
+        super().__init__(app)
+
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
+        """
+        Process the request and add tracing attributes.
+
+        Args:
+            request: The incoming request.
+            call_next: The next middleware or route handler.
+
+        Returns:
+            The response from the next middleware or route handler.
+
+        """
+        # Get the current span
+        current_span = trace.get_current_span()
+
+        if current_span.is_recording():
+            # Add query string if present
+            if request.url.query:
+                # Add individual query parameters as attributes using FastAPI
+                for key, value in request.query_params.items():
+                    current_span.set_attribute(
+                        f"{Attributes.HTTP_REQUEST_QUERY_PARAMS}.{key}", value
+                    )
+
+            # Can't access path parameters directly in middleware.
+            # This is what starlette does internally.
+            # https://github.com/fastapi/fastapi/issues/861
+            # https://github.com/encode/starlette/blob/5c43dde0ec0917673bb280bcd7ab0c37b78061b7/starlette/routing.py#L544
+            routes = request.app.router.routes
+            for route in routes:
+                match, scope = route.matches(request)
+                if match == Match.FULL:
+                    for key, value in scope["path_params"].items():
+                        current_span.set_attribute(
+                            f"{Attributes.HTTP_REQUEST_PATH_PARAMS}.{key}", str(value)
+                        )
+
+        return await call_next(request)

--- a/app/main.py
+++ b/app/main.py
@@ -37,6 +37,6 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     await es_manager.close()
 
 
-app = register_api(lifespan)
+app = register_api(lifespan, otel_enabled=settings.otel_enabled)
 
 configure_logger(rich_rendering=settings.running_locally)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       DB_CONFIG: '{"DB_URL":"postgresql+asyncpg://localuser:localpass@db:5432/destiny_dev"}'
       MINIO_CONFIG: '{"HOST":"fs:9000","ACCESS_KEY":"localuser","SECRET_KEY":"localpass"}'
       ES_CONFIG: '{"ES_URL": "https://elasticsearch:9200", "ES_USER": "elastic", "ES_PASS": "destiny", "ES_CA_PATH": "/app/certs/ca/ca.crt"}'
-      OTEL_CONFIG: '{"trace_endpoint": "http://signoz-otel-collector:4318/v1/traces", "meter_endpoint": "http://signoz-otel-collector:4318/v1/metrics"}'
+      # OTEL_CONFIG: '{"trace_endpoint": "http://signoz-otel-collector:4318/v1/traces", "meter_endpoint": "http://signoz-otel-collector:4318/v1/metrics"}'
       APP_NAME: destiny-app
     networks:
       - default
@@ -105,7 +105,7 @@ services:
       DB_CONFIG: '{"DB_URL":"postgresql+asyncpg://localuser:localpass@db:5432/destiny_dev"}'
       MINIO_CONFIG: '{"HOST":"fs:9000","ACCESS_KEY":"localuser","SECRET_KEY":"localpass"}'
       ES_CONFIG: '{"ES_URL": "https://elasticsearch:9200", "ES_USER": "elastic", "ES_PASS": "destiny", "ES_CA_PATH": "/app/certs/ca/ca.crt"}'
-      OTEL_CONFIG: '{"trace_endpoint": "http://signoz-otel-collector:4318/v1/traces", "meter_endpoint": "http://signoz-otel-collector:4318/v1/metrics"}'
+      # OTEL_CONFIG: '{"trace_endpoint": "http://signoz-otel-collector:4318/v1/traces", "meter_endpoint": "http://signoz-otel-collector:4318/v1/metrics"}'
       APP_NAME: destiny-worker
     networks:
       - default

--- a/tests/core/telemetry/test_fastapi.py
+++ b/tests/core/telemetry/test_fastapi.py
@@ -1,0 +1,63 @@
+"""Test script to demonstrate the TracingMiddleware functionality."""
+
+from typing import Annotated
+
+from fastapi import FastAPI, Path
+from fastapi.testclient import TestClient
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from app.core.telemetry.fastapi import FastAPITracingMiddleware
+
+
+def setup_tracing():
+    """Set up OpenTelemetry for testing."""
+    # Set up tracer
+    trace.set_tracer_provider(TracerProvider())
+    tracer = trace.get_tracer(__name__)
+
+    # Set up in-memory exporter to capture spans for testing
+    memory_exporter = InMemorySpanExporter()
+    span_processor = SimpleSpanProcessor(memory_exporter)
+    trace.get_tracer_provider().add_span_processor(span_processor)
+
+    return tracer, memory_exporter
+
+
+def test_tracing_middleware():
+    """Test the TracingMiddleware with a simple FastAPI app."""
+    tracer, memory_exporter = setup_tracing()
+
+    app = FastAPI()
+    app.add_middleware(FastAPITracingMiddleware)
+
+    @app.get("/test/{item_id}/")
+    async def test_endpoint(
+        item_id: Annotated[str, Path(...)], query_param: str = "default"
+    ) -> dict[str, str]:
+        return {"item_id": item_id, "query_param": query_param}
+
+    client = TestClient(app)
+
+    with tracer.start_as_current_span("test_request"):
+        client.get("/test/123?query_param=test_value&another_param=another_value")
+
+    # Get the spans from the in-memory exporter
+    spans = memory_exporter.get_finished_spans()
+
+    # Find our test span
+    test_span = None
+    for span in spans:
+        if span.name == "test_request":
+            test_span = span
+            break
+
+    assert test_span is not None, "Test span not found"
+
+    # Verify the attributes were set by the middleware
+    attributes = test_span.attributes
+    assert attributes["http.request.query.query_param"] == "test_value"
+    assert attributes["http.request.query.another_param"] == "another_value"
+    assert attributes["http.request.path.item_id"] == "123"


### PR DESCRIPTION
Traces the query and path parameters on each request.

This does make the assumption that these parameters are not sensitive. We've already made this elsewhere so I'm comfortable for now (logging logs the full URL as well), but one to keep in mind.