### PR TITLE
Upgrade psql size

### DIFF
--- a/infra/app/locals.tf
+++ b/infra/app/locals.tf
@@ -10,13 +10,13 @@ locals {
   is_production  = var.environment == "production"
   is_development = var.environment == "development"
 
-  prod_db_storage_mb = 65536
+  prod_db_storage_mb = 4194304
   dev_db_storage_mb  = 32768
 
   # IPOS tiers for postgresql flexible server
   # We use the default for our storage size as defined at
   # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server#storage_tier-defaults-based-on-storage_mb
-  prod_db_storage_tier = "P6"
+  prod_db_storage_tier = "P50"
   dev_db_storage_tier  = "P4"
 
   minimum_resource_tags = {


### PR DESCRIPTION
Scaling up postgres database for #416.

Currently we have 8 million references on a 64GB instance, taking up roughly 50% of the storage. Scaling this to 500 million references is around 4TB - again on a 50% usage, annoyingly the tier below is 2TB which is probably going to be too tight (~90% used).

Of course this is napkin maths and we might find the storage doesn't scale linearly. My instinct is in any case we'd upgrade to 4TB pretty promptly anyway, either requiring the extra swap storage space for a migration or adding a bunch of other enhancements.

The VM SKU is a bit of a shot in the dark, I think it's better to underprovision so I'd consider leaving it for now and monitoring performance. 

All up this would bring storage cost to 480EUR/mo (not considering IOPS/throughput charges).

We probably want to deploy #454 before this, in case disk size has an impact on upgrade performance.