### PR TITLE
Investigate sporadic GH action errors

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,8 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-
       - name: Install Graphviz
         run: |
           sudo apt-get update

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -27,13 +27,6 @@ jobs:
           mkdir -p .certs
           echo 'dummy certificate for CI only' > .certs/ca.crt
 
-      - name: Set up python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{matrix.python-version}}
-          cache: pip
-          cache-dependency-path: pyproject.toml
-
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:

--- a/.github/workflows/release-sdk-to-pypi.yml
+++ b/.github/workflows/release-sdk-to-pypi.yml
@@ -34,11 +34,6 @@ jobs:
           echo "package_name=$PACKAGE_NAME" >> $GITHUB_OUTPUT
           echo "📦 Package: $PACKAGE_NAME v$VERSION"
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,13 +49,6 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
-      - name: Set up python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{matrix.python-version}}
-          cache: pip
-          cache-dependency-path: pyproject.toml
-
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:


### PR DESCRIPTION
Investigating the below that have started occurring >50% of the time since last week.

<img width="869" height="117" alt="image" src="https://github.com/user-attachments/assets/c572fed0-b8ac-4138-99eb-2a75a86e399a" />

I don't exactly know the cause but while investigating found that `setup-python` is redundant with `setup-uv` (as long as we invoke uv, which we do). So, head in sand and removing instead.
