### PR TITLE
Added service delegations to subnets to unblock container app env creation

### DIFF
--- a/infra/app/network.tf
+++ b/infra/app/network.tf
@@ -55,6 +55,16 @@ resource "azurerm_subnet" "app" {
   resource_group_name  = azurerm_resource_group.this.name
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = ["10.0.4.0/23"]
+
+  delegation {
+    name = "app"
+    service_delegation {
+      name = "Microsoft.App/environments"
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+      ]
+    }
+  }
 }
 
 resource "azurerm_subnet" "tasks" {
@@ -62,6 +72,16 @@ resource "azurerm_subnet" "tasks" {
   resource_group_name  = azurerm_resource_group.this.name
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = ["10.0.6.0/23"]
+
+  delegation {
+    name = "tasks"
+    service_delegation {
+      name = "Microsoft.App/environments"
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+      ]
+    }
+  }
 }
 
 resource "azurerm_subnet" "ui" {
@@ -69,4 +89,14 @@ resource "azurerm_subnet" "ui" {
   resource_group_name  = azurerm_resource_group.this.name
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = ["10.0.8.0/23"]
+
+  delegation {
+    name = "ui"
+    service_delegation {
+      name = "Microsoft.App/environments"
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+      ]
+    }
+  }
 }


### PR DESCRIPTION
Adding service delegations to our subnets for our app, tasks, and ui. Without these service delegations, the initial creation of a container app environment will be blocked with the following error 

```
performing CreateOrUpdate: unexpected status 400 (400 Bad Request) with error: ManagedEnvironmentSubnetDelegationError: The subnet of the environment must be delegated to the service 'Microsoft.App/environments'.
```
