### PR TITLE
Guard canonical reference getter

### DIFF
--- a/app/domain/references/service.py
+++ b/app/domain/references/service.py
@@ -272,9 +272,10 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
                     reference.duplicate_decision.canonical_reference_id
                 )
 
-        canonical_references = await self._get_deduplicated_references(
-            references=canonical_references
-        )
+        if canonical_references:
+            canonical_references = await self._get_deduplicated_references(
+                references=canonical_references
+            )
 
         if duplicate_canonical_ids:
             canonical_references += await self._get_deduplicated_references(

--- a/tests/unit/domain/references/test_service.py
+++ b/tests/unit/domain/references/test_service.py
@@ -611,6 +611,25 @@ async def test_get_deduplicated_canonical_references(
     )
 
 
+@pytest.mark.asyncio
+async def test_get_deduplicated_canonical_references_all_duplicates(
+    fake_repository, fake_uow, canonical_reference, get_duplicate_reference
+):
+    """All-duplicate input should return the canonical without raising ValueError."""
+    duplicate_reference = get_duplicate_reference(canonical_reference.id)
+    canonical_reference.duplicate_references = [duplicate_reference]
+    refs = fake_repository([canonical_reference, duplicate_reference])
+    uow = fake_uow(references=refs)
+    service = ReferenceService(
+        ReferenceAntiCorruptionService(fake_repository()), uow, fake_uow()
+    )
+    canonical_list = await service._get_deduplicated_canonical_references(  # noqa: SLF001
+        references=[duplicate_reference]
+    )
+    assert len(canonical_list) == 1
+    assert canonical_list[0].id == canonical_reference.id
+
+
 async def test_get_canonical_reference_with_implied_changeset(
     fake_uow, fake_repository
 ):


### PR DESCRIPTION
When passing in a payload of only duplicates (eg one duplicate), the conversion from canonical references (non-existent) to deduplicated canonical references would pass an empty list and fail.

Eg: https://ui.honeycomb.io/destiny-evidence/environments/production/result/4zvtsEa1o8T/trace/mpsFUHd3HJw?fields[]=s_name&fields[]=s_serviceName&span=bda2fb544202242f