### PR TITLE
Handle empty search results in two-stage search

### DIFF
--- a/app/domain/references/routes.py
+++ b/app/domain/references/routes.py
@@ -343,8 +343,12 @@ async def search_references(
         publication_year_range=publication_year_range,
         sort=sort,
     )
-    references = await reference_service.get_deduplicated_references(
-        [hit.id for hit in search_result.hits]
+    references = (
+        await reference_service.get_deduplicated_references(
+            [hit.id for hit in search_result.hits]
+        )
+        if search_result.hits
+        else []
     )
     return anti_corruption_service.two_stage_reference_search_result_to_sdk(
         search_result, references

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -320,6 +320,21 @@ async def test_pagination(
     assert data["page"]["count"] == 5
 
 
+async def test_empty_search_results(
+    client: AsyncClient,
+    search_references: list,  # noqa: ARG001
+) -> None:
+    """Test that search returning no results returns empty list, not error."""
+    response = await client.get(
+        "/v1/references/search/",
+        params={"q": "title:nonexistent_term_xyz123"},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["total"]["count"] == 0
+    assert data["references"] == []
+
+
 @pytest.mark.parametrize(
     ("params", "expected_status"),
     [


### PR DESCRIPTION
## Summary

Fixes 500 error when search returns no results.

The two-stage search calls `get_deduplicated_references` with an empty list when 
ES returns no hits, which triggers a `ValueError` from the validation that requires 
exactly one of `reference_ids` or `references` to be provided (`bool([]) == bool(None)`).

## Changes

- Skip `get_deduplicated_references` call when `search_result.hits` is empty
- Add regression test for empty search results

## Test plan

- [x] `test_empty_search_results` verifies 200 response with empty results
- [x] All existing search tests pass