### PR TITLE
Fix SHACL shapes comment and add missing regression test

### DIFF
--- a/app/static/evrepo-core-shapes.ttl
+++ b/app/static/evrepo-core-shapes.ttl
@@ -28,7 +28,7 @@ evrepo:InvestigationShape a sh:NodeShape ;
         sh:minCount 1 ;
     ] .
 
-# --- Finding must have Context and Outcome; arm data and effect estimates are optional ---
+# --- Finding must have Context, Outcome, and at least one effect estimate; arm data is optional ---
 
 evrepo:FindingShape a sh:NodeShape ;
     sh:targetClass evrepo:Finding ;

--- a/tests/unit/domain/references/services/test_linked_data_validation_service.py
+++ b/tests/unit/domain/references/services/test_linked_data_validation_service.py
@@ -114,6 +114,35 @@ VALID_DATA_WITH_ONTOLOGY_CONCEPT = {
 }
 
 
+VALID_DATA_WITHOUT_ARM_DATA = {
+    "@context": {"evrepo": EVREPO},
+    "@type": "evrepo:LinkedDataEnhancement",
+    "evrepo:hasInvestigation": {
+        "@type": "evrepo:Investigation",
+        "evrepo:hasFinding": {
+            "@type": "evrepo:Finding",
+            "evrepo:hasContext": {"@type": "evrepo:Context"},
+            "evrepo:hasOutcome": {
+                "@type": "evrepo:Outcome",
+                "evrepo:name": "Reading comprehension",
+            },
+            "evrepo:evaluates": {
+                "@type": "evrepo:Intervention",
+                "evrepo:name": "Tutoring",
+            },
+            "evrepo:comparedTo": {"@type": "evrepo:ControlCondition"},
+            "evrepo:hasEffectEstimate": {
+                "@type": "evrepo:EffectEstimate",
+                "evrepo:pointEstimate": {
+                    "@value": "0.35",
+                    "@type": "http://www.w3.org/2001/XMLSchema#decimal",
+                },
+            },
+        },
+    },
+}
+
+
 VOCAB_URI = "https://vocab.evidence-repository.org/vocabulary/v1"
 
 
@@ -137,6 +166,15 @@ async def test_ontology_concept_types_resolved_via_graph_merge(
     """
     result = await service.validate(
         data=VALID_DATA_WITH_ONTOLOGY_CONCEPT, vocabulary_uri=VOCAB_URI
+    )
+    assert result.conforms, f"Expected conforms=True, got errors: {result.errors}"
+
+
+@pytest.mark.asyncio
+async def test_finding_without_arm_data_conforms(service: LinkedDataValidationService):
+    """Finding without hasArmData should conform — arm data is optional."""
+    result = await service.validate(
+        data=VALID_DATA_WITHOUT_ARM_DATA, vocabulary_uri=VOCAB_URI
     )
     assert result.conforms, f"Expected conforms=True, got errors: {result.errors}"
 


### PR DESCRIPTION
## Summary

- Fixed the comment on `FindingShape` in `evrepo-core-shapes.ttl` — it incorrectly stated both arm data and effect estimates are optional, but `hasEffectEstimate` still has `sh:minCount 1`. The comment now reads: "at least one effect estimate; arm data is optional."
- Added a regression test (`test_finding_without_arm_data_conforms`) that proves a Finding without `hasArmData` conforms to the relaxed constraint from #631.