### PR TITLE
Specify trusted identifier when testing exact deduplication

### DIFF
--- a/tests/unit/domain/references/services/test_deduplication_service.py
+++ b/tests/unit/domain/references/services/test_deduplication_service.py
@@ -35,6 +35,18 @@ def reference() -> Reference:
 
 
 @pytest.fixture
+def reference_with_non_other_identifier(reference: Reference) -> Reference:
+    assert reference.identifiers
+    reference.identifiers.append(
+        LinkedExternalIdentifierFactory.build(
+            identifier=OpenAlexIdentifierFactory.build(),
+            reference_id=reference.id,
+        )
+    )
+    return reference
+
+
+@pytest.fixture
 def searchable_reference(reference: Reference) -> Reference:
     return reference.model_copy(
         update={
@@ -60,20 +72,23 @@ def anti_corruption_service():
 
 @pytest.mark.asyncio
 async def test_find_exact_duplicate_happy_path(
-    reference, anti_corruption_service, fake_uow, fake_repository
+    reference_with_non_other_identifier,
+    anti_corruption_service,
+    fake_uow,
+    fake_repository,
 ):
-    candidate = reference.model_copy(
+    candidate = reference_with_non_other_identifier.model_copy(
         update={"id": uuid.uuid4()},
     )
     repo = fake_repository([candidate])
     uow = fake_uow(references=repo)
     uow.references.find_with_identifiers = AsyncMock(return_value=[candidate])
     service = DeduplicationService(anti_corruption_service, uow, fake_uow())
-    result = await service.find_exact_duplicate(reference)
+    result = await service.find_exact_duplicate(reference_with_non_other_identifier)
     assert result == candidate
     # No longer a subset
     result = await service.find_exact_duplicate(
-        reference.model_copy(update={"visibility": "hidden"})
+        reference_with_non_other_identifier.model_copy(update={"visibility": "hidden"})
     )
     assert not result
 


### PR DESCRIPTION
Fixes a flake in our unit tests where if all generated identifiers are of type Other, exact deduplication won't run (as it needs at least one non-other identifier).