### PR TITLE
Optimise bulk query

### DIFF
--- a/app/domain/references/models/sql.py
+++ b/app/domain/references/models/sql.py
@@ -81,13 +81,9 @@ class Reference(GenericSQLPersistence[DomainReference]):
         "ExternalIdentifier",
         back_populates="reference",
         cascade="all, delete, delete-orphan",
-        info=RelationshipInfo(load_type=RelationshipLoadType.SELECTIN).model_dump(),
     )
     enhancements: Mapped[list["Enhancement"]] = relationship(
-        "Enhancement",
-        back_populates="reference",
-        cascade="all, delete, delete-orphan",
-        info=RelationshipInfo(load_type=RelationshipLoadType.SELECTIN).model_dump(),
+        "Enhancement", back_populates="reference", cascade="all, delete, delete-orphan"
     )
     duplicate_decision: Mapped["ReferenceDuplicateDecision"] = relationship(
         "ReferenceDuplicateDecision",

--- a/app/domain/references/services/synchronizer_service.py
+++ b/app/domain/references/services/synchronizer_service.py
@@ -27,7 +27,6 @@ class ReferenceSynchronizer(GenericSynchronizer[Reference]):
     _required_preloads: ClassVar[list] = [
         "identifiers",
         "enhancements",
-        "canonical_reference",
         "duplicate_references",
         "duplicate_decision",
     ]
@@ -38,7 +37,7 @@ class ReferenceSynchronizer(GenericSynchronizer[Reference]):
         trace_attribute(Attributes.DB_PK, str(reference_id))
         reference = await self.sql_uow.references.get_by_pk(
             reference_id,
-            preload=self._required_preloads,
+            preload=[*self._required_preloads, "canonical_reference"],
         )
 
         if not reference.is_canonical_like and reference.canonical_reference:

--- a/app/persistence/sql/repository.py
+++ b/app/persistence/sql/repository.py
@@ -78,6 +78,8 @@ class GenericAsyncSqlRepository(
         self,
         preload: list[GenericSQLPreloadableType] | None = None,
         depth: int = 1,
+        *,
+        force_selectin: bool = False,
     ) -> list[_AbstractLoad]:
         """
         Get a list of relationship loading strategies with support for nesting.
@@ -85,6 +87,9 @@ class GenericAsyncSqlRepository(
         Args:
             preload: List of relationships to preload
             depth: Internal tracker for max relationship depth
+            force_selectin: If True, use SELECTIN loading for all relationships
+                regardless of their configured load_type. Useful for bulk queries
+                where JOINs would cause cartesian product explosion.
 
         Returns:
             A list of ORM loading options configured for the relationships
@@ -113,7 +118,7 @@ class GenericAsyncSqlRepository(
             )
 
             # Determine the base loading strategy
-            if load_type == RelationshipLoadType.SELECTIN:
+            if force_selectin or load_type == RelationshipLoadType.SELECTIN:
                 if is_self_referential:
                     # recursion_depth is only valid for self-referential relationships
                     loader = selectinload(relationship, recursion_depth=1)
@@ -139,7 +144,9 @@ class GenericAsyncSqlRepository(
             if preload and is_self_referential:
                 loader = loader.options(
                     *self._get_relationship_loads(
-                        [p for p in preload if p not in avoid_propagate], depth + 1
+                        [p for p in preload if p not in avoid_propagate],
+                        depth + 1,
+                        force_selectin=force_selectin,
                     )
                 )
 
@@ -221,7 +228,7 @@ class GenericAsyncSqlRepository(
         - SQLNotFoundError: If any of the records do not exist.
 
         """
-        options = self._get_relationship_loads(preload)
+        options = self._get_relationship_loads(preload, force_selectin=True)
         query = (
             select(self._persistence_cls)
             .where(self._persistence_cls.id.in_(pks))


### PR DESCRIPTION
I noticed when running a repair for #532 in staging that the SQL `get_by_pks` call was slower than expected.

This came down to join strategy - our repository favours `joinedload` for most joins as it's the simplest implementation and generally better for individual operations (the bulk of our workflow). This however leads to cartesian products, scaling with the number of objects and the number of relationships. `selectinload` has more overhead but performs better when doing multiple one-to-many relationships across multiple objects.

This PR adds a `force_selectin` option to the relationship resolver so that bulk repository methods can use `selectinload` where appropriate. There might be a case to say we could switch most/all our relationships to `selectinload`, I think we can save that decision for another time though.

I deployed this mid-repair to confirm the performance improved: https://ui.honeycomb.io/destiny-evidence/environments/staging/datasets/destiny-repository-task-staging/result/AS53dn7tLQR?cs_0=omitMissingValues