### PR TITLE
generalise metrics datasets across api and worker

### DIFF
--- a/app/core/telemetry/attributes.py
+++ b/app/core/telemetry/attributes.py
@@ -60,6 +60,7 @@ class Attributes(StrEnum):
     SERVICE_NAME = service_attributes.SERVICE_NAME
     SERVICE_VERSION = service_attributes.SERVICE_VERSION
     SERVICE_NAMESPACE = _service_attributes.SERVICE_NAMESPACE
+    SERVICE_INSTANCE_ID = _service_attributes.SERVICE_INSTANCE_ID
 
     # User attributes
     USER_ID = _user_attributes.USER_ID

--- a/app/core/telemetry/otel.py
+++ b/app/core/telemetry/otel.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from typing import TYPE_CHECKING
 
 from opentelemetry import metrics, trace
@@ -49,12 +50,15 @@ def configure_otel(
     if config.api_key:
         headers["x-honeycomb-team"] = config.api_key
 
+    service_instance_id = str(uuid.uuid4())
+
     ## Traces
     resource = Resource.create(
         {
             Attributes.SERVICE_NAMESPACE: "destiny",
             Attributes.SERVICE_NAME: f"{app_name}-{env.value}",
             Attributes.SERVICE_VERSION: app_version,
+            Attributes.SERVICE_INSTANCE_ID: service_instance_id,
             Attributes.DEPLOYMENT_ENVIRONMENT: env.value,
         }
     )
@@ -108,3 +112,5 @@ def configure_otel(
 
     handler = AttrFilteredLoggingHandler(logger_provider=logger_provider)
     logger_configurer.configure_otel_logger(handler)
+
+    logger.info("Opentelemetry configured", service_instance_id=service_instance_id)

--- a/app/core/telemetry/otel.py
+++ b/app/core/telemetry/otel.py
@@ -90,8 +90,7 @@ def configure_otel(
             PeriodicExportingMetricReader(
                 OTLPMetricExporter(
                     endpoint=str(config.meter_endpoint),
-                    headers=headers
-                    | {"x-honeycomb-dataset": f"metrics-{app_name}-{env.value}"},
+                    headers=headers | {"x-honeycomb-dataset": "metrics-repository"},
                 )
             )
         ],


### PR DESCRIPTION
Follows best practices for non-trace data: https://docs.honeycomb.io/get-started/best-practices/organizing-data/#general-datasets.

Also added a correlation ID for each instance. I wasn't able to hit the [IMDS](https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service?tabs=linux) for some reason, so mapping to the actual Azure instance is manual, but didn't feel worth the rabbit hole.