### PR TITLE
Don't collect_and_dispatch_references_for_enhancement after robot automations

### DIFF
--- a/app/domain/references/tasks.py
+++ b/app/domain/references/tasks.py
@@ -11,7 +11,6 @@ from structlog.contextvars import bound_contextvars
 
 from app.core.telemetry.attributes import Attributes, name_span, trace_attribute
 from app.core.telemetry.logger import get_logger
-from app.core.telemetry.taskiq import queue_task_with_trace
 from app.domain.references.models.models import (
     EnhancementRequest,
     EnhancementRequestStatus,
@@ -367,8 +366,4 @@ async def detect_and_dispatch_robot_automations(
             )
         )
         requests.append(enhancement_request)
-        await queue_task_with_trace(
-            collect_and_dispatch_references_for_enhancement,
-            enhancement_request_id=enhancement_request.id,
-        )
     return requests

--- a/tests/unit/domain/references/test_tasks.py
+++ b/tests/unit/domain/references/test_tasks.py
@@ -16,7 +16,6 @@ from app.domain.references.services.anti_corruption_service import (
     ReferenceAntiCorruptionService,
 )
 from app.domain.references.tasks import (
-    collect_and_dispatch_references_for_enhancement,
     detect_and_dispatch_robot_automations,
     validate_and_import_robot_enhancement_batch_result,
 )
@@ -58,13 +57,6 @@ async def test_robot_automations(monkeypatch, fake_uow, fake_repository):
         mock_detect_robot_automations,
     )
 
-    mock_collect_and_dispatch_request_to_robot = AsyncMock()
-    monkeypatch.setattr(
-        collect_and_dispatch_references_for_enhancement,
-        "kiq",
-        mock_collect_and_dispatch_request_to_robot,
-    )
-
     requests = await detect_and_dispatch_robot_automations(
         reference_service=ReferenceService(
             ReferenceAntiCorruptionService(fake_repository), fake_uow()
@@ -83,13 +75,6 @@ async def test_robot_automations(monkeypatch, fake_uow, fake_repository):
     )
     assert (
         mock_register_request.call_args[1]["enhancement_request"].robot_id == robot_id
-    )
-    mock_collect_and_dispatch_request_to_robot.assert_awaited_once()
-    assert (
-        mock_collect_and_dispatch_request_to_robot.call_args[1][
-            "enhancement_request_id"
-        ]
-        == expected_request.id
     )
     mock_detect_robot_automations.assert_awaited_once_with(
         reference_ids=in_reference_ids, enhancement_ids=in_enhancement_ids


### PR DESCRIPTION
Don't `collect_and_dispatch_references_for_enhancement` after robot automations now we're doing pull rather than push.
