### PR TITLE
Add cors var and api frontdoor config

### DIFF
--- a/docs/procedures/oauth.rst
+++ b/docs/procedures/oauth.rst
@@ -83,7 +83,7 @@ The API base URL for each environment is as follows:
 .. csv-table:: API URLs
     :header: "Environment", "API URL"
 
-    "Development", "https://destiny-repository-deve-app.gentlecoast-c1c9497a.swedencentral.azurecontainerapps.io"
+    "Development", "https://api.dev.evidence-repository.org"
     "Staging", "https://destiny-repository-stag-app.proudmeadow-2a76e8ac.swedencentral.azurecontainerapps.io"
     "Production", "https://destiny-repository-prod-app.politesea-556f2857.swedencentral.azurecontainerapps.io"
 
@@ -120,8 +120,7 @@ Script template
     # Easy access of configurations listed in the tables above
     CONFIGS = {
         "development": {
-            "url": "https://destiny-repository-deve-app.gentlecoast-c1c9497a"
-                   ".swedencentral.azurecontainerapps.io",
+            "url": "https://api.dev.evidence-repository.org",
             "login_url": "https://login.microsoftonline.com/f870e5ae-5521-4a94-b9ff-cdde7d36dd35",
             "client": "0fde62ae-2203-44a5-9722-73e965325ae7",
             "app": "0a4b8df7-5c97-42b2-be07-2bb25e06dbb2",

--- a/infra/app/auth.tf
+++ b/infra/app/auth.tf
@@ -244,6 +244,7 @@ resource "azuread_application_redirect_uris" "ui_redirect" {
   type           = "SPA"
 
   redirect_uris = [
+    "https://${local.ui_hostname}",
     "https://${data.azurerm_container_app.ui.ingress[0].fqdn}",
   ]
 }

--- a/infra/app/auth_v2.tf
+++ b/infra/app/auth_v2.tf
@@ -265,6 +265,7 @@ resource "azuread_application_redirect_uris" "external_directory_ui_redirect" {
   type           = "SPA"
 
   redirect_uris = [
+    "https://${local.ui_hostname}",
     "https://${data.azurerm_container_app.ui.ingress[0].fqdn}",
   ]
 }

--- a/infra/app/frontdoor.tf
+++ b/infra/app/frontdoor.tf
@@ -76,6 +76,16 @@ resource "azurerm_cdn_frontdoor_route" "api" {
   link_to_default_domain          = false
 }
 
+
+resource "azurerm_cdn_frontdoor_custom_domain_association" "api" {
+  cdn_frontdoor_custom_domain_id = azurerm_cdn_frontdoor_custom_domain.api.id
+  cdn_frontdoor_route_ids        = [azurerm_cdn_frontdoor_route.api.id]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
 resource "dnsimple_zone_record" "api_validation" {
   zone_name = var.dnsimple_zone_name
   name      = "_dnsauth.${var.api_subdomain}"
@@ -145,6 +155,15 @@ resource "azurerm_cdn_frontdoor_route" "ui" {
   patterns_to_match               = ["/*"]
   supported_protocols             = ["Http", "Https"]
   link_to_default_domain          = false
+}
+
+resource "azurerm_cdn_frontdoor_custom_domain_association" "ui" {
+  cdn_frontdoor_custom_domain_id = azurerm_cdn_frontdoor_custom_domain.ui.id
+  cdn_frontdoor_route_ids        = [azurerm_cdn_frontdoor_route.ui.id]
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "dnsimple_zone_record" "ui_validation" {

--- a/infra/app/frontdoor.tf
+++ b/infra/app/frontdoor.tf
@@ -56,6 +56,10 @@ resource "azurerm_cdn_frontdoor_custom_domain" "api" {
   tls {
     certificate_type = "ManagedCertificate"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "azurerm_cdn_frontdoor_route" "api" {
@@ -122,6 +126,10 @@ resource "azurerm_cdn_frontdoor_custom_domain" "ui" {
 
   tls {
     certificate_type = "ManagedCertificate"
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 

--- a/infra/app/frontdoor.tf
+++ b/infra/app/frontdoor.tf
@@ -1,5 +1,6 @@
 locals {
   api_hostname = "${var.api_subdomain}.${var.dnsimple_zone_name}"
+  ui_hostname  = "${var.ui_subdomain}.${var.dnsimple_zone_name}"
 }
 
 data "azurerm_cdn_frontdoor_profile" "shared" {
@@ -7,14 +8,16 @@ data "azurerm_cdn_frontdoor_profile" "shared" {
   resource_group_name = var.shared_resource_group_name
 }
 
-resource "azurerm_cdn_frontdoor_endpoint" "api" {
-  name                     = "api-${var.environment}"
+resource "azurerm_cdn_frontdoor_endpoint" "this" {
+  name                     = "fde-${local.name}"
   cdn_frontdoor_profile_id = data.azurerm_cdn_frontdoor_profile.shared.id
   tags                     = local.minimum_resource_tags
 }
 
+# --- API ---
+
 resource "azurerm_cdn_frontdoor_origin_group" "api" {
-  name                     = "api-${var.environment}"
+  name                     = "og-api-${local.name}"
   cdn_frontdoor_profile_id = data.azurerm_cdn_frontdoor_profile.shared.id
   session_affinity_enabled = false
 
@@ -33,7 +36,7 @@ resource "azurerm_cdn_frontdoor_origin_group" "api" {
 }
 
 resource "azurerm_cdn_frontdoor_origin" "api" {
-  name                           = "api-${var.environment}"
+  name                           = "o-api-${local.name}"
   cdn_frontdoor_origin_group_id  = azurerm_cdn_frontdoor_origin_group.api.id
   enabled                        = true
   certificate_name_check_enabled = true
@@ -46,7 +49,7 @@ resource "azurerm_cdn_frontdoor_origin" "api" {
 }
 
 resource "azurerm_cdn_frontdoor_custom_domain" "api" {
-  name                     = "api-${var.environment}"
+  name                     = "cd-api-${local.name}"
   cdn_frontdoor_profile_id = data.azurerm_cdn_frontdoor_profile.shared.id
   host_name                = local.api_hostname
 
@@ -56,8 +59,8 @@ resource "azurerm_cdn_frontdoor_custom_domain" "api" {
 }
 
 resource "azurerm_cdn_frontdoor_route" "api" {
-  name                            = "api-${var.environment}"
-  cdn_frontdoor_endpoint_id       = azurerm_cdn_frontdoor_endpoint.api.id
+  name                            = "rt-api-${local.name}"
+  cdn_frontdoor_endpoint_id       = azurerm_cdn_frontdoor_endpoint.this.id
   cdn_frontdoor_origin_group_id   = azurerm_cdn_frontdoor_origin_group.api.id
   cdn_frontdoor_origin_ids        = [azurerm_cdn_frontdoor_origin.api.id]
   cdn_frontdoor_custom_domain_ids = [azurerm_cdn_frontdoor_custom_domain.api.id]
@@ -66,11 +69,9 @@ resource "azurerm_cdn_frontdoor_route" "api" {
   https_redirect_enabled          = true
   patterns_to_match               = ["/*"]
   supported_protocols             = ["Http", "Https"]
-  link_to_default_domain          = false
+  link_to_default_domain          = true
 }
 
-# Front Door validates ownership of the custom domain by checking a TXT record
-# at `_dnsauth.<subdomain>`. The CNAME is what actually routes traffic.
 resource "dnsimple_zone_record" "api_validation" {
   zone_name = var.dnsimple_zone_name
   name      = "_dnsauth.${var.api_subdomain}"
@@ -83,6 +84,73 @@ resource "dnsimple_zone_record" "api" {
   zone_name = var.dnsimple_zone_name
   name      = var.api_subdomain
   type      = "CNAME"
-  value     = azurerm_cdn_frontdoor_endpoint.api.host_name
+  value     = azurerm_cdn_frontdoor_endpoint.this.host_name
+  ttl       = 3600
+}
+
+# --- UI ---
+
+resource "azurerm_cdn_frontdoor_origin_group" "ui" {
+  name                     = "og-ui-${local.name}"
+  cdn_frontdoor_profile_id = data.azurerm_cdn_frontdoor_profile.shared.id
+  session_affinity_enabled = false
+
+  load_balancing {
+    additional_latency_in_milliseconds = 50
+    sample_size                        = 4
+    successful_samples_required        = 3
+  }
+}
+
+resource "azurerm_cdn_frontdoor_origin" "ui" {
+  name                           = "o-ui-${local.name}"
+  cdn_frontdoor_origin_group_id  = azurerm_cdn_frontdoor_origin_group.ui.id
+  enabled                        = true
+  certificate_name_check_enabled = true
+  host_name                      = data.azurerm_container_app.ui.ingress[0].fqdn
+  origin_host_header             = data.azurerm_container_app.ui.ingress[0].fqdn
+  http_port                      = 80
+  https_port                     = 443
+  priority                       = 1
+  weight                         = 1000
+}
+
+resource "azurerm_cdn_frontdoor_custom_domain" "ui" {
+  name                     = "cd-ui-${local.name}"
+  cdn_frontdoor_profile_id = data.azurerm_cdn_frontdoor_profile.shared.id
+  host_name                = local.ui_hostname
+
+  tls {
+    certificate_type = "ManagedCertificate"
+  }
+}
+
+resource "azurerm_cdn_frontdoor_route" "ui" {
+  name                            = "rt-ui-${local.name}"
+  cdn_frontdoor_endpoint_id       = azurerm_cdn_frontdoor_endpoint.this.id
+  cdn_frontdoor_origin_group_id   = azurerm_cdn_frontdoor_origin_group.ui.id
+  cdn_frontdoor_origin_ids        = [azurerm_cdn_frontdoor_origin.ui.id]
+  cdn_frontdoor_custom_domain_ids = [azurerm_cdn_frontdoor_custom_domain.ui.id]
+  enabled                         = true
+  forwarding_protocol             = "HttpsOnly"
+  https_redirect_enabled          = true
+  patterns_to_match               = ["/*"]
+  supported_protocols             = ["Http", "Https"]
+  link_to_default_domain          = true
+}
+
+resource "dnsimple_zone_record" "ui_validation" {
+  zone_name = var.dnsimple_zone_name
+  name      = "_dnsauth.${var.ui_subdomain}"
+  type      = "TXT"
+  value     = azurerm_cdn_frontdoor_custom_domain.ui.validation_token
+  ttl       = 3600
+}
+
+resource "dnsimple_zone_record" "ui" {
+  zone_name = var.dnsimple_zone_name
+  name      = var.ui_subdomain
+  type      = "CNAME"
+  value     = azurerm_cdn_frontdoor_endpoint.this.host_name
   ttl       = 3600
 }

--- a/infra/app/frontdoor.tf
+++ b/infra/app/frontdoor.tf
@@ -49,7 +49,7 @@ resource "azurerm_cdn_frontdoor_origin" "api" {
 }
 
 resource "azurerm_cdn_frontdoor_custom_domain" "api" {
-  name                     = "cd-api-${local.name}"
+  name                     = replace(local.api_hostname, ".", "-")
   cdn_frontdoor_profile_id = data.azurerm_cdn_frontdoor_profile.shared.id
   host_name                = local.api_hostname
 
@@ -120,7 +120,7 @@ resource "azurerm_cdn_frontdoor_origin" "ui" {
 }
 
 resource "azurerm_cdn_frontdoor_custom_domain" "ui" {
-  name                     = "cd-ui-${local.name}"
+  name                     = replace(local.ui_hostname, ".", "-")
   cdn_frontdoor_profile_id = data.azurerm_cdn_frontdoor_profile.shared.id
   host_name                = local.ui_hostname
 

--- a/infra/app/frontdoor.tf
+++ b/infra/app/frontdoor.tf
@@ -1,0 +1,88 @@
+locals {
+  api_hostname = "${var.api_subdomain}.${var.dnsimple_zone_name}"
+}
+
+data "azurerm_cdn_frontdoor_profile" "shared" {
+  name                = var.shared_frontdoor_profile_name
+  resource_group_name = var.shared_resource_group_name
+}
+
+resource "azurerm_cdn_frontdoor_endpoint" "api" {
+  name                     = "api-${var.environment}"
+  cdn_frontdoor_profile_id = data.azurerm_cdn_frontdoor_profile.shared.id
+  tags                     = local.minimum_resource_tags
+}
+
+resource "azurerm_cdn_frontdoor_origin_group" "api" {
+  name                     = "api-${var.environment}"
+  cdn_frontdoor_profile_id = data.azurerm_cdn_frontdoor_profile.shared.id
+  session_affinity_enabled = false
+
+  load_balancing {
+    additional_latency_in_milliseconds = 50
+    sample_size                        = 4
+    successful_samples_required        = 3
+  }
+
+  health_probe {
+    protocol            = "Https"
+    interval_in_seconds = 100
+    path                = "/v1/system/healthcheck/"
+    request_type        = "GET"
+  }
+}
+
+resource "azurerm_cdn_frontdoor_origin" "api" {
+  name                           = "api-${var.environment}"
+  cdn_frontdoor_origin_group_id  = azurerm_cdn_frontdoor_origin_group.api.id
+  enabled                        = true
+  certificate_name_check_enabled = true
+  host_name                      = data.azurerm_container_app.api.ingress[0].fqdn
+  origin_host_header             = data.azurerm_container_app.api.ingress[0].fqdn
+  http_port                      = 80
+  https_port                     = 443
+  priority                       = 1
+  weight                         = 1000
+}
+
+resource "azurerm_cdn_frontdoor_custom_domain" "api" {
+  name                     = "api-${var.environment}"
+  cdn_frontdoor_profile_id = data.azurerm_cdn_frontdoor_profile.shared.id
+  host_name                = local.api_hostname
+
+  tls {
+    certificate_type = "ManagedCertificate"
+  }
+}
+
+resource "azurerm_cdn_frontdoor_route" "api" {
+  name                            = "api-${var.environment}"
+  cdn_frontdoor_endpoint_id       = azurerm_cdn_frontdoor_endpoint.api.id
+  cdn_frontdoor_origin_group_id   = azurerm_cdn_frontdoor_origin_group.api.id
+  cdn_frontdoor_origin_ids        = [azurerm_cdn_frontdoor_origin.api.id]
+  cdn_frontdoor_custom_domain_ids = [azurerm_cdn_frontdoor_custom_domain.api.id]
+  enabled                         = true
+  forwarding_protocol             = "HttpsOnly"
+  https_redirect_enabled          = true
+  patterns_to_match               = ["/*"]
+  supported_protocols             = ["Http", "Https"]
+  link_to_default_domain          = false
+}
+
+# Front Door validates ownership of the custom domain by checking a TXT record
+# at `_dnsauth.<subdomain>`. The CNAME is what actually routes traffic.
+resource "dnsimple_zone_record" "api_validation" {
+  zone_name = var.dnsimple_zone_name
+  name      = "_dnsauth.${var.api_subdomain}"
+  type      = "TXT"
+  value     = azurerm_cdn_frontdoor_custom_domain.api.validation_token
+  ttl       = 3600
+}
+
+resource "dnsimple_zone_record" "api" {
+  zone_name = var.dnsimple_zone_name
+  name      = var.api_subdomain
+  type      = "CNAME"
+  value     = azurerm_cdn_frontdoor_endpoint.api.host_name
+  ttl       = 3600
+}

--- a/infra/app/frontdoor.tf
+++ b/infra/app/frontdoor.tf
@@ -69,7 +69,7 @@ resource "azurerm_cdn_frontdoor_route" "api" {
   https_redirect_enabled          = true
   patterns_to_match               = ["/*"]
   supported_protocols             = ["Http", "Https"]
-  link_to_default_domain          = true
+  link_to_default_domain          = false
 }
 
 resource "dnsimple_zone_record" "api_validation" {
@@ -136,7 +136,7 @@ resource "azurerm_cdn_frontdoor_route" "ui" {
   https_redirect_enabled          = true
   patterns_to_match               = ["/*"]
   supported_protocols             = ["Http", "Https"]
-  link_to_default_domain          = true
+  link_to_default_domain          = false
 }
 
 resource "dnsimple_zone_record" "ui_validation" {

--- a/infra/app/github_actions.tf
+++ b/infra/app/github_actions.tf
@@ -146,5 +146,5 @@ resource "github_actions_environment_secret" "destiny_api_endpoint" {
   repository      = github_repository_environment.environment.repository
   environment     = github_repository_environment.environment.environment
   secret_name     = "DESTINY_API_ENDPOINT"
-  plaintext_value = "https://${data.azurerm_container_app.api.ingress[0].fqdn}/v1/"
+  plaintext_value = "https://${local.api_hostname}/v1/"
 }

--- a/infra/app/main.tf
+++ b/infra/app/main.tf
@@ -337,8 +337,9 @@ module "container_app_ui" {
       value = local.auth_application_id
     },
     {
-      name  = "AUTH_PROVIDER"
-      value = var.auth_provider
+      name = "AUTH_PROVIDER"
+      # UI drives a single login flow; map "both" to azure as the default.
+      value = var.auth_provider == "both" ? "azure" : var.auth_provider
     },
     {
       name  = "KEYCLOAK_URL"

--- a/infra/app/main.tf
+++ b/infra/app/main.tf
@@ -215,7 +215,7 @@ module "container_app" {
 
   env_vars = concat(local.env_vars, [{
     name  = "CORS_ALLOW_ORIGINS",
-    value = jsonencode(["*"])
+    value = jsonencode(var.cors_allow_origins)
   }])
 
   secrets = local.secrets

--- a/infra/app/main.tf
+++ b/infra/app/main.tf
@@ -186,15 +186,16 @@ locals {
 
 data "azurerm_container_app" "api" {
   # Used as the Front Door origin host_name.
+  # No depends_on: the module.container_app.container_app_name reference
+  # is sufficient for ordering, and adding depends_on forces the data read
+  # to be deferred to apply, cascading "known after apply" into every consumer.
   name                = module.container_app.container_app_name
   resource_group_name = azurerm_resource_group.this.name
-  depends_on          = [module.container_app]
 }
 
 data "azurerm_container_app" "ui" {
   name                = module.container_app_ui.container_app_name
   resource_group_name = azurerm_resource_group.this.name
-  depends_on          = [module.container_app_ui]
 }
 
 module "container_app" {

--- a/infra/app/main.tf
+++ b/infra/app/main.tf
@@ -139,6 +139,13 @@ locals {
       name  = "KEYCLOAK_CLIENT_ID"
       value = var.auth_provider != "azure" ? "destiny-repository-client-${var.environment}" : ""
     },
+    {
+      name = "CORS_ALLOW_ORIGINS",
+      value = jsonencode(concat(var.cors_allow_origins, [
+        "https://${local.ui_hostname}",
+        "https://${data.azurerm_container_app.ui.ingress[0].fqdn}",
+      ]))
+    },
   ]
 
 
@@ -178,8 +185,7 @@ locals {
 }
 
 data "azurerm_container_app" "api" {
-  # This data source is used to get the latest revision FQDN for the container app
-  # so that we can use it in the eppi-import GitHub Action.
+  # Used as the Front Door origin host_name.
   name                = module.container_app.container_app_name
   resource_group_name = azurerm_resource_group.this.name
   depends_on          = [module.container_app]
@@ -213,10 +219,7 @@ module "container_app" {
     client_id    = azurerm_user_assigned_identity.container_apps_identity.client_id
   }
 
-  env_vars = concat(local.env_vars, [{
-    name  = "CORS_ALLOW_ORIGINS",
-    value = jsonencode(var.cors_allow_origins)
-  }])
+  env_vars = local.env_vars
 
   secrets = local.secrets
 
@@ -327,7 +330,7 @@ module "container_app_ui" {
     },
     {
       name  = "NEXT_PUBLIC_API_URL"
-      value = "https://${data.azurerm_container_app.api.ingress[0].fqdn}/v1/"
+      value = "https://${local.api_hostname}/v1/"
     },
     {
       name  = "NEXT_PUBLIC_AZURE_APPLICATION_ID"

--- a/infra/app/outputs.tf
+++ b/infra/app/outputs.tf
@@ -1,3 +1,13 @@
+output "api_hostname" {
+  description = "Public hostname served by Front Door for the API."
+  value       = local.api_hostname
+}
+
+output "api_frontdoor_endpoint_host_name" {
+  description = "Azure-assigned hostname of the API Front Door endpoint (CNAME target)."
+  value       = azurerm_cdn_frontdoor_endpoint.api.host_name
+}
+
 output "elasticsearch_password" {
   description = "The password for the elastic user."
   value       = ec_deployment.cluster.elasticsearch_password

--- a/infra/app/outputs.tf
+++ b/infra/app/outputs.tf
@@ -3,9 +3,14 @@ output "api_hostname" {
   value       = local.api_hostname
 }
 
-output "api_frontdoor_endpoint_host_name" {
-  description = "Azure-assigned hostname of the API Front Door endpoint (CNAME target)."
-  value       = azurerm_cdn_frontdoor_endpoint.api.host_name
+output "ui_hostname" {
+  description = "Public hostname served by Front Door for the UI."
+  value       = local.ui_hostname
+}
+
+output "frontdoor_endpoint_host_name" {
+  description = "Azure-assigned hostname of the Front Door endpoint shared by API and UI (CNAME target)."
+  value       = azurerm_cdn_frontdoor_endpoint.this.host_name
 }
 
 output "elasticsearch_password" {

--- a/infra/app/terraform.tf
+++ b/infra/app/terraform.tf
@@ -50,6 +50,11 @@ terraform {
       source  = "hashicorp/random"
       version = "3.7.1"
     }
+
+    dnsimple = {
+      source  = "dnsimple/dnsimple"
+      version = "1.11.0"
+    }
   }
 }
 
@@ -88,6 +93,11 @@ provider "elasticstack" {
     username  = ec_deployment.cluster.elasticsearch_username
     password  = ec_deployment.cluster.elasticsearch_password
   }
+}
+
+provider "dnsimple" {
+  account = var.dnsimple_account_id
+  token   = var.dnsimple_token
 }
 
 provider "honeycombio" {

--- a/infra/app/terraform.tf
+++ b/infra/app/terraform.tf
@@ -53,7 +53,7 @@ terraform {
 
     dnsimple = {
       source  = "dnsimple/dnsimple"
-      version = "1.11.0"
+      version = "2.0.1"
     }
   }
 }

--- a/infra/app/variables.tf
+++ b/infra/app/variables.tf
@@ -92,6 +92,11 @@ variable "api_subdomain" {
   type        = string
 }
 
+variable "ui_subdomain" {
+  description = "Subdomain (relative to dnsimple_zone_name) for the UI Front Door endpoint. For example: 'ui' in production, 'ui.stag' in staging."
+  type        = string
+}
+
 variable "cors_allow_origins" {
   description = "Origins permitted by the API's CORS policy (e.g. https://data.evidence-repository.org)."
   type        = list(string)

--- a/infra/app/variables.tf
+++ b/infra/app/variables.tf
@@ -65,6 +65,38 @@ variable "shared_keycloak_url" {
   type        = string
 }
 
+variable "shared_frontdoor_profile_name" {
+  description = "Name of the shared Azure Front Door profile used to expose the API publicly. Sourced from the destiny-evidence-shared TFC variable set."
+  type        = string
+}
+
+variable "dnsimple_account_id" {
+  description = "DNSimple account ID used to manage DNS records for evidence-repository.org. Sourced from the destiny-evidence-shared TFC variable set."
+  type        = string
+}
+
+variable "dnsimple_token" {
+  description = "DNSimple API token used to manage DNS records. Sourced from the destiny-evidence-shared TFC variable set."
+  type        = string
+  sensitive   = true
+}
+
+variable "dnsimple_zone_name" {
+  description = "DNSimple zone (apex domain) that owns the API hostname."
+  type        = string
+  default     = "evidence-repository.org"
+}
+
+variable "api_subdomain" {
+  description = "Subdomain (relative to dnsimple_zone_name) for the API Front Door endpoint. For example: 'api' in production, 'api.stag' in staging."
+  type        = string
+}
+
+variable "cors_allow_origins" {
+  description = "Origins permitted by the API's CORS policy (e.g. https://data.evidence-repository.org)."
+  type        = list(string)
+}
+
 variable "azure_tenant_id" {
   description = "ID of the azure application "
   type        = string


### PR DESCRIPTION
Closes #638 

Adds `api.{env}.evidence-repository.org` and `app.{env}.evidence-repository.org` (for the inbuilt UI) DNS. Also adds CORS configuration (prior was `*`).

This does not restrict FQDN access, widespread migration & docs changes will be required for that (#644 and #646).

Deployed in dev:
https://app.dev.evidence-repository.org 
https://api.dev.evidence-repository.org
