### PR TITLE
commit enum value before it is used

### DIFF
--- a/app/migrations/versions/6f6d08aab362_deprecate_collision_strategy.py
+++ b/app/migrations/versions/6f6d08aab362_deprecate_collision_strategy.py
@@ -34,6 +34,7 @@ def upgrade() -> None:
         ),
         server_default="deprecated",
     )
+    connection.commit()
     # ### end Alembic commands ###
 
 


### PR DESCRIPTION
Should resolve:
```
sqlalchemy.exc.DBAPIError: (sqlalchemy.dialects.postgresql.asyncpg.Error) <class 'asyncpg.exceptions.UnsafeNewEnumValueUsageError'>: unsafe use of new value "deprecated" of enum type collision_strategy

HINT: New enum values must be committed before they can be used.
```