### PR TITLE
Relax SHACL constraint: drop minCount on hasArmData

### DIFF
--- a/app/static/evrepo-core-shapes.ttl
+++ b/app/static/evrepo-core-shapes.ttl
@@ -28,7 +28,7 @@ evrepo:InvestigationShape a sh:NodeShape ;
         sh:minCount 1 ;
     ] .
 
-# --- Finding must have Context, Outcome, at least one arm, and an effect estimate ---
+# --- Finding must have Context and Outcome; arm data and effect estimates are optional ---
 
 evrepo:FindingShape a sh:NodeShape ;
     sh:targetClass evrepo:Finding ;
@@ -49,7 +49,6 @@ evrepo:FindingShape a sh:NodeShape ;
     ] , [
         sh:path evrepo:hasArmData ;
         sh:class evrepo:ObservedResult ;
-        sh:minCount 1 ;
     ] , [
         sh:path evrepo:hasEffectEstimate ;
         sh:class evrepo:EffectEstimate ;


### PR DESCRIPTION
## Summary
- Drop `sh:minCount 1` from `hasArmData` on `FindingShape`
- Findings with precomputed effect sizes (SMD-only) but no per-arm statistics are now valid
- `hasEffectEstimate >= 1` and `hasFinding >= 1` unchanged

## Validation performed
- 6 unit tests pass (including ontology concept type resolution from PR #627)
- Full local E2E: 6,575 EEF EPPI refs imported, robot produced 5,013 enhancements
- 4,357 LDEs stored (up from 2,445 without this fix)
- 1,122 of 1,126 SMD-only refs now pass SHACL (previously 0)
- pre-commit all files pass