### PR TITLE
Give enhancement request writer and robot writer to UI auth client

### DIFF
--- a/infra/app/auth.tf
+++ b/infra/app/auth.tf
@@ -198,6 +198,8 @@ resource "azuread_application_api_access" "destiny_repository_auth_ui" {
 
   scope_ids = [
     random_uuid.reference_reader_scope.result,
+    random_uuid.enhancement_request_writer_scope.result,
+    random_uuid.robot_writer_scope.result,
   ]
 }
 


### PR DESCRIPTION
Our current auth setup is not fit for purpose for fine-grained permissions ([we know this](https://github.com/destiny-evidence/destiny-shared-infra/issues/20))

We have a current use-case where robot developers want to be able to register robots and request enhancements. Currently we maintain two tiers: "developer" (admin) and "ui" (read-only). This expands the "ui" tier to be able to do those two mentioned operations. I suppose we could argue that these would be within the remit of a standard UI someday.

I don't expect these permissions to stay this way given the ticket linked above.