### PR TITLE
Extend lock duration and make it configurable

### DIFF
--- a/infra/app/main.tf
+++ b/infra/app/main.tf
@@ -118,6 +118,10 @@ locals {
       name  = "MAX_REFERENCE_LOOKUP_QUERY_LENGTH",
       value = var.max_reference_lookup_query_length
     },
+    {
+      name  = "MESSAGE_LOCK_RENEWAL_DURATION",
+      value = var.message_lock_renewal_duration
+    }
   ]
 
 

--- a/infra/app/variables.tf
+++ b/infra/app/variables.tf
@@ -296,3 +296,9 @@ variable "es_migrator_reindex_polling_interval" {
   default     = 5 * 60 # 5min
 
 }
+
+variable "message_lock_renewal_duration" {
+  description = "Duration to renew message locks for in seconds"
+  type        = number
+  default     = 12 * 60 * 60 # 12 hours
+}


### PR DESCRIPTION
Now that only a handful of tasks are using the locks, this is a bit safer to push out to a very comfortable duration. Was at 3 hours, now 12.