### PR TITLE
Exclude LDEs from percolation

### DIFF
--- a/app/domain/references/models/es.py
+++ b/app/domain/references/models/es.py
@@ -38,6 +38,7 @@ from app.persistence.es.persistence import GenericESPersistence, GenericNestedDo
 EXCLUDED_ENHANCEMENT_TYPES = {
     EnhancementType.RAW,
     EnhancementType.REFERENCE_ASSOCIATION,
+    EnhancementType.LINKED_DATA,
 }
 
 # Fields excluded from ES indexing. These are not useful for candidate generation


### PR DESCRIPTION
The structured nature of Linked Data Enhancements causes [mayhem](https://ui.honeycomb.io/destiny-evidence/environments/staging/datasets/destiny-repository-task-staging/result/kuuk4PjoX5q/trace/rjDnyptpCCL?fields[]=s_name&fields[]=s_serviceName&span=766854c2db069920) when Elasticsearch tries to dynamically infer the types of each value.

Any percolation on this data can be done using existing or new projections.