### PR TITLE
Fix undefined uuid reference in dedup race condition tests

### DIFF
--- a/tests/unit/domain/references/test_tasks.py
+++ b/tests/unit/domain/references/test_tasks.py
@@ -312,11 +312,11 @@ class TestProcessReferenceDuplicateDecisionRaceCondition:
 
     @pytest.fixture
     def decision_id(self):
-        return uuid.uuid4()
+        return uuid7()
 
     @pytest.fixture
     def reference_id(self):
-        return uuid.uuid4()
+        return uuid7()
 
     @pytest.fixture
     def mock_decision_pending(self, decision_id, reference_id):


### PR DESCRIPTION
## Summary

- Replace `uuid.uuid4()` with `uuid7()` in `test_tasks.py` — `uuid` module was never imported, `uuid7` is already imported and used throughout the file

Introduced in #535.

## Test plan

- [x] `pre-commit run --all-files` passes