### PR TITLE
Use a single container app environment for our container apps

### DIFF
--- a/infra/app/main.tf
+++ b/infra/app/main.tf
@@ -177,7 +177,7 @@ data "azurerm_container_app" "ui" {
 
 module "container_app" {
   source                          = "app.terraform.io/destiny-evidence/container-app/azure"
-  version                         = "1.9.0-beta"
+  version                         = "1.9.0"
   app_name                        = var.app_name
   cpu                             = var.container_app_cpu
   environment                     = var.environment
@@ -231,12 +231,13 @@ module "container_app" {
 
 module "container_app_tasks" {
   source                          = "app.terraform.io/destiny-evidence/container-app/azure"
-  version                         = "1.9.0-beta"
+  version                         = "1.9.0"
   app_name                        = "${var.app_name}-task"
   cpu                             = var.container_app_tasks_cpu
   environment                     = var.environment
   container_registry_id           = data.azurerm_container_registry.this.id
   container_registry_login_server = data.azurerm_container_registry.this.login_server
+  container_app_environment_id    = module.container_app.container_app_env_id
   infrastructure_subnet_id        = azurerm_subnet.tasks.id
   memory                          = var.container_app_tasks_memory
   resource_group_name             = azurerm_resource_group.this.name
@@ -245,7 +246,6 @@ module "container_app_tasks" {
   max_replicas                    = var.tasks_max_replicas
   tags                            = local.minimum_resource_tags
 
-  container_app_environment_id = module.container_app.container_app_env_id
 
   identity = {
     id           = azurerm_user_assigned_identity.container_apps_tasks_identity.id
@@ -283,17 +283,16 @@ module "container_app_tasks" {
 
 module "container_app_ui" {
   source                          = "app.terraform.io/destiny-evidence/container-app/azure"
-  version                         = "1.9.0-beta"
+  version                         = "1.9.0"
   app_name                        = "${var.app_name}-ui"
   environment                     = var.environment
   container_registry_id           = data.azurerm_container_registry.this.id
   container_registry_login_server = data.azurerm_container_registry.this.login_server
+  container_app_environment_id    = module.container_app.container_app_env_id
   infrastructure_subnet_id        = azurerm_subnet.ui.id
   resource_group_name             = azurerm_resource_group.this.name
   region                          = azurerm_resource_group.this.location
   tags                            = local.minimum_resource_tags
-
-  container_app_environment_id = module.container_app.container_app_env_id
 
   identity = {
     id           = azurerm_user_assigned_identity.container_apps_ui_identity.id


### PR DESCRIPTION
Fixes #359 

Latest release of the container app module allows specification of a container app environment to use when creating the container app.

You can see it successfully rolled out to dev here https://app.terraform.io/app/destiny-evidence/workspaces/destiny-repository-development/runs/run-QVTXZvVuHGoZUf7t. The main app, the ui, and the tasks are all running in the same container app environment along with the container app jobs. 

#### Rollout
This rollout causes some downtime as the re-creation of the container apps requires us to deploy the correctly tagged image out once they're up and running. We'll want to make sure we do this at a time of relatively low traffic. 

This will also change the FQDN of the UI container app, meaning we will need to share these updated urls with the rest of the destiny folks. 

I'm thinking we'll do staging tomorrow, let it marinate over the weekend and then deploy to production early Monday morning. 

