### PR TITLE
Instrument/alerting

### DIFF
--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -307,8 +307,8 @@ class SDKTranslationError(DestinyRepositoryError):
             errors (str): A sequence of errors, likely copied from ValidationError
 
         """
-        super().__init__(str(errors))
         self.errors = errors
+        super().__init__(str(self))
 
     def __str__(self) -> str:
         """Convert pydantic exception errors to string."""

--- a/app/persistence/uow.py
+++ b/app/persistence/uow.py
@@ -108,7 +108,8 @@ class AsyncUnitOfWorkBase(AbstractAsyncContextManager, ABC):
             )
             set_span_status(trace.StatusCode.ERROR, str(exc_value), exc_value)
             await self.rollback()
-        set_span_status(trace.StatusCode.OK)
+        else:
+            set_span_status(trace.StatusCode.OK)
         self._is_active = False
 
     @abstractmethod

--- a/infra/app/honeycomb.tf
+++ b/infra/app/honeycomb.tf
@@ -48,9 +48,6 @@ data "honeycombio_query_specification" "application_errors" {
   time_range = 300
 }
 
-resource "honeycombio_query" "application_errors" {
-  query_json = data.honeycombio_query_specification.application_errors.json
-}
 
 resource "honeycombio_slack_recipient" "alerts" {
   channel = var.honeycomb_alert_slack_channel
@@ -62,7 +59,7 @@ resource "honeycombio_trigger" "error_trigger" {
 
   name = "Unhandled Exception"
 
-  query_id = honeycombio_query.application_errors.id
+  query_json = data.honeycombio_query_specification.application_errors.json
 
   frequency = 300
 

--- a/infra/app/honeycomb.tf
+++ b/infra/app/honeycomb.tf
@@ -1,0 +1,77 @@
+resource "honeycombio_environment" "this" {
+  name = var.environment
+}
+
+
+resource "honeycombio_api_key" "this" {
+  name           = "${var.app_name}-${var.environment}-ingest-api-key"
+  environment_id = honeycombio_environment.this.id
+  type           = "ingest"
+
+  permissions {
+    create_datasets = true
+  }
+}
+
+data "honeycombio_query_specification" "application_errors" {
+  calculation {
+    op = "COUNT"
+  }
+
+  # Note we don't check for any explicit exception fields here, as it allows
+  # us to trace context for handled exceptions without alerting for them.
+  filter {
+    column = "error"
+    op     = "exists"
+  }
+
+  filter {
+    column = "severity"
+    op     = "equals"
+    value  = "error"
+  }
+
+  filter {
+    column = "severity"
+    op     = "equals"
+    value  = "critical"
+  }
+
+  filter {
+    column = "http.status_code"
+    op     = ">="
+    value  = 500
+  }
+
+  filter_combination = "or"
+
+  time_range = 300
+}
+
+resource "honeycombio_query" "application_errors" {
+  query_json = data.honeycombio_query_specification.application_errors.query_json
+}
+
+resource "honeycombio_slack_recipient" "alerts" {
+  channel = var.honeycomb_alert_slack_channel
+}
+
+resource "honeycombio_trigger" "error_trigger" {
+  name = "Unhandled Exception"
+
+  query_id = honeycombio_query.application_errors.id
+
+  frequency = 300
+
+  alert_type = "on_true"
+
+  threshold {
+    op    = ">"
+    value = 0
+  }
+
+  recipient {
+    id = honeycombio_slack_recipient.alerts.id
+  }
+
+}

--- a/infra/app/honeycomb.tf
+++ b/infra/app/honeycomb.tf
@@ -48,6 +48,9 @@ data "honeycombio_query_specification" "application_errors" {
   time_range = 300
 }
 
+resource "honeycombio_query" "application_errors" {
+  query_json = data.honeycombio_query_specification.application_errors.json
+}
 
 resource "honeycombio_slack_recipient" "alerts" {
   channel = var.honeycomb_alert_slack_channel
@@ -59,7 +62,7 @@ resource "honeycombio_trigger" "error_trigger" {
 
   name = "Unhandled Exception"
 
-  query_json = data.honeycombio_query_specification.application_errors.json
+  query_id = honeycombio_query.application_errors.id
 
   frequency = 300
 

--- a/infra/app/honeycomb.tf
+++ b/infra/app/honeycomb.tf
@@ -60,7 +60,7 @@ resource "honeycombio_trigger" "error_trigger" {
   # Free tier only allows two triggers total, so we only create this in production.
   count = var.environment == "production" ? 1 : 0
 
-  name = "Unhandled Exception"
+  name = "Application Error"
 
   query_id = honeycombio_query.application_errors.id
 

--- a/infra/app/honeycomb.tf
+++ b/infra/app/honeycomb.tf
@@ -57,9 +57,6 @@ resource "honeycombio_slack_recipient" "alerts" {
 }
 
 resource "honeycombio_trigger" "error_trigger" {
-  # Free tier only allows two triggers total, so we only create this in production.
-  count = var.environment == "production" ? 1 : 0
-
   name = "Application Error"
 
   query_id = honeycombio_query.application_errors.id

--- a/infra/app/honeycomb.tf
+++ b/infra/app/honeycomb.tf
@@ -57,6 +57,9 @@ resource "honeycombio_slack_recipient" "alerts" {
 }
 
 resource "honeycombio_trigger" "error_trigger" {
+  # Free tier only allows two triggers total, so we only create this in production.
+  count = var.environment == "production" ? 1 : 0
+
   name = "Unhandled Exception"
 
   query_id = honeycombio_query.application_errors.id
@@ -73,5 +76,4 @@ resource "honeycombio_trigger" "error_trigger" {
   recipient {
     id = honeycombio_slack_recipient.alerts.id
   }
-
 }

--- a/infra/app/honeycomb.tf
+++ b/infra/app/honeycomb.tf
@@ -57,6 +57,9 @@ resource "honeycombio_slack_recipient" "alerts" {
 }
 
 resource "honeycombio_trigger" "error_trigger" {
+  # Free tier only allows two triggers total, so we only create this in production.
+  count = var.environment == "production" ? 1 : 0
+
   name = "Application Error"
 
   query_id = honeycombio_query.application_errors.id

--- a/infra/app/honeycomb.tf
+++ b/infra/app/honeycomb.tf
@@ -27,13 +27,13 @@ data "honeycombio_query_specification" "application_errors" {
 
   filter {
     column = "severity"
-    op     = "equals"
+    op     = "="
     value  = "error"
   }
 
   filter {
     column = "severity"
-    op     = "equals"
+    op     = "="
     value  = "critical"
   }
 
@@ -43,13 +43,13 @@ data "honeycombio_query_specification" "application_errors" {
     value  = 500
   }
 
-  filter_combination = "or"
+  filter_combination = "OR"
 
   time_range = 300
 }
 
 resource "honeycombio_query" "application_errors" {
-  query_json = data.honeycombio_query_specification.application_errors.query_json
+  query_json = data.honeycombio_query_specification.application_errors.json
 }
 
 resource "honeycombio_slack_recipient" "alerts" {

--- a/infra/app/main.tf
+++ b/infra/app/main.tf
@@ -566,19 +566,3 @@ resource "elasticstack_elasticsearch_snapshot_lifecycle" "snapshots" {
   expire_after = "30d"
   min_count    = local.is_production ? 336 : 7 # 7 days worth
 }
-
-
-resource "honeycombio_environment" "this" {
-  name = var.environment
-}
-
-
-resource "honeycombio_api_key" "this" {
-  name           = "${var.app_name}-${var.environment}-ingest-api-key"
-  environment_id = honeycombio_environment.this.id
-  type           = "ingest"
-
-  permissions {
-    create_datasets = true
-  }
-}

--- a/infra/app/terraform.tf
+++ b/infra/app/terraform.tf
@@ -72,6 +72,12 @@ provider "elasticstack" {
 }
 
 provider "honeycombio" {
+  # Honeycomb requires two different API auth scopes
+
+  # v1: configuration
+  api_key = var.honeycombio_configuration_api_key
+
+  # v2: provisioning
   api_key_id     = var.honeycombio_api_key_id
   api_key_secret = var.honeycombio_api_key_secret
 }

--- a/infra/app/variables.tf
+++ b/infra/app/variables.tf
@@ -230,3 +230,9 @@ variable "telemetry_enabled" {
   type        = bool
   default     = true
 }
+
+variable "honeycomb_alert_slack_channel" {
+  description = "Slack channel for Honeycomb alerts"
+  type        = string
+  default     = "#destiny-alerts"
+}

--- a/infra/app/variables.tf
+++ b/infra/app/variables.tf
@@ -213,6 +213,12 @@ variable "honeycombio_api_key_secret" {
   sensitive   = true
 }
 
+variable "honeycombio_configuration_api_key" {
+  description = "Configuration API key for Honeycomb.io"
+  type        = string
+  sensitive   = true
+}
+
 variable "honeycombio_trace_endpoint" {
   description = "Trace endpoint for Honeycomb.io"
   type        = string


### PR DESCRIPTION
Adds a simple alerter with slack integration. The alerter runs on all datasets (eg robots also).

This will be too aggressive to start, but we can use it to refine both the application tracing and the trigger over time. Then we can consider pivoting to PagerDuty or similar.

Alert conditions:
- Errored span
  - There's an implementation detail here: if an error is raised and we catch it in a higher span, the raising span will still trigger this alert. For eg, a FastAPI exception handler will not suppress a honeycomb alert from firing. For now, I think that visibility is nice anyway as it can help us guide users.
- Error or critical level log
- 5XX status code

I've put a couple of test alerts in the `#testiny` slack channel.


NB - we can also manage boards via terraform, but that seems like more effort than desired for now. They're two clicks to duplicate across environments and will take some time for us to cement.