### PR TITLE
Turned on index phrases for title and abstract

### DIFF
--- a/app/domain/references/models/es.py
+++ b/app/domain/references/models/es.py
@@ -232,11 +232,14 @@ class ReferenceSearchFieldsMixin(InnerDoc):
     """
     Mixin to project Reference fields relevant to various search strategies.
 
-    Currently this holds fields for identifing candidate canonicals during deduplication
-    and for searching references by query on title, authors, and abstracts.
+    Currently this holds fields for identifying candidate canonicals during
+    deduplication and for searching references by query on title, authors,
+    and abstracts.
     """
 
-    abstract: str | None = mapped_field(Text(required=False), default=None)
+    abstract: str | None = mapped_field(
+        Text(required=False, index_phrases=True), default=None
+    )
     """The abstract of the reference."""
 
     authors: list[str] | None = mapped_field(
@@ -259,7 +262,9 @@ class ReferenceSearchFieldsMixin(InnerDoc):
     )
     """The publication year of the reference."""
 
-    title: str | None = mapped_field(Text(required=False), default=None)
+    title: str | None = mapped_field(
+        Text(required=False, index_phrases=True), default=None
+    )
     """The title of the reference."""
 
     annotations: list[str] | None = mapped_field(

--- a/tests/es_utils.py
+++ b/tests/es_utils.py
@@ -22,7 +22,7 @@ class DomainSimpleDoc(SQLAttributeMixin):
 class SimpleDoc(GenericESPersistence):
     """Simple test document with basic fields."""
 
-    title: str = mapped_field(Text())
+    title: str = mapped_field(Text(index_phrases=True))
     year: int = mapped_field(Integer())
     content: str = mapped_field(Text())
 


### PR DESCRIPTION
### Background
Fixes #503

Root level abstract and title now have [index_phrases](https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/index-phrases) enabled

### Rollout
This mapping change needs to be applied with an index migration but does not require a full index repair. It will increase the size of the index somewhat, but should be as high proportion of document size as it is only applied to two root level fields (nested enhancements represent the bulk of the document size). 

However, our staging references index is currently 34GB on a primary shard (and another 34GB on a replica), When we migrate these index, we will split it across three shards, which will be at the low end of the recommended range. This can be done using the following command on the es migrator container app job 

```
python -m app.utils.es.es_migration --migrate --alias reference --number-of-shards 3
```

### Pre-Benchmarking 

`q=(abstract:(("cardiovascular+disease*"+OR+"heart+disease*"+OR+"cardiac+disease*"+OR+"coronary+disease*"+OR+"coronary+heart+disease*"+OR+"myocardial+infarct*"+OR+"arrhythmia*"+OR+"heart+fail*"+OR+"vascular+disease*"+OR+"ischemic+heart+disease*"+OR+"ischemia"+OR+"atherosclerosis"+OR+"angina"+OR+"stroke"+OR+"cerebrovascular+disease*"+OR+"peripheral+arterial+disease*"+OR+"peripheral+artery+disease*"+OR+"hypertension"+OR+"high+blood+pressure"+OR+"congestive+heart+fail*"))+OR+title:(("cardiovascular+disease*"+OR+"heart+disease*"+OR+"cardiac+disease*"+OR+"coronary+disease*"+OR+"coronary+heart+disease*"+OR+"myocardial+infarct*"+OR+"arrhythmia*"+OR+"heart+fail*"+OR+"vascular+disease*"+OR+"ischemic+heart+disease*"+OR+"ischemia"+OR+"atherosclerosis"+OR+"angina"+OR+"stroke"+OR+"cerebrovascular+disease*"+OR+"peripheral+arterial+disease*"+OR+"peripheral+artery+disease*"+OR+"hypertension"+OR+"high+blood+pressure"+OR+"congestive+heart+fail*")))&page=1`

Is a real query we've seen run against our elasticsearch instance. During a time of high load this query took `9.4s` and takes between `1.6s` and `2.5s` in times of little-to-no load. 

We'll want to check how much faster this runs after applying these changes. 
