### PR TITLE
Loosen the SHACLs

### DIFF
--- a/app/static/evrepo-core-shapes.ttl
+++ b/app/static/evrepo-core-shapes.ttl
@@ -18,13 +18,14 @@ evrepo:LinkedDataEnhancementShape a sh:NodeShape ;
         sh:minCount 1 ;
     ] .
 
-# --- Investigation may have Findings ---
+# --- Investigation must have at least one Finding ---
 
 evrepo:InvestigationShape a sh:NodeShape ;
     sh:targetClass evrepo:Investigation ;
     sh:property [
         sh:path evrepo:hasFinding ;
         sh:class evrepo:Finding ;
+        sh:minCount 1 ;
     ] .
 
 # --- Finding must be non-empty (at least one of the structural links present) ---

--- a/app/static/evrepo-core-shapes.ttl
+++ b/app/static/evrepo-core-shapes.ttl
@@ -18,28 +18,25 @@ evrepo:LinkedDataEnhancementShape a sh:NodeShape ;
         sh:minCount 1 ;
     ] .
 
-# --- Investigation must have at least one Finding ---
+# --- Investigation may have Findings ---
 
 evrepo:InvestigationShape a sh:NodeShape ;
     sh:targetClass evrepo:Investigation ;
     sh:property [
         sh:path evrepo:hasFinding ;
         sh:class evrepo:Finding ;
-        sh:minCount 1 ;
     ] .
 
-# --- Finding must have Context, Outcome, and at least one effect estimate; arm data is optional ---
+# --- Finding may carry any subset of Context, Outcome, Conditions, arm data, and effect estimates ---
 
 evrepo:FindingShape a sh:NodeShape ;
     sh:targetClass evrepo:Finding ;
     sh:property [
         sh:path evrepo:hasContext ;
         sh:class evrepo:Context ;
-        sh:minCount 1 ;
     ] , [
         sh:path evrepo:hasOutcome ;
         sh:class evrepo:Outcome ;
-        sh:minCount 1 ;
     ] , [
         sh:path evrepo:evaluates ;
         sh:class evrepo:Condition ;
@@ -52,7 +49,6 @@ evrepo:FindingShape a sh:NodeShape ;
     ] , [
         sh:path evrepo:hasEffectEstimate ;
         sh:class evrepo:EffectEstimate ;
-        sh:minCount 1 ;
     ] .
 
 # --- ObservedResult must link to a Condition ---

--- a/app/static/evrepo-core-shapes.ttl
+++ b/app/static/evrepo-core-shapes.ttl
@@ -27,10 +27,18 @@ evrepo:InvestigationShape a sh:NodeShape ;
         sh:class evrepo:Finding ;
     ] .
 
-# --- Finding may carry any subset of Context, Outcome, Conditions, arm data, and effect estimates ---
+# --- Finding must be non-empty (at least one of the structural links present) ---
 
 evrepo:FindingShape a sh:NodeShape ;
     sh:targetClass evrepo:Finding ;
+    sh:or (
+        [ sh:path evrepo:hasContext        ; sh:minCount 1 ]
+        [ sh:path evrepo:hasOutcome        ; sh:minCount 1 ]
+        [ sh:path evrepo:hasEffectEstimate ; sh:minCount 1 ]
+        [ sh:path evrepo:evaluates         ; sh:minCount 1 ]
+        [ sh:path evrepo:comparedTo        ; sh:minCount 1 ]
+        [ sh:path evrepo:hasArmData        ; sh:minCount 1 ]
+    ) ;
     sh:property [
         sh:path evrepo:hasContext ;
         sh:class evrepo:Context ;


### PR DESCRIPTION
Removes mincount constraints on hasContext, hasOutcome and hasEffectEstimate. Maintains that a Finding cannot be completely empty (as might be the case in completely uncoded works, eg as seen in ESEA).

Thread for context: https://covidence.slack.com/archives/C0810ARPCRG/p1777351294845379

This allows us to create a linked data enhancement for ESSA data in https://github.com/destiny-evidence/vocabulary-mapping-robot/issues/37.
