### PR TITLE
Configure elasticsearch autoscale max sizes

### DIFF
--- a/infra/app/locals.tf
+++ b/infra/app/locals.tf
@@ -23,8 +23,9 @@ locals {
       db_log_disconnections         = "on"
       db_log_min_duration_statement = 500 # Log queries > 500ms
 
-      es_snapshot_schedule  = "0 30 1 * * ?" # Daily at 01:30
-      es_snapshot_retention = 7
+      es_snapshot_schedule   = "0 30 1 * * ?" # Daily at 01:30
+      es_snapshot_retention  = 7
+      es_hot_max_size_memory = "8g" # 280GB storage: https://cloud.elastic.co/pricing
     }
 
     staging = {
@@ -47,8 +48,9 @@ locals {
       db_log_disconnections         = "on"
       db_log_min_duration_statement = 500 # Log queries > 500ms
 
-      es_snapshot_schedule  = "0 30 1 * * ?"
-      es_snapshot_retention = 7
+      es_snapshot_schedule   = "0 30 1 * * ?"
+      es_snapshot_retention  = 7
+      es_hot_max_size_memory = "8g" # 280GB storage: https://cloud.elastic.co/pricing
     }
 
     production = {
@@ -71,8 +73,9 @@ locals {
       db_log_disconnections         = "off" # High volume in production
       db_log_min_duration_statement = 500   # Log queries > 500ms
 
-      es_snapshot_schedule  = "0 30 1 * * ?" # Daily at 01:30
-      es_snapshot_retention = 30             # 30 days
+      es_snapshot_schedule   = "0 30 1 * * ?" # Daily at 01:30
+      es_snapshot_retention  = 30             # 30 days
+      es_hot_max_size_memory = "60g"          # 2TB storage: https://cloud.elastic.co/pricing
     }
   }
 

--- a/infra/app/main.tf
+++ b/infra/app/main.tf
@@ -472,7 +472,7 @@ resource "ec_deployment" "cluster" {
     hot = {
       size = "2g"
       autoscaling = {
-        max_size          = "30g"
+        max_size          = local.env.es_hot_max_size_memory
         max_size_resource = "memory"
       }
     }
@@ -480,7 +480,7 @@ resource "ec_deployment" "cluster" {
     warm = {
       size = "0g"
       autoscaling = {
-        max_size          = "30g"
+        max_size          = "2g" # 400GB storage: https://cloud.elastic.co/pricing
         max_size_resource = "memory"
       }
     }
@@ -488,7 +488,7 @@ resource "ec_deployment" "cluster" {
     cold = {
       size = "0g"
       autoscaling = {
-        max_size          = "60g"
+        max_size          = "0g"
         max_size_resource = "memory"
       }
     }
@@ -496,7 +496,7 @@ resource "ec_deployment" "cluster" {
     frozen = {
       size = "0g"
       autoscaling = {
-        max_size          = "60g"
+        max_size          = "0g"
         max_size_resource = "memory"
       }
     }
@@ -504,7 +504,7 @@ resource "ec_deployment" "cluster" {
     ml = {
       size = "0g"
       autoscaling = {
-        max_size          = "30g"
+        max_size          = "0g"
         max_size_resource = "memory"
       }
     }


### PR DESCRIPTION
Closes #492.

See #478 for derivation of 2TB storage size.

Also lowered/removed autoscaling on lower tiers - currently we only have `warm` on for some default kibana etc metrics, everything else is in `hot`.

These define autoscale limits, we won't be provisioning this much right away.