### PR TITLE
Add locks to azure service bus operations

### DIFF
--- a/app/core/azure_service_bus_broker.py
+++ b/app/core/azure_service_bus_broker.py
@@ -11,7 +11,6 @@ from collections.abc import AsyncGenerator, Callable
 from datetime import UTC, datetime, timedelta
 from typing import TypeVar
 
-import tenacity
 from azure.identity.aio import DefaultAzureCredential
 from azure.servicebus import ServiceBusReceivedMessage, ServiceBusReceiveMode
 from azure.servicebus.aio import (
@@ -24,7 +23,7 @@ from azure.servicebus.amqp import AmqpAnnotatedMessage, AmqpMessageBodyType
 from taskiq import AckableMessage, AsyncBroker, BrokerMessage
 
 from app.core.config import get_settings
-from app.core.exceptions import MessageBrokerError, MessageBrokerRetryableError
+from app.core.exceptions import MessageBrokerError
 from app.core.telemetry.logger import get_logger
 
 _T = TypeVar("_T")
@@ -136,12 +135,6 @@ class AzureServiceBusBroker(AsyncBroker):
         if self.credential:
             await self.credential.close()
 
-    @tenacity.retry(
-        retry=tenacity.retry_if_exception_type(MessageBrokerRetryableError),
-        wait=tenacity.wait_exponential_jitter(initial=0.5, jitter=1, exp_base=2),
-        stop=tenacity.stop_after_attempt(5),
-        reraise=True,
-    )
     async def kick(self, message: BrokerMessage) -> None:
         """
         Send message to the queue.
@@ -175,24 +168,13 @@ class AzureServiceBusBroker(AsyncBroker):
 
         logger.debug("Sending message...", task_id=message.task_id, delay=delay)
 
-        try:
-            if delay is None:
-                # Send message directly to main queue
-                await self.sender.send_messages(service_bus_message)
-            else:
-                # Use Azure's built-in scheduled messages feature
-                scheduled_time = datetime.now(UTC) + timedelta(seconds=delay)
-                await self.sender.schedule_messages(service_bus_message, scheduled_time)
-        except AttributeError as exc:
-            # Sporadic issue with Azure service bus. Suspect a race condition.
-            # Has pattern:
-            #   AttributeError: 'NoneType' object has no attribute 'create_sender_link'
-            # See: https://github.com/Azure/azure-sdk-for-python/issues/32967
-            if "NoneType" in str(exc) and "create_sender_link" in str(exc):
-                raise MessageBrokerRetryableError(
-                    detail="Sporadic Azure Service Bus issue encountered."
-                ) from exc
-            raise
+        if delay is None:
+            # Send message directly to main queue
+            await self.sender.send_messages(service_bus_message)
+        else:
+            # Use Azure's built-in scheduled messages feature
+            scheduled_time = datetime.now(UTC) + timedelta(seconds=delay)
+            await self.sender.schedule_messages(service_bus_message, scheduled_time)
 
     async def listen(self) -> AsyncGenerator[AckableMessage, None]:
         """

--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -50,21 +50,6 @@ class MessageBrokerError(DestinyRepositoryError):
         super().__init__(detail, *args)
 
 
-class MessageBrokerRetryableError(MessageBrokerError):
-    """An exception thrown in a message broker that can be retried."""
-
-    def __init__(self, detail: str, *args: object) -> None:
-        """
-        Initialize the BrokerError exception.
-
-        Args:
-            detail (str): The detail message for the exception.
-            *args: Additional arguments for the exception.
-
-        """
-        super().__init__(detail, *args)
-
-
 class NotFoundError(DestinyRepositoryError):
     """Exception for when we can't find something we expect to find."""
 


### PR DESCRIPTION
Got a different variation on the service bus error overnight, which finally led me to:

<img width="578" height="215" alt="image" src="https://github.com/user-attachments/assets/fea2ac72-bd36-4b42-983e-a94e7c8cbbb2" />

~Naturally, clicking that link just takes you to the python azure service bus docs which don't mention concurrency locking.~ Link is probably meant to point here: https://learn.microsoft.com/en-us/python/api/overview/azure/servicebus-readme?view=azure-python#thread-safety