### PR TITLE
Remove localhost redirect uri from auth_v2

### DIFF
--- a/infra/app/auth_v2.tf
+++ b/infra/app/auth_v2.tf
@@ -266,7 +266,6 @@ resource "azuread_application_redirect_uris" "external_directory_ui_redirect" {
 
   redirect_uris = [
     "https://${data.azurerm_container_app.ui.ingress[0].fqdn}",
-    "http://localhost"
   ]
 }
 


### PR DESCRIPTION
We don't want this redirect uri. Context here https://covidence.slack.com/archives/C0810ARPCRG/p1768255530034719?thread_ts=1767683955.758679&cid=C0810ARPCRG. 