### PR TITLE
Remove enhancement_type and external_identifier_type enums from postgres

### DIFF
--- a/app/domain/references/models/sql.py
+++ b/app/domain/references/models/sql.py
@@ -201,10 +201,7 @@ class ExternalIdentifier(GenericSQLPersistence[DomainExternalIdentifier]):
         UUID, ForeignKey("reference.id"), nullable=False
     )
     identifier_type: Mapped[ExternalIdentifierType] = mapped_column(
-        ENUM(
-            *[identifier.value for identifier in ExternalIdentifierType],
-            name="external_identifier_type",
-        ),
+        String,
         nullable=False,
     )
     other_identifier_name: Mapped[str] = mapped_column(

--- a/app/migrations/versions/1a717e152dff_remove_external_identifier_type_enum.py
+++ b/app/migrations/versions/1a717e152dff_remove_external_identifier_type_enum.py
@@ -1,0 +1,44 @@
+"""
+Remove external identifier type enum
+
+Revision ID: 1a717e152dff
+Revises: eb47e22ea5af
+Create Date: 2025-11-19 23:49:04.821842+00:00
+
+"""
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '1a717e152dff'
+down_revision: Union[str, None] = 'eb47e22ea5af'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # We have to drop the indices before altering the column or we get operand failures on the where conditions
+    # WHERE (identifier_type <> 'other'::public.external_identifier_type);
+    # The right side of the above doesn't update when changing the column type, resulting in a
+    # character varying <> external_identifier_type comparison which has no valid operator.
+
+    op.drop_index('ix_external_identifier_type_other', table_name='external_identifier', postgresql_where=sa.text("identifier_type = 'other'"))
+    op.drop_index('ix_external_identifier_type', table_name='external_identifier', postgresql_where=sa.text("identifier_type != 'other'"))
+
+    op.alter_column('external_identifier', 'identifier_type', type_=sa.String(), existing_nullable=False)
+    op.execute("DROP TYPE IF EXISTS external_identifier_type")
+
+    op.create_index('ix_external_identifier_type', 'external_identifier', ['identifier_type', 'identifier'], unique=False, postgresql_where=sa.text("identifier_type != 'other'"))
+    op.create_index('ix_external_identifier_type_other', 'external_identifier', ['identifier_type', 'other_identifier_name', 'identifier'], unique=False, postgresql_where=sa.text("identifier_type = 'other'"))
+
+
+
+def downgrade() -> None:
+    # Not safely downgradable. We can create the enum type, but can't
+    # apply it to the pending_enhancement table without triggering the problem
+    # we're trying to avoid. See also https://github.com/destiny-evidence/destiny-repository/pull/343#discussion_r2458931314
+    pass

--- a/app/migrations/versions/eb47e22ea5af_remove_enhancement_type_enum.py
+++ b/app/migrations/versions/eb47e22ea5af_remove_enhancement_type_enum.py
@@ -1,5 +1,5 @@
 """
-remove enhancement_type enum from postgres
+Remove enhancement_type enum
 
 Revision ID: eb47e22ea5af
 Revises: 41a6980bb04e
@@ -21,10 +21,7 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.alter_column('enhancement', 'enhancement_type',
-               existing_type=postgresql.ENUM('bibliographic', 'abstract', 'annotation', 'location', name='enhancement_type'),
-               type_=sa.String(),
-               existing_nullable=False)
+    op.alter_column('enhancement', 'enhancement_type', type_=sa.String(), existing_nullable=False)
     op.execute("DROP TYPE IF EXISTS enhancement_type")
 
 


### PR DESCRIPTION
Based on conversations here, we are moving away from using postgres enums in favour of relying on our domain models https://github.com/destiny-evidence/destiny-repository/pull/343#discussion_r2458931314. 

This PR removes the following two enums 
* `enhancement_type` to unblock https://github.com/destiny-evidence/destiny-repository/pull/391
* `external_identifier_type` to unblock adding ERIC ids as an identifier type for #373 

