### PR TITLE
Refactor eppi parser to handle single references.

### DIFF
--- a/libs/sdk/src/destiny_sdk/enhancements.py
+++ b/libs/sdk/src/destiny_sdk/enhancements.py
@@ -5,7 +5,7 @@ import json
 from enum import StrEnum, auto
 from typing import Annotated, Any, Literal, Self
 
-from pydantic import UUID4, BaseModel, Field, HttpUrl, model_validator
+from pydantic import UUID4, BaseModel, ConfigDict, Field, HttpUrl, model_validator
 
 from destiny_sdk.core import _JsonlFileInputMixIn
 from destiny_sdk.identifiers import Identifier
@@ -466,6 +466,9 @@ class Enhancement(_JsonlFileInputMixIn, BaseModel):
 
 class EnhancementFileInput(BaseModel):
     """Enhancement model used to marshall a file input to new references."""
+
+    model_config = ConfigDict(populate_by_name=True)
+    # (nik) adding this to handle the alias_generator.
 
     source: str = Field(
         description="The enhancement source for tracking provenance.",

--- a/libs/sdk/src/destiny_sdk/parsers/eppi_parser.py
+++ b/libs/sdk/src/destiny_sdk/parsers/eppi_parser.py
@@ -270,7 +270,7 @@ class EPPIParser:
             enhancements=enhancements,
         )
 
-    def parse_full_eppi_json(
+    def parse_full_eppi(
         self,
         data: dict,
         source: str | None = None,
@@ -334,7 +334,7 @@ class EPPIParser:
             list[ReferenceFileInput]: List of parsed references from the data.
 
         """
-        return self.parse_full_eppi_json(
+        return self.parse_full_eppi(
             data=data,
             source=source,
             robot_version=robot_version,

--- a/libs/sdk/uv.lock
+++ b/libs/sdk/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12, <4"
 
 [[package]]
@@ -233,7 +233,7 @@ wheels = [
 
 [[package]]
 name = "destiny-sdk"
-version = "0.6.0"
+version = "0.7.5"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
first off, apologies for the long branch name. i went straight from the issue and didn't think. 

this PR adds a method (`parse_reference`) for parsing a single EPPI reference, as opposed to the whole parsed dict resulting from eppi.json with n references. this is a requirement for `deet`, where we want to attach citations in destiny format to a given reference from an eppi json. 

also added a new method (`parse_full_eppi`) which replaces the existing `parse_data` method. `parse_data` is retained, wrapping around `parse_full_eppi`, but could be deprecated. this will require changing the tests to reference the new method rather than the old one. 

Closes #458 