### PR TITLE
Merge ontology into data graph for SHACL sh:class validation

### DIFF
--- a/app/domain/references/services/linked_data_validation_service.py
+++ b/app/domain/references/services/linked_data_validation_service.py
@@ -93,6 +93,10 @@ class LinkedDataValidationService:
             )
 
         # Step 3: SHACL validation
+        # Merge ontology into data graph so sh:class constraints can resolve
+        # concept types. pyshacl's sh:class only checks rdf:type triples in the
+        # data graph, not ont_graph — even with ont_graph set.
+        data_graph += ontology
         try:
             conforms, _graph, results_text = shacl_validate(
                 data_graph,

--- a/tests/unit/domain/references/services/test_linked_data_validation_service.py
+++ b/tests/unit/domain/references/services/test_linked_data_validation_service.py
@@ -74,6 +74,46 @@ VALID_DATA = {
 }
 
 
+VALID_DATA_WITH_ONTOLOGY_CONCEPT = {
+    "@context": {"evrepo": EVREPO},
+    "@type": "evrepo:LinkedDataEnhancement",
+    "evrepo:hasInvestigation": {
+        "@type": "evrepo:Investigation",
+        "evrepo:hasFinding": {
+            "@type": "evrepo:Finding",
+            "evrepo:hasContext": {"@type": "evrepo:Context"},
+            "evrepo:hasOutcome": {
+                "@type": "evrepo:Outcome",
+                "evrepo:name": "Reading comprehension",
+            },
+            "evrepo:evaluates": {
+                "@type": "evrepo:Intervention",
+                "evrepo:name": "Tutoring",
+            },
+            "evrepo:comparedTo": {"@type": "evrepo:ControlCondition"},
+            "evrepo:hasArmData": {
+                "@type": "evrepo:ObservedResult",
+                "evrepo:forCondition": {"@type": "evrepo:Intervention"},
+                "evrepo:n": {
+                    "@value": 50,
+                    "@type": "http://www.w3.org/2001/XMLSchema#integer",
+                },
+            },
+            "evrepo:hasEffectEstimate": {
+                "@type": "evrepo:EffectEstimate",
+                "evrepo:pointEstimate": {
+                    "@value": "0.35",
+                    "@type": "http://www.w3.org/2001/XMLSchema#decimal",
+                },
+                "evrepo:effectSizeMetric": {
+                    "@id": "https://vocab.evidence-repository.org/hedgesG",
+                },
+            },
+        },
+    },
+}
+
+
 VOCAB_URI = "https://vocab.evidence-repository.org/vocabulary/v1"
 
 
@@ -82,6 +122,23 @@ async def test_valid_data_conforms(service: LinkedDataValidationService):
     result = await service.validate(data=VALID_DATA, vocabulary_uri=VOCAB_URI)
     assert result.conforms
     assert result.errors == []
+
+
+@pytest.mark.asyncio
+async def test_ontology_concept_types_resolved_via_graph_merge(
+    service: LinkedDataValidationService,
+):
+    """sh:class constraints on ontology-typed concepts pass.
+
+    effectSizeMetric references evrepo:hedgesG, whose rdf:type
+    EffectSizeMetricConcept lives in the ontology, not in the LDE data.
+    Without merging the ontology into the data graph before SHACL
+    validation, pyshacl cannot resolve the type and the constraint fails.
+    """
+    result = await service.validate(
+        data=VALID_DATA_WITH_ONTOLOGY_CONCEPT, vocabulary_uri=VOCAB_URI
+    )
+    assert result.conforms, f"Expected conforms=True, got errors: {result.errors}"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Merge the vocabulary ontology into the data graph before SHACL validation so `sh:class` constraints can resolve concept types
- pyshacl's `sh:class` only checks `rdf:type` triples in the data graph, not `ont_graph`, even when `ont_graph` is explicitly passed
- Without this, every LDE referencing typed concepts (e.g. `EffectSizeMetricScheme/hedgesG`) fails validation because the type triple (`hedgesG rdf:type EffectSizeMetricConcept`) only exists in the vocabulary

## Context

Discovered during local end-to-end testing of the vocabulary-mapping-robot against the staging ESEA vocabulary. The robot output is valid JSON-LD — concept URIs resolve to typed nodes via the vocabulary — but SHACL validation rejected LDEs with effect estimates because it couldn't see the type assertions across graphs.

Confirmed experimentally: `inference="rdfs"` doesn't help either. The type triples must be present in the data graph for `sh:class` to find them.

## Changes

- `linked_data_validation_service.py`: one line — `data_graph += ontology` before `shacl_validate()`
- New test `test_ontology_concept_types_resolved_via_graph_merge`: validates that an LDE referencing `evrepo:hedgesG` via `effectSizeMetric` passes `sh:class evrepo:EffectSizeMetricConcept`. Verified the test fails without the fix.

## Validation performed

- `test_ontology_concept_types_resolved_via_graph_merge` passes with fix, fails without
- All existing SHACL validation tests pass (6/6)
- Local E2E against full EPPI dataset: 2,442 LDEs ingested from vocab robot. Remaining 4,131 failures are unrelated SHACL shape issues on the robot side (hasFinding minCount).