### PR TITLE
Handle concurrent claiming of robot enhancement batches

### DIFF
--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -768,6 +768,33 @@ class PendingEnhancementSQLRepository(
         return await super().bulk_update_by_filter(filter_conditions, **kwargs)
 
     @trace_repository_method(tracer)
+    async def find_available_for_robot(
+        self,
+        robot_id: UUID,
+        limit: int,
+    ) -> list[DomainPendingEnhancement]:
+        """
+        Find pending enhancements available for a robot, locking rows.
+
+        Uses SELECT ... FOR UPDATE SKIP LOCKED to prevent concurrent robot
+        replicas from claiming the same pending enhancements.
+        """
+        query = (
+            select(SQLPendingEnhancement)
+            .where(
+                SQLPendingEnhancement.robot_id == robot_id,
+                SQLPendingEnhancement.robot_enhancement_batch_id.is_(None),
+                SQLPendingEnhancement.status == PendingEnhancementStatus.PENDING,
+            )
+            .order_by(SQLPendingEnhancement.created_at)
+            .limit(limit)
+            .with_for_update(skip_locked=True)
+        )
+
+        result = await self._session.execute(query)
+        return [record.to_domain() for record in result.scalars().all()]
+
+    @trace_repository_method(tracer)
     async def count_retry_depth(self, pending_enhancement_id: UUID) -> int:
         """
         Count how many times a pending enhancement has been retried.

--- a/app/domain/references/routes.py
+++ b/app/domain/references/routes.py
@@ -545,19 +545,17 @@ async def request_robot_enhancement_batch(
             "Using max_pending_enhancements_batch_size: %d",
             limit,
         )
-    pending_enhancements = await reference_service.get_pending_enhancements_for_robot(
-        robot_id=robot_id,
-        limit=limit,
+    robot_enhancement_batch = (
+        await reference_service.claim_and_create_robot_enhancement_batch(
+            robot_id=robot_id,
+            limit=limit,
+            lease_duration=lease,
+            blob_repository=blob_repository,
+        )
     )
-    if not pending_enhancements:
-        return Response(status_code=status.HTTP_204_NO_CONTENT)
 
-    robot_enhancement_batch = await reference_service.create_robot_enhancement_batch(
-        robot_id=robot_id,
-        pending_enhancements=pending_enhancements,
-        lease_duration=lease,
-        blob_repository=blob_repository,
-    )
+    if not robot_enhancement_batch:
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     return await anti_corruption_service.robot_enhancement_batch_to_sdk_robot(
         robot_enhancement_batch

--- a/app/domain/references/service.py
+++ b/app/domain/references/service.py
@@ -1063,17 +1063,27 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
         )
 
     @sql_unit_of_work
-    async def get_pending_enhancements_for_robot(
-        self, robot_id: UUID, limit: int
-    ) -> list[PendingEnhancement]:
-        """Get pending enhancements for a robot."""
-        pending_enhancements = await self.sql_uow.pending_enhancements.find(
-            robot_id=robot_id,
-            robot_enhancement_batch_id=None,
-            status=PendingEnhancementStatus.PENDING,
-            order_by="created_at",
-            limit=limit,
+    async def claim_and_create_robot_enhancement_batch(
+        self,
+        robot_id: UUID,
+        limit: int,
+        lease_duration: datetime.timedelta,
+        blob_repository: BlobRepository,
+    ) -> RobotEnhancementBatch | None:
+        """
+        Atomically claim pending enhancements and create a robot enhancement batch.
+
+        Returns None if no pending enhancements are available.
+        """
+        pending_enhancements = (
+            await self.sql_uow.pending_enhancements.find_available_for_robot(
+                robot_id=robot_id,
+                limit=limit,
+            )
         )
+
+        if not pending_enhancements:
+            return None
 
         # There is a restriction in EnhancementService._categorize_enhancements
         # that reference IDs are unique per batch. The below adapter is a band-aid to
@@ -1081,31 +1091,10 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
         # given reference ID are filtered out, and hence not accepted, and can be picked
         # up in a future batch.
         # See https://github.com/destiny-evidence/destiny-repository/issues/353.
-        return list(
+        pending_enhancements = list(
             {pe.reference_id: pe for pe in reversed(pending_enhancements)}.values()
         )
 
-    @sql_unit_of_work
-    async def create_robot_enhancement_batch(
-        self,
-        robot_id: UUID,
-        pending_enhancements: list[PendingEnhancement],
-        lease_duration: datetime.timedelta,
-        blob_repository: BlobRepository,
-    ) -> RobotEnhancementBatch:
-        """
-        Create a robot enhancement batch.
-
-        Args:
-            robot_id (UUID): The ID of the robot.
-            pending_enhancements (list[PendingEnhancement]): The list of pending
-                enhancements to include in the batch.
-            blob_repository (BlobRepository): The blob repository.
-
-        Returns:
-            RobotEnhancementBatch: The created robot enhancement batch.
-
-        """
         robot_enhancement_batch = RobotEnhancementBatch(robot_id=robot_id)
 
         await self.sql_uow.robot_enhancement_batches.add(robot_enhancement_batch)

--- a/tests/routers/test_references.py
+++ b/tests/routers/test_references.py
@@ -531,14 +531,9 @@ async def test_request_robot_enhancement_batch(
         session, pending_enhancement
     )
 
-    mock_get_pending = AsyncMock(return_value=[pending_enhancement])
-    mock_create_batch = AsyncMock(return_value=robot_enhancement_batch)
-
+    mock_claim = AsyncMock(return_value=robot_enhancement_batch)
     monkeypatch.setattr(
-        ReferenceService, "get_pending_enhancements_for_robot", mock_get_pending
-    )
-    monkeypatch.setattr(
-        ReferenceService, "create_robot_enhancement_batch", mock_create_batch
+        ReferenceService, "claim_and_create_robot_enhancement_batch", mock_claim
     )
 
     response = await client.post(
@@ -546,11 +541,9 @@ async def test_request_robot_enhancement_batch(
     )
 
     assert response.status_code == status.HTTP_200_OK
-    mock_get_pending.assert_awaited_once_with(robot_id=robot.id, limit=10)
-
-    mock_create_batch.assert_awaited_once_with(
+    mock_claim.assert_awaited_once_with(
         robot_id=robot.id,
-        pending_enhancements=[pending_enhancement],
+        limit=10,
         lease_duration=datetime.timedelta(minutes=5),
         blob_repository=ANY,
     )
@@ -564,13 +557,9 @@ async def test_request_robot_enhancement_batch_no_pending_enhancements(
     """Test requesting a batch when there are no pending enhancements."""
     robot = await add_robot(session)
 
-    mock_get_pending = AsyncMock(return_value=[])
-    mock_create_batch = AsyncMock()
+    mock_claim = AsyncMock(return_value=None)
     monkeypatch.setattr(
-        ReferenceService, "get_pending_enhancements_for_robot", mock_get_pending
-    )
-    monkeypatch.setattr(
-        ReferenceService, "create_robot_enhancement_batch", mock_create_batch
+        ReferenceService, "claim_and_create_robot_enhancement_batch", mock_claim
     )
 
     response = await client.post(
@@ -578,8 +567,7 @@ async def test_request_robot_enhancement_batch_no_pending_enhancements(
     )
 
     assert response.status_code == status.HTTP_204_NO_CONTENT
-    mock_get_pending.assert_awaited_once_with(robot_id=robot.id, limit=10)
-    mock_create_batch.assert_not_awaited()
+    mock_claim.assert_awaited_once()
 
 
 async def test_request_robot_enhancement_batch_limit_exceeded(
@@ -590,9 +578,9 @@ async def test_request_robot_enhancement_batch_limit_exceeded(
     """Test requesting a batch with limit exceeding maximum allowed."""
     robot = await add_robot(session)
 
-    mock_get_pending = AsyncMock(return_value=[])
+    mock_claim = AsyncMock(return_value=None)
     monkeypatch.setattr(
-        ReferenceService, "get_pending_enhancements_for_robot", mock_get_pending
+        ReferenceService, "claim_and_create_robot_enhancement_batch", mock_claim
     )
 
     # Request with a very high limit
@@ -601,9 +589,9 @@ async def test_request_robot_enhancement_batch_limit_exceeded(
     )
 
     assert response.status_code == status.HTTP_204_NO_CONTENT
-    # Should be called with the default max limit, not the requested limit
-    mock_get_pending.assert_awaited_once()
-    call_args = mock_get_pending.call_args
+    # Should be called with the capped limit, not the requested limit
+    mock_claim.assert_awaited_once()
+    call_args = mock_claim.call_args
     assert call_args.kwargs["limit"] == 10000  # Should be capped at max limit
 
 
@@ -612,9 +600,9 @@ async def test_request_robot_enhancement_batch_invalid_robot_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test requesting a batch with invalid robot ID format."""
-    mock_get_pending = AsyncMock(return_value=[])
+    mock_claim = AsyncMock(return_value=None)
     monkeypatch.setattr(
-        ReferenceService, "get_pending_enhancements_for_robot", mock_get_pending
+        ReferenceService, "claim_and_create_robot_enhancement_batch", mock_claim
     )
 
     response = await client.post(
@@ -622,7 +610,7 @@ async def test_request_robot_enhancement_batch_invalid_robot_id(
     )
 
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
-    mock_get_pending.assert_not_awaited()
+    mock_claim.assert_not_awaited()
 
 
 async def test_request_robot_enhancement_batch_missing_robot_id(
@@ -630,15 +618,15 @@ async def test_request_robot_enhancement_batch_missing_robot_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test requesting a batch without robot_id parameter."""
-    mock_get_pending = AsyncMock(return_value=[])
+    mock_claim = AsyncMock(return_value=None)
     monkeypatch.setattr(
-        ReferenceService, "get_pending_enhancements_for_robot", mock_get_pending
+        ReferenceService, "claim_and_create_robot_enhancement_batch", mock_claim
     )
 
     response = await client.post("/v1/robot-enhancement-batches/?limit=10")
 
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
-    mock_get_pending.assert_not_awaited()
+    mock_claim.assert_not_awaited()
 
 
 async def test_get_robot_enhancement_batch_happy_path(

--- a/tests/unit/domain/references/test_service.py
+++ b/tests/unit/domain/references/test_service.py
@@ -717,8 +717,10 @@ async def test_get_reference_changesets_from_enhancements(fake_uow, fake_reposit
 
 
 @pytest.mark.asyncio
-async def test_create_robot_enhancement_batch(fake_repository, fake_uow, test_robot):
-    """Test the creation of a robot enhancement batch."""
+async def test_claim_and_create_robot_enhancement_batch(
+    fake_repository, fake_uow, test_robot
+):
+    """Test atomic claiming of pending enhancements and batch creation."""
     mock_blob_repository = AsyncMock()
     mock_blob_repository.upload_file_to_blob_storage.return_value = BlobStorageFile(
         location="minio",
@@ -757,27 +759,35 @@ async def test_create_robot_enhancement_batch(fake_repository, fake_uow, test_ro
             """Get hydrated references by IDs (simplified for testing)."""
             return await self.get_by_pks(reference_ids)
 
+    class FakePendingEnhancementRepository(fake_repository):
+        async def find_available_for_robot(self, robot_id, limit):
+            """Fake implementation of the locking query."""
+            results = [
+                pe
+                for pe in self.repository.values()
+                if pe.robot_id == robot_id
+                and pe.robot_enhancement_batch_id is None
+                and pe.status == PendingEnhancementStatus.PENDING
+            ]
+            return results[:limit]
+
     uow = fake_uow(
         references=FakeReferencesRepository(init_entries=references),
-        pending_enhancements=fake_repository(init_entries=pending_enhancements),
+        pending_enhancements=FakePendingEnhancementRepository(
+            init_entries=pending_enhancements
+        ),
         robot_enhancement_batches=fake_repository(),
     )
     service = ReferenceService(
         ReferenceAntiCorruptionService(fake_repository()), uow, fake_uow()
     )
 
-    batch_pending_enhancements = await service.get_pending_enhancements_for_robot(
-        robot_id=test_robot.id, limit=10
-    )
-
-    assert len(batch_pending_enhancements) == 3
-
     lease = datetime.timedelta(minutes=5)
     expected_expiry_time = utc_now() + lease
 
-    created_batch = await service.create_robot_enhancement_batch(
+    created_batch = await service.claim_and_create_robot_enhancement_batch(
         robot_id=test_robot.id,
-        pending_enhancements=batch_pending_enhancements,
+        limit=10,
         lease_duration=lease,
         blob_repository=mock_blob_repository,
     )
@@ -812,6 +822,36 @@ async def test_create_robot_enhancement_batch(fake_repository, fake_uow, test_ro
 
     assert created_batch.reference_data_file is not None
     assert created_batch.reference_data_file.endswith(".jsonl")
+
+
+@pytest.mark.asyncio
+async def test_claim_and_create_robot_enhancement_batch_returns_none_when_empty(
+    fake_repository, fake_uow, test_robot
+):
+    """Test that None is returned when no pending enhancements are available."""
+    mock_blob_repository = AsyncMock()
+
+    class FakePendingEnhancementRepository(fake_repository):
+        async def find_available_for_robot(self, robot_id, limit):
+            return []
+
+    uow = fake_uow(
+        pending_enhancements=FakePendingEnhancementRepository(),
+        robot_enhancement_batches=fake_repository(),
+    )
+    service = ReferenceService(
+        ReferenceAntiCorruptionService(fake_repository()), uow, fake_uow()
+    )
+
+    result = await service.claim_and_create_robot_enhancement_batch(
+        robot_id=test_robot.id,
+        limit=10,
+        lease_duration=datetime.timedelta(minutes=5),
+        blob_repository=mock_blob_repository,
+    )
+
+    assert result is None
+    mock_blob_repository.upload_file_to_blob_storage.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Noticed this edge case when doing #588 - two replicas would grab the same set of references and the status state machine (& association of pending_enhancement to robot_enhancement_batch) broke.

This PR:
- combines searching & allocating robot enhancement batches into one UOW
- locks the searched rows `FOR UPDATE` until the UOW completes