### PR TITLE
Added publication date to reference search fields projection

### DIFF
--- a/app/domain/references/models/es.py
+++ b/app/domain/references/models/es.py
@@ -232,8 +232,8 @@ class ReferenceSearchFieldsMixin(InnerDoc):
     """
     Mixin to project Reference fields relevant to various search strategies.
 
-    Currently this holds fields for identifing candidate canonicals during deduplication
-    and for searching references by query on title, authors, and abstracts.
+    Currently this holds fields for identifying candidate canonicals during
+    deduplication and for searching references by query.
     """
 
     abstract: str | None = mapped_field(Text(required=False), default=None)
@@ -252,6 +252,12 @@ class ReferenceSearchFieldsMixin(InnerDoc):
     - Middle authors in alphabetical order
     - Last author
     """
+
+    publication_date: datetime.date | None = mapped_field(
+        Date(required=False),
+        default=None,
+    )
+    """The publication date of the reference."""
 
     publication_year: int | None = mapped_field(
         Integer(required=False),
@@ -317,6 +323,7 @@ class ReferenceSearchFieldsMixin(InnerDoc):
             abstract=projection.abstract,
             title=projection.title,
             authors=projection.authors,
+            publication_date=projection.publication_date,
             publication_year=projection.publication_year,
             annotations=projection.annotations,
             evaluated_schemes=projection.evaluated_schemes,

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -494,6 +494,11 @@ class ReferenceSearchFields(ProjectedBaseModel):
         default_factory=list, description="The authors of the reference."
     )
 
+    publication_date: datetime.date | None = Field(
+        default=None,
+        description="The publication date of the reference.",
+    )
+
     publication_year: int | None = Field(
         default=None,
         description="The publication year of the reference.",

--- a/app/domain/references/models/projections.py
+++ b/app/domain/references/models/projections.py
@@ -43,7 +43,7 @@ class ReferenceSearchFieldsProjection(GenericProjection[ReferenceSearchFields]):
         :rtype: ReferenceSearchFields
         """
         try:
-            title, publication_year = None, None
+            title, publication_year, publication_date = None, None, None
             abstract = None
             authorship: list[destiny_sdk.enhancements.Authorship] = []
             annotations_by_scheme: dict[
@@ -71,6 +71,10 @@ class ReferenceSearchFieldsProjection(GenericProjection[ReferenceSearchFields]):
                             else None
                         )
                         or publication_year
+                    )
+
+                    publication_date = (
+                        enhancement.content.publication_date or publication_date
                     )
 
                 elif enhancement.content.enhancement_type == EnhancementType.ABSTRACT:
@@ -109,6 +113,7 @@ class ReferenceSearchFieldsProjection(GenericProjection[ReferenceSearchFields]):
             return ReferenceSearchFields(
                 abstract=abstract,
                 authors=cls.__order_authorship_by_position(authorship),
+                publication_date=publication_date,
                 publication_year=publication_year,
                 title=title,
                 annotations=annotations,
@@ -148,7 +153,7 @@ class ReferenceSearchFieldsProjection(GenericProjection[ReferenceSearchFields]):
         """
         Order a references enhancements by priority for projecting in increasing order.
 
-        Prioritiy is defined as
+        Priority is defined as
         * Firstly, we prioritize enhancements on the canonical reference
         * Secondly, we prioritize most recent enhancements
 

--- a/tests/unit/domain/references/models/test_projections.py
+++ b/tests/unit/domain/references/models/test_projections.py
@@ -254,7 +254,7 @@ class TestReferenceSearchFieldsProjection:
         """Test that we prioritise canonical enhancements"""
         reference_id = uuid.uuid4()
 
-        canonical_biblography = EnhancementFactory.build(
+        canonical_bibliography = EnhancementFactory.build(
             reference_id=reference_id,
             content=BibliographicMetadataEnhancementFactory.build(
                 title="We get this title, this enhancement is on canonical reference",
@@ -265,16 +265,24 @@ class TestReferenceSearchFieldsProjection:
 
         reference = ReferenceFactory.build(
             id=reference_id,
-            enhancements=[bibliographic_enhancement, canonical_biblography],
+            enhancements=[bibliographic_enhancement, canonical_bibliography],
         )
 
         reference_proj = ReferenceSearchFieldsProjection.get_from_reference(reference)
-        assert reference_proj.title == canonical_biblography.content.title
+        assert reference_proj.title == canonical_bibliography.content.title
+        assert (
+            reference_proj.publication_date
+            == canonical_bibliography.content.publication_date
+        )
+        assert (
+            reference_proj.publication_year
+            == canonical_bibliography.content.publication_year
+        )
 
     def test_reference_sorting_prioritises_created_date(
         self, bibliographic_enhancement, sample_authorship
     ):
-        """Test that we prioritise the created date of the enhancements"""
+        """Test that we prioritize the created date of the enhancements"""
         reference_id = uuid.uuid4()
 
         most_recent_bibliography = EnhancementFactory.build(
@@ -295,7 +303,7 @@ class TestReferenceSearchFieldsProjection:
         reference_proj = ReferenceSearchFieldsProjection.get_from_reference(reference)
         assert reference_proj.title == most_recent_bibliography.content.title
 
-    def test_reference_sorting_priorises_canonical_over_most_recent(
+    def test_reference_sorting_prioritizes_canonical_over_most_recent(
         self, bibliographic_enhancement, sample_authorship
     ):
         """
@@ -325,6 +333,10 @@ class TestReferenceSearchFieldsProjection:
 
         reference_proj = ReferenceSearchFieldsProjection.get_from_reference(reference)
         assert reference_proj.title == bibliographic_enhancement.content.title
+        assert (
+            reference_proj.publication_date
+            == bibliographic_enhancement.content.publication_date
+        )
 
     def test_reference_sorting_the_uber_refrence(
         self,
@@ -453,6 +465,10 @@ class TestReferenceSearchFieldsProjection:
 
         assert result.publication_year == (
             most_recent_canonical_bibliography.content.publication_year
+        )
+
+        assert result.publication_date == (
+            most_recent_canonical_bibliography.content.publication_date
         )
 
         assert result.title == most_recent_canonical_bibliography.content.title
@@ -588,7 +604,7 @@ class TestReferenceSearchFieldsProjection:
         """Test we get year from publication date if publication year not provided."""
         enhancement_without_publication_year = EnhancementFactory.build(
             source="fallback_source",
-            # Can't use factory here as we're explicity setting missing values
+            # Can't use factory here as we're explicitly setting missing values
             content=destiny_sdk.enhancements.BibliographicMetadataEnhancement(
                 enhancement_type=EnhancementType.BIBLIOGRAPHIC,
                 title="Date Fallback Paper",


### PR DESCRIPTION
Added publication_date to our reference search fields projection. 

We need to maintain some of the functionality on the stats query of the demonstrator ui post removing the nested elasticsearch documents, and this allows us to show recently published research ingested into destiny https://github.com/destiny-evidence/demonstrator-ui/blob/main/app/search_client.py#L936. We'll be removing some of the enhancement counts etc, so this felt like an easy win to preserve.

You can successfully search publication_date with query string (tried it locally) 

It might not truly belong in the search fields, but I've added it there as the search fields will become essentially our entire document once we do #516 and it felt strange to create another mixin at the moment for fields that _are_ searchable. 