### PR TITLE
Increase the database size to allow enum removal migrations on the enhancement table

### DIFF
--- a/infra/app/database.tf
+++ b/infra/app/database.tf
@@ -1,13 +1,13 @@
 locals {
   database_migrator_name = "db-migrator-${var.environment}"
 
-  prod_db_storage_mb = 65536
+  prod_db_storage_mb = 131072
   dev_db_storage_mb  = 32768
 
   # IPOS tiers for postgresql flexible server
   # We use the default for our storage size as defined at
   # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server#storage_tier-defaults-based-on-storage_mb
-  prod_db_storage_tier = "P6"
+  prod_db_storage_tier = "P10"
   dev_db_storage_tier  = "P4"
 }
 


### PR DESCRIPTION
Required as part of #422 to remove the visibility enum due to size of the `enhancement` table. Required in staging as well as production because staging currently has the largest database. 

Storage tier increased to the minimum supported storage tier for the 128GB database size (https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server#storage_tier-defaults-based-on-storage_mb)