### PR TITLE
Add feature flag to toggle off candidate canonical searching

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -328,6 +328,7 @@ class FeatureFlags(BaseModel):
     """Feature flags for the application."""
 
     enable_percolation: bool = True
+    enable_canonical_candidate_search: bool = True
 
 
 class DedupCandidateScoringConfig(BaseModel):

--- a/app/domain/references/services/deduplication_service.py
+++ b/app/domain/references/services/deduplication_service.py
@@ -171,6 +171,13 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
         :return: The updated decision with candidate IDs and status.
         :rtype: ReferenceDuplicateDecision
         """
+        if not settings.feature_flags.enable_canonical_candidate_search:
+            return await self.sql_uow.reference_duplicate_decisions.update_by_pk(
+                reference_duplicate_decision.id,
+                duplicate_determination=DuplicateDetermination.UNSEARCHABLE,
+                detail="Canonical candidate search is disabled.",
+            )
+
         reference = await self.sql_uow.references.get_by_pk(
             reference_duplicate_decision.reference_id,
             preload=["enhancements", "identifiers"],

--- a/tests/unit/domain/references/services/test_deduplication_service.py
+++ b/tests/unit/domain/references/services/test_deduplication_service.py
@@ -303,6 +303,45 @@ async def test_nominate_candidate_canonicals_candidates_found(
 
 
 @pytest.mark.asyncio
+async def test_nominate_candidate_canonicals_flag_disabled(
+    searchable_reference,
+    anti_corruption_service,
+    fake_uow,
+    fake_repository,
+    monkeypatch,
+):
+    """When the feature flag is off, the decision is UNSEARCHABLE and ES is skipped."""
+    from app.domain.references.services import deduplication_service as dedup_module
+
+    monkeypatch.setattr(
+        dedup_module.settings.feature_flags,
+        "enable_canonical_candidate_search",
+        False,
+    )
+
+    decision = ReferenceDuplicateDecision(
+        reference_id=searchable_reference.id,
+        duplicate_determination=DuplicateDetermination.PENDING,
+    )
+    service = DeduplicationService(
+        anti_corruption_service,
+        fake_uow(
+            reference_duplicate_decisions=fake_repository([decision]),
+            references=fake_repository([searchable_reference]),
+        ),
+        fake_uow(),
+    )
+    service.es_uow = MagicMock()
+    service.es_uow.references.search_for_candidate_canonicals = AsyncMock()
+
+    result = await service.nominate_candidate_canonicals(decision)
+    assert result.duplicate_determination == DuplicateDetermination.UNSEARCHABLE
+    assert not result.candidate_canonical_ids
+    assert result.detail == "Canonical candidate search is disabled."
+    service.es_uow.references.search_for_candidate_canonicals.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_nominate_candidate_canonicals_no_candidates(
     searchable_reference, anti_corruption_service, fake_uow, fake_repository
 ):


### PR DESCRIPTION
Partial fulfilment of #640. Candidate canonical searching is not an actively used feature (#278).

See also https://covidence.slack.com/archives/C099F6PR8R2/p1776911734874049