### PR TITLE
Pass message id in application properties also

### DIFF
--- a/app/core/azure_service_bus_broker.py
+++ b/app/core/azure_service_bus_broker.py
@@ -181,6 +181,7 @@ class AzureServiceBusBroker(AsyncBroker):
                 "correlation_id": message.task_id,
             },
             application_properties={
+                "message_id": message.task_id,
                 "renew_lock": str(message.labels.get("renew_lock", False)),
                 "compressed": compressed,
             },
@@ -231,7 +232,10 @@ class AzureServiceBusBroker(AsyncBroker):
                     async def ack_message(
                         sb_message: ServiceBusReceivedMessage = sb_message,
                     ) -> None:
-                        task_id = sb_message.properties.message_id
+                        task_id = sb_message.application_properties.get(
+                            b"message_id",
+                            sb_message.application_properties.get("message_id"),
+                        )
                         logger.info("Attempting to complete message", task_id=task_id)
                         if self.receiver is not None:
                             async with self._receive_lock:
@@ -250,7 +254,10 @@ class AzureServiceBusBroker(AsyncBroker):
                     ) -> None:
                         logger.error(
                             "Lock renewal failed for message",
-                            task_id=sb_message.properties.message_id,
+                            task_id=sb_message.application_properties.get(
+                                b"message_id",
+                                sb_message.application_properties.get("message_id"),
+                            ),
                             exception=exception,
                         )
                         logger.info("Attempting to re-register lock renewal")


### PR DESCRIPTION
Seemingly we can't access `properties` on AzureServiceBus messages

`exception=AttributeError(\"'ServiceBusReceivedMessage' object has no attribute 'properties'\")>"`

https://ui.honeycomb.io/destiny-evidence/environments/production/result/5wEf3boNDJJ?expd_col=_hny.ts&expd_id=HPSRRgUgdhb&expd_page=50&expd_vc=_hny.ts&expd_vc=body&expd_vc=library.name&tab=explore