### PR TITLE
Set the span status after AuthError initialised

### DIFF
--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -450,9 +450,9 @@ class AuthError(destiny_sdk.auth.AuthException):
             *args: Additional arguments for the exception.
 
         """
+        super().__init__(status_code, detail, headers)
         set_span_status(
             StatusCode.ERROR,
             detail=detail,
             exception=self,
         )
-        super().__init__(status_code, detail, headers)


### PR DESCRIPTION
Fixes #256 

Setting the span status called `self.status_code` down the chain, which has not been initialized because the init call was after setting the span status. Fixed by initializing first.