### PR TITLE
Get new queue sender for each message

### DIFF
--- a/app/core/azure_service_bus_broker.py
+++ b/app/core/azure_service_bus_broker.py
@@ -17,7 +17,6 @@ from azure.servicebus.aio import (
     AutoLockRenewer,
     ServiceBusClient,
     ServiceBusReceiver,
-    ServiceBusSender,
 )
 from azure.servicebus.amqp import AmqpAnnotatedMessage, AmqpMessageBodyType
 from taskiq import AckableMessage, AsyncBroker, BrokerMessage
@@ -84,7 +83,6 @@ class AzureServiceBusBroker(AsyncBroker):
         self.max_lock_renewal_duration = max_lock_renewal_duration
 
         self.service_bus_client: ServiceBusClient | None = None
-        self.sender: ServiceBusSender | None = None
         self.receiver: ServiceBusReceiver | None = None
         self.credential: DefaultAzureCredential | None = None
         self.auto_lock_renewer: AutoLockRenewer | None = None
@@ -108,10 +106,6 @@ class AzureServiceBusBroker(AsyncBroker):
                 detail="Either connection_string or namespace must be provided"
             )
 
-        self.sender = self.service_bus_client.get_queue_sender(
-            queue_name=self._queue_name
-        )
-
         if self.is_worker_process:
             self.receiver = self.service_bus_client.get_queue_receiver(
                 queue_name=self._queue_name,
@@ -126,8 +120,6 @@ class AzureServiceBusBroker(AsyncBroker):
         """Close all connections on shutdown."""
         await super().shutdown()
 
-        if self.sender:
-            await self.sender.close()
         if self.receiver:
             await self.receiver.close()
         if self.service_bus_client:
@@ -145,7 +137,7 @@ class AzureServiceBusBroker(AsyncBroker):
         :raises MessageBrokerError:detail= if startup wasn't called.
         :param message: message to send.
         """
-        if self.sender is None or self.service_bus_client is None:
+        if self.service_bus_client is None:
             raise MessageBrokerError(detail="Please run startup before kicking.")
 
         headers = {}
@@ -168,13 +160,16 @@ class AzureServiceBusBroker(AsyncBroker):
 
         logger.debug("Sending message...", task_id=message.task_id, delay=delay)
 
-        if delay is None:
-            # Send message directly to main queue
-            await self.sender.send_messages(service_bus_message)
-        else:
-            # Use Azure's built-in scheduled messages feature
-            scheduled_time = datetime.now(UTC) + timedelta(seconds=delay)
-            await self.sender.schedule_messages(service_bus_message, scheduled_time)
+        async with self.service_bus_client.get_queue_sender(
+            queue_name=self._queue_name
+        ) as sender:
+            if delay is None:
+                # Send message directly to main queue
+                await sender.send_messages(service_bus_message)
+            else:
+                # Use Azure's built-in scheduled messages feature
+                scheduled_time = datetime.now(UTC) + timedelta(seconds=delay)
+                await sender.schedule_messages(service_bus_message, scheduled_time)
 
     async def listen(self) -> AsyncGenerator[AckableMessage, None]:
         """

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -25,6 +25,13 @@ class FakeServiceBusSender:
     Azure Service Bus sender during unit tests.
     """
 
+    async def __aenter__(self) -> "FakeServiceBusSender":
+        """Open the sender."""
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+        """Close the sender."""
+
     async def schedule_messages(
         self, message: AmqpAnnotatedMessage, scheduled_time: datetime | None = None
     ) -> None:

--- a/tests/core/test_azure_service_bus_broker.py
+++ b/tests/core/test_azure_service_bus_broker.py
@@ -17,6 +17,7 @@ from taskiq.utils import maybe_awaitable
 
 from app.core.azure_service_bus_broker import AzureServiceBusBroker
 from app.core.exceptions import MessageBrokerError
+from tests.core.conftest import FakeServiceBusSender
 
 
 async def get_first_task(broker: AzureServiceBusBroker):
@@ -109,13 +110,12 @@ async def test_happy_startup(broker: AzureServiceBusBroker) -> None:
     """
     Test that the broker initializes correctly.
 
-    This test checks that the broker's Service Bus client,
-    sender and receiver are correctly initialized.
+    This test checks that the broker's Service Bus client
+    and receiver are correctly initialized.
 
     :param broker: Azure Service Bus broker.
     """
     assert broker.service_bus_client is not None
-    assert broker.sender is not None
     assert broker.receiver is not None
 
 
@@ -143,7 +143,14 @@ async def test_kick_success(
         },
     )
 
-    await broker.kick(sent)
+    from tests.core.conftest import FakeServiceBusSender
+
+    with patch.object(
+        broker.service_bus_client,
+        "get_queue_sender",
+        return_value=FakeServiceBusSender(),
+    ):
+        await broker.kick(sent)
 
     message = await asyncio.wait_for(get_first_task(broker), timeout=1.0)
 
@@ -175,8 +182,15 @@ async def test_delayed_message(
         labels={"delay": "2"},
     )
 
-    # Send the delayed message
-    await broker.kick(broker_msg)
+    from tests.core.conftest import FakeServiceBusSender
+
+    with patch.object(
+        broker.service_bus_client,
+        "get_queue_sender",
+        return_value=FakeServiceBusSender(),
+    ):
+        # Send the delayed message
+        await broker.kick(broker_msg)
 
     # Try to get the message immediately - should not be available yet
     with pytest.raises(asyncio.TimeoutError):
@@ -195,34 +209,32 @@ async def test_delayed_message(
 @pytest.mark.anyio
 async def test_priority_handling(
     broker: AzureServiceBusBroker,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
     Test that priority is correctly set in the message headers.
 
     :param broker: current broker.
-    :param test_sender: test sender.
-    :param test_receiver: test receiver.
     """
-    assert broker.sender is not None
-    original_send_messages = broker.sender.send_messages
-    sent_message = None
+    sent_message = {}
 
-    async def mock_send_messages(message: AmqpAnnotatedMessage) -> None:
-        nonlocal sent_message
-        sent_message = message
-        await original_send_messages(message)
+    class CaptureSender(FakeServiceBusSender):
+        async def send_messages(self, message: AmqpAnnotatedMessage) -> None:
+            sent_message["msg"] = message
+            await super().send_messages(message)
 
-    monkeypatch.setattr(broker.sender, "send_messages", mock_send_messages)
-    await broker.kick(
-        BrokerMessage(
-            task_id="priority-task",
-            task_name="priority-name",
-            message=b"priority-message",
-            labels={"priority": "5"},
+    with patch.object(
+        broker.service_bus_client, "get_queue_sender", return_value=CaptureSender()
+    ):
+        await broker.kick(
+            BrokerMessage(
+                task_id="priority-task",
+                task_name="priority-name",
+                message=b"priority-message",
+                labels={"priority": "5"},
+            )
         )
-    )
 
-    assert isinstance(sent_message, AmqpAnnotatedMessage)
-    assert sent_message.header is not None
-    assert sent_message.header.priority == 5
+    msg = sent_message.get("msg")
+    assert isinstance(msg, AmqpAnnotatedMessage)
+    assert msg.header is not None
+    assert msg.header.priority == 5


### PR DESCRIPTION
Since increasing our throughput of service bus messages, we've had some sporadic errors deep in the Azure service bus client. 

Eg: https://ui.honeycomb.io/destiny-evidence/environments/staging/datasets/destiny-repository-task-staging/result/zPWTuV3Pipz?expd_col=_hny.ts&expd_id=uTNFKFAiv97&expd_page=25&tab=explore&vs=hideCompare&expd_drawer_row=0

There's a small amount of conjecture online (https://github.com/Azure/azure-sdk-for-python/issues/32967, https://github.com/celery/celery/issues/8878) but no concrete causes/solutions. My suspicion is it's a race condition - we also hit it far more often when distributing automations (async) compared to distributing imports (sync), and somebody reported better performance when setting concurrent celery jobs to 1.

This PR is somewhat a stab in the dark, but hoping that using shorter-lived senders will help. Worst case our simplest remedial route may be some tenacity retrying (_we should probably do this anyway_).

Another route to check would be to remove `properties` from the message (line 152) as another user reported that helps. Would ideally like to avoid this however as that transports our task trace correlation.