### PR TITLE
Make created_at an optional field for context-specific use

### DIFF
--- a/app/domain/references/services/anti_corruption_service.py
+++ b/app/domain/references/services/anti_corruption_service.py
@@ -132,8 +132,9 @@ class ReferenceAntiCorruptionService(GenericAntiCorruptionService):
         try:
             enhancement_model = enhancement_in.model_dump()
 
-            ## The SDK isn't allowed to pass in ids, so ignore this.
+            ## The SDK isn't allowed to pass in ids or created_ats, so ignore these.
             enhancement_model.pop("id", None)
+            enhancement_model.pop("created_at", None)
 
             enhancement = Enhancement.model_validate(
                 enhancement_model

--- a/libs/sdk/pyproject.toml
+++ b/libs/sdk/pyproject.toml
@@ -36,7 +36,7 @@ license = "Apache-2.0"
 name = "destiny_sdk"
 readme = "README.md"
 requires-python = ">=3.12, <4"
-version = "0.11.2"
+version = "0.11.3"
 
 [project.optional-dependencies]
 labs = []

--- a/libs/sdk/src/destiny_sdk/enhancements.py
+++ b/libs/sdk/src/destiny_sdk/enhancements.py
@@ -620,6 +620,7 @@ class Enhancement(_JsonlFileInputMixIn, BaseModel):
     ]
     created_at: datetime.datetime | None = Field(
         default=None,
+        frozen=True,
         description=(
             "The ISO8601 datetime when the enhancement was added to the repository. "
             "This field is populated by the repository, if it is included on an "

--- a/libs/sdk/src/destiny_sdk/enhancements.py
+++ b/libs/sdk/src/destiny_sdk/enhancements.py
@@ -618,10 +618,13 @@ class Enhancement(_JsonlFileInputMixIn, BaseModel):
             description="The content of the enhancement.",
         ),
     ]
-    created_at: datetime.datetime = Field(
+    created_at: datetime.datetime | None = Field(
+        default=None,
         description=(
-            "The ISO8601 datetime when the enhancement was added to the repository."
-        )
+            "The ISO8601 datetime when the enhancement was added to the repository. "
+            "This field is populated by the repository, if it is included on an "
+            "incoming enhancement it will be ignored."
+        ),
     )
 
 

--- a/libs/sdk/uv.lock
+++ b/libs/sdk/uv.lock
@@ -256,7 +256,7 @@ wheels = [
 
 [[package]]
 name = "destiny-sdk"
-version = "0.11.2"
+version = "0.11.3"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },

--- a/tests/unit/domain/references/services/test_anti_corruption_service.py
+++ b/tests/unit/domain/references/services/test_anti_corruption_service.py
@@ -31,12 +31,11 @@ class TestEnhancementFromSdk:
                 process=AbstractProcessType.OTHER,
                 abstract="Test abstract content.",
             ),
+            created_at=datetime.datetime.now(datetime.UTC),
         )
 
     def test_created_at_is_stripped(self, service, sdk_enhancement):
         """SDK-provided created_at should be ignored during translation."""
-        sdk_enhancement.created_at = datetime.datetime.now(datetime.UTC)
-
         domain_enhancement = service.enhancement_from_sdk(sdk_enhancement)
 
         assert domain_enhancement.created_at is None

--- a/tests/unit/domain/references/services/test_anti_corruption_service.py
+++ b/tests/unit/domain/references/services/test_anti_corruption_service.py
@@ -1,0 +1,42 @@
+"""Tests for ReferenceAntiCorruptionService."""
+
+import datetime
+from unittest.mock import MagicMock
+from uuid import uuid7
+
+import destiny_sdk
+import pytest
+from destiny_sdk.enhancements import AbstractProcessType
+from destiny_sdk.visibility import Visibility
+
+from app.domain.references.services.anti_corruption_service import (
+    ReferenceAntiCorruptionService,
+)
+
+
+class TestEnhancementFromSdk:
+    """Tests for enhancement_from_sdk translation."""
+
+    @pytest.fixture
+    def service(self):
+        return ReferenceAntiCorruptionService(blob_repository=MagicMock())
+
+    @pytest.fixture
+    def sdk_enhancement(self):
+        return destiny_sdk.enhancements.Enhancement(
+            reference_id=uuid7(),
+            source="test-source",
+            visibility=Visibility.PUBLIC,
+            content=destiny_sdk.enhancements.AbstractContentEnhancement(
+                process=AbstractProcessType.OTHER,
+                abstract="Test abstract content.",
+            ),
+        )
+
+    def test_created_at_is_stripped(self, service, sdk_enhancement):
+        """SDK-provided created_at should be ignored during translation."""
+        sdk_enhancement.created_at = datetime.datetime.now(datetime.UTC)
+
+        domain_enhancement = service.enhancement_from_sdk(sdk_enhancement)
+
+        assert domain_enhancement.created_at is None

--- a/uv.lock
+++ b/uv.lock
@@ -689,7 +689,7 @@ test = [
 
 [[package]]
 name = "destiny-sdk"
-version = "0.11.2"
+version = "0.11.3"
 source = { editable = "libs/sdk" }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
Follow-up to #624 - the pydantic model was asserting that robots should provide `created_at`, which is untrue. It is set at the SQL layer of the repository.