### PR TITLE
Updated automodule path for robot models in docs

### DIFF
--- a/docs/codebase/models/robots.rst
+++ b/docs/codebase/models/robots.rst
@@ -2,13 +2,13 @@ Robot Models
 =============
 
 This documentation auto-generates details about the Pydantic models defined in
-``app/domain/robots/models.py``.
+``app/domain/robots/models/models.py``.
 
 .. contents:: Table of Contents
     :depth: 1
     :local:
 
-.. automodule:: app.domain.robots.models
+.. automodule:: app.domain.robots.models.models
     :members:
     :undoc-members:
     :inherited-members: BaseModel, str


### PR DESCRIPTION
Automodule path was incorrect so wasn't autogenerating the docs for robot models. 

## Before 
<img width="1775" height="615" alt="Screenshot 2025-10-14 at 10 01 38" src="https://github.com/user-attachments/assets/eee20fe2-5e13-452f-8025-81e7cc8ef16e" />

## After
<img width="924" height="843" alt="Screenshot 2025-10-14 at 10 01 46" src="https://github.com/user-attachments/assets/b9c8730f-d9cb-4f13-b70f-25279e371a7b" />
