### PR TITLE
Fix infra var name for log_endpoint

### DIFF
--- a/infra/app/main.tf
+++ b/infra/app/main.tf
@@ -123,7 +123,7 @@ locals {
       value = jsonencode({
         trace_endpoint = var.honeycombio_trace_endpoint
         meter_endpoint = var.honeycombio_meter_endpoint
-        logs_endpoint  = var.honeycombio_logs_endpoint
+        log_endpoint   = var.honeycombio_log_endpoint
         api_key        = honeycombio_api_key.this.key
       })
     },

--- a/infra/app/variables.tf
+++ b/infra/app/variables.tf
@@ -231,7 +231,7 @@ variable "honeycombio_meter_endpoint" {
   default     = "https://api.honeycomb.io/v1/metrics"
 }
 
-variable "honeycombio_logs_endpoint" {
+variable "honeycombio_log_endpoint" {
   description = "Meter endpoint for Honeycomb.io"
   type        = string
   default     = "https://api.honeycomb.io/v1/logs"

--- a/infra/app/variables.tf
+++ b/infra/app/variables.tf
@@ -232,7 +232,7 @@ variable "honeycombio_meter_endpoint" {
 }
 
 variable "honeycombio_log_endpoint" {
-  description = "Meter endpoint for Honeycomb.io"
+  description = "Logging endpoint for Honeycomb.io"
   type        = string
   default     = "https://api.honeycomb.io/v1/logs"
 }


### PR DESCRIPTION
Quick fix to rename the `logs_endpoint` variable to `log_endpoint` so that it aligns with the expected variable name in the application config.py