### PR TITLE
Toy robot starts up correctly for E2E tests

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -74,22 +74,16 @@ services:
     entrypoint: taskiq worker app.tasks:broker --tasks-pattern app/**/tasks.py --fs-discover
   toy-robot:
     build: https://github.com/destiny-evidence/toy-robot.git
+    profiles: ["e2e"]
+    depends_on:
+      app:
+        condition: service_healthy
     environment:
       DESTINY_REPOSITORY_URL: "http://app:8000/v1"
       ENV: "test"
       ROBOT_ID: "1ee5aa1f-3248-4d21-9fee-718d4ff0ba5f" # Just a dummy, won't be used.
       ROBOT_SECRET: "dummy"
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "python",
-          "-c",
-          "import socket; sock = socket.create_connection(('localhost',8001), 2); sock.close()",
-        ]
-      interval: 10s
-      timeout: 10s
-      retries: 5
+
   e2e:
     profiles: ["e2e"]
     build:
@@ -105,7 +99,7 @@ services:
       app:
         condition: service_healthy
       toy-robot:
-        condition: service_healthy
+        condition: service_started
     environment:
       DB_URL: "postgresql+psycopg://localuser:localpass@db:5432/destiny_dev"
       REPO_URL: "http://app:8000/v1"


### PR DESCRIPTION
The toy robot wasn't starting up correctly for the E2E tests, causing them to fail. This removes the health-check which was listening on a port that was no longer used, as well as making the toy robot dependent on successful destiny repository start-up, so that the polling requests receive responses. 