### PR TITLE
API Interface for Deduplication

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -47,6 +47,7 @@ class AuthRole(StrEnum):
     ADMINISTRATOR = "administrator"
     IMPORT_WRITER = "import.writer"
     REFERENCE_READER = "reference.reader"
+    REFERENCE_DEDUPLICATOR = "reference.deduplicator"
     ENHANCEMENT_REQUEST_WRITER = "enhancement_request.writer"
 
 
@@ -56,6 +57,7 @@ class AuthScope(StrEnum):
     ADMINISTRATOR = "administrator.all"
     IMPORT_WRITER = "import.writer.all"
     REFERENCE_READER = "reference.reader.all"
+    REFERENCE_DEDUPLICATOR = "reference.deduplicator.all"
     ENHANCEMENT_REQUEST_WRITER = "enhancement_request.writer.all"
     ROBOT_WRITER = "robot.writer.all"
 

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -770,3 +770,12 @@ class RobotEnhancementBatch(DomainBaseModel, SQLAttributeMixin):
         default=None,
         description="The pending enhancements in this batch.",
     )
+
+
+class ReferenceIds(BaseModel):
+    """Model representing a list of reference IDs."""
+
+    reference_ids: list[UUID4] = Field(
+        ...,
+        description="A list of reference IDs.",
+    )

--- a/app/domain/references/routes.py
+++ b/app/domain/references/routes.py
@@ -36,6 +36,7 @@ from app.domain.references.models.models import (
     EnhancementRequestStatus,
     ExternalIdentifierSearch,
     PendingEnhancementStatus,
+    ReferenceIds,
 )
 from app.domain.references.service import ReferenceService
 from app.domain.references.services.anti_corruption_service import (
@@ -129,6 +130,17 @@ def choose_auth_strategy_reference_reader() -> AuthMethod:
     )
 
 
+def choose_auth_strategy_reference_deduplicator() -> AuthMethod:
+    """Choose reader scope auth strategy for our authorization."""
+    return choose_auth_strategy(
+        tenant_id=settings.azure_tenant_id,
+        application_id=settings.azure_application_id,
+        auth_scope=AuthScope.REFERENCE_DEDUPLICATOR,
+        auth_role=AuthRole.REFERENCE_DEDUPLICATOR,
+        bypass_auth=settings.running_locally,
+    )
+
+
 # NB hybrid_auth is not easily wrapped in CachingStrategyAuth because of the robot
 # service dependency.
 # May be revisited with https://github.com/destiny-evidence/destiny-repository/issues/199
@@ -151,6 +163,9 @@ async def enhancement_request_hybrid_auth(
 
 reference_reader_auth = CachingStrategyAuth(
     selector=choose_auth_strategy_reference_reader,
+)
+reference_deduplication_auth = CachingStrategyAuth(
+    selector=choose_auth_strategy_reference_deduplicator,
 )
 
 
@@ -182,6 +197,11 @@ enhancement_request_automation_router = APIRouter(
         Depends(enhancement_request_hybrid_auth),
         Depends(PayloadAttributeTracer("robot_id")),
     ],
+)
+deduplication_router = APIRouter(
+    prefix="/deduplication",
+    tags=["deduplication"],
+    dependencies=[Depends(reference_deduplication_auth)],
 )
 
 
@@ -498,3 +518,20 @@ async def fulfill_robot_enhancement_batch(
     return await anti_corruption_service.robot_enhancement_batch_to_sdk(
         robot_enhancement_batch
     )
+
+
+@deduplication_router.post(
+    "/",
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def invoke_deduplication_for_references(
+    reference_ids: ReferenceIds,
+    reference_service: Annotated[ReferenceService, Depends(reference_service)],
+) -> None:
+    """Invoke the deduplication process."""
+    await reference_service.invoke_deduplication_for_references(
+        reference_ids.reference_ids
+    )
+
+
+reference_router.include_router(deduplication_router)

--- a/app/domain/references/routes.py
+++ b/app/domain/references/routes.py
@@ -199,8 +199,8 @@ enhancement_request_automation_router = APIRouter(
     ],
 )
 deduplication_router = APIRouter(
-    prefix="/deduplication",
-    tags=["deduplication"],
+    prefix="/duplicate-decisions",
+    tags=["duplicate-decisions"],
     dependencies=[Depends(reference_deduplication_auth)],
 )
 
@@ -529,6 +529,10 @@ async def invoke_deduplication_for_references(
     reference_service: Annotated[ReferenceService, Depends(reference_service)],
 ) -> None:
     """Invoke the deduplication process."""
+    logger.info(
+        "Invoking deduplication for references.",
+        n_references=len(reference_ids.reference_ids),
+    )
     await reference_service.invoke_deduplication_for_references(
         reference_ids.reference_ids
     )

--- a/app/domain/references/service.py
+++ b/app/domain/references/service.py
@@ -18,6 +18,7 @@ from app.core.exceptions import (
 )
 from app.core.telemetry.attributes import Attributes, trace_attribute
 from app.core.telemetry.logger import get_logger
+from app.core.telemetry.taskiq import queue_task_with_trace
 from app.domain.imports.models.models import CollisionStrategy
 from app.domain.references.models.models import (
     DuplicateDetermination,
@@ -327,7 +328,7 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
                 canonical_reference_id=str(canonical_reference.id),
             )
             await self._deduplication_service.register_duplicate_decision_for_reference(
-                reference=reference,
+                reference_id=reference.id,
                 duplicate_determination=DuplicateDetermination.EXACT_DUPLICATE,
                 canonical_reference_id=canonical_reference.id,
             )
@@ -335,7 +336,7 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
 
         duplicate_decision = (
             await self._deduplication_service.register_duplicate_decision_for_reference(
-                reference=reference
+                reference_id=reference.id
             )
         )
         await self._merge_reference(reference)
@@ -938,4 +939,25 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
         return await self._enhancement_service.build_robot_enhancement_batch(
             robot_enhancement_batch=robot_enhancement_batch,
             reference_data_file=reference_data_file,
+        )
+
+    @sql_unit_of_work
+    async def invoke_deduplication_for_references(
+        self,
+        reference_ids: list[UUID],
+    ) -> None:
+        """Invoke deduplication for a list of references."""
+
+        async def _register_and_queue(reference_id: UUID) -> None:
+            """Coroutine to register and queue deduplication."""
+            reference_duplicate_decision = await self._deduplication_service.register_duplicate_decision_for_reference(  # noqa: E501
+                reference_id=reference_id
+            )
+            await queue_task_with_trace(
+                ("app.domain.references.tasks", "process_reference_duplicate_decision"),
+                reference_duplicate_decision_id=reference_duplicate_decision.id,
+            )
+
+        await asyncio.gather(
+            *[_register_and_queue(reference_id) for reference_id in reference_ids]
         )

--- a/app/domain/references/services/deduplication_service.py
+++ b/app/domain/references/services/deduplication_service.py
@@ -105,7 +105,7 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
 
     async def register_duplicate_decision_for_reference(
         self,
-        reference: Reference,
+        reference_id: uuid.UUID,
         enhancement_id: uuid.UUID | None = None,
         duplicate_determination: Literal[DuplicateDetermination.EXACT_DUPLICATE]
         | None = None,
@@ -143,7 +143,7 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
             else DuplicateDetermination.PENDING
         )
         reference_duplicate_decision = ReferenceDuplicateDecision(
-            reference_id=reference.id,
+            reference_id=reference_id,
             enhancement_id=enhancement_id,
             duplicate_determination=_duplicate_determination,
             canonical_reference_id=canonical_reference_id,

--- a/app/persistence/sql/repository.py
+++ b/app/persistence/sql/repository.py
@@ -383,7 +383,7 @@ class GenericAsyncSqlRepository(
         return persistence.to_domain()
 
     @trace_repository_method(tracer)
-    async def bulk_add(
+    async def add_bulk(
         self, records: list[GenericDomainModelType]
     ) -> list[GenericDomainModelType]:
         """

--- a/infra/app/auth.tf
+++ b/infra/app/auth.tf
@@ -2,6 +2,7 @@
 resource "random_uuid" "administrator_role" {}
 resource "random_uuid" "importer_role" {}
 resource "random_uuid" "reference_reader_role" {}
+resource "random_uuid" "reference_deduplicator_role" {}
 resource "random_uuid" "robot_writer_role" {}
 resource "random_uuid" "enhancement_request_writer_role" {}
 
@@ -9,6 +10,7 @@ resource "random_uuid" "enhancement_request_writer_role" {}
 resource "random_uuid" "administrator_scope" {}
 resource "random_uuid" "importer_scope" {}
 resource "random_uuid" "reference_reader_scope" {}
+resource "random_uuid" "reference_deduplicator_scope" {}
 resource "random_uuid" "robot_writer_scope" {}
 resource "random_uuid" "enhancement_request_writer_scope" {}
 
@@ -47,6 +49,15 @@ resource "azuread_application" "destiny_repository" {
       value                      = "reference.reader.all"
       user_consent_description   = "Allow you to view references"
       user_consent_display_name  = "Reference Reader"
+    }
+    oauth2_permission_scope {
+      admin_consent_description  = "Allow the app to deduplicate references as the signed-in user"
+      admin_consent_display_name = "Reference Deduplicator as user"
+      id                         = random_uuid.reference_deduplicator_scope.result
+      type                       = "User"
+      value                      = "reference.deduplicator.all"
+      user_consent_description   = "Allow you to deduplicate references"
+      user_consent_display_name  = "Reference Deduplicator"
     }
 
     oauth2_permission_scope {
@@ -104,6 +115,15 @@ resource "azuread_application_app_role" "reference_reader" {
   display_name         = "Reference Reader"
   role_id              = random_uuid.reference_reader_role.result
   value                = "reference.reader"
+}
+
+resource "azuread_application_app_role" "reference_deduplicator" {
+  application_id       = azuread_application.destiny_repository.id
+  allowed_member_types = ["Application"]
+  description          = "Can deduplicate references"
+  display_name         = "Reference Deduplicator"
+  role_id              = random_uuid.reference_deduplicator_role.result
+  value                = "reference.deduplicator"
 }
 
 resource "azuread_application_app_role" "enhancement_request_writer" {

--- a/tests/integration/test_es_references.py
+++ b/tests/integration/test_es_references.py
@@ -333,7 +333,7 @@ async def test_es_repository_update_existing(
     assert len(updated_reference.enhancements or []) == 0
 
 
-async def test_bulk_add(
+async def test_add_bulk(
     es_reference_repository: ReferenceESRepository, reference: Reference
 ):
     """Test bulk adding multiple references."""

--- a/tests/routers/test_imports.py
+++ b/tests/routers/test_imports.py
@@ -9,6 +9,7 @@ import pytest
 from elasticsearch import AsyncElasticsearch
 from fastapi import FastAPI, status
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from taskiq import InMemoryBroker
 
@@ -33,6 +34,8 @@ from app.domain.imports.models.sql import (
     ImportResult as SQLImportResult,
 )
 from app.domain.imports.service import ImportService
+from app.domain.references import routes as references
+from app.domain.references.models.sql import ReferenceDuplicateDecision
 from app.tasks import broker
 
 # Use the database session in all tests to set up the database manager.
@@ -54,6 +57,7 @@ def app() -> FastAPI:
         }
     )
     app.include_router(imports.router, prefix="/v1")
+    app.include_router(references.reference_router, prefix="/v1")
     return app
 
 
@@ -379,3 +383,43 @@ async def test_missing_import_record(
     response = await client.get(f"/v1/imports/records/{(_id:=uuid.uuid4())}/batches/")
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.json()["detail"] == f"ImportRecord with id {_id} does not exist."
+
+
+async def test_deduplicate_references(
+    client: AsyncClient,
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    es_client: AsyncElasticsearch,  # noqa: ARG001
+) -> None:
+    """
+    Test that we can deduplicate references for an import record.
+
+    NB this test takes advantage of the fact that duplicate_decision doesn't
+    FK to Reference (see app.domain.references.models.sql.ReferenceDuplicateDecision
+    for more). If that changes, this test will need seeding.
+    """
+    mock_queue = AsyncMock()
+    monkeypatch.setattr(
+        "app.domain.references.service.queue_task_with_trace", mock_queue
+    )
+
+    ref_ids = {uuid.uuid4(), uuid.uuid4(), uuid.uuid4()}
+    response = await client.post(
+        "/v1/references/duplicate-decisions/",
+        json={"reference_ids": [str(r) for r in ref_ids]},
+    )
+    assert response.status_code == status.HTTP_202_ACCEPTED
+
+    # Assert queue_task_with_trace was called 3 times with correct IDs
+    assert mock_queue.call_count == 3
+    called_ids = {
+        call.kwargs["reference_duplicate_decision_id"]
+        for call in mock_queue.call_args_list
+    }
+
+    data = await session.execute(select(ReferenceDuplicateDecision))
+    results = data.scalars().all()
+    assert len(results) == 3
+    assert {r.reference_id for r in results} == ref_ids
+    assert {r.duplicate_determination for r in results} == {"pending"}
+    assert {r.id for r in results} == called_ids

--- a/tests/unit/domain/conftest.py
+++ b/tests/unit/domain/conftest.py
@@ -31,7 +31,7 @@ class FakeRepository:
         self.repository[record.id] = record
         return record
 
-    async def bulk_add(
+    async def add_bulk(
         self, records: list[DummyDomainSQLModel]
     ) -> list[DummyDomainSQLModel]:
         """Add multiple records to the repository in bulk."""

--- a/tests/unit/domain/references/services/test_deduplication_service.py
+++ b/tests/unit/domain/references/services/test_deduplication_service.py
@@ -125,7 +125,7 @@ async def test_register_duplicate_decision_for_reference_happy_path(
         fake_uow(),
     )
     result = await service.register_duplicate_decision_for_reference(
-        reference_with_identifiers
+        reference_with_identifiers.id
     )
     assert result.reference_id == reference_with_identifiers.id
     assert result.duplicate_determination == DuplicateDetermination.PENDING
@@ -142,7 +142,7 @@ async def test_register_duplicate_decision_invalid_combination(
     )
     with pytest.raises(DeduplicationValueError):
         await service.register_duplicate_decision_for_reference(
-            reference_with_identifiers,
+            reference_with_identifiers.id,
             duplicate_determination=DuplicateDetermination.EXACT_DUPLICATE,
             canonical_reference_id=None,
         )


### PR DESCRIPTION
Adds a very basic API endpoint `POST /v1/references/duplicate-decisions/` to queue deduplication tasks for a given list of reference ids.

Please be my guest if you have any ideas for specific requirements here! The initial use-cases I have in mind are triggering on existing references on release, triggering after enhancements, re-running on new deduplication algorithms.

I imagine this router will get built out over time - things like checking duplicate decision progress, calling via CLI, tools to manually resolve duplicates - hence the new role provisioning.