### PR TITLE
Hotfix/health check session leak

### DIFF
--- a/app/system/healthcheck.py
+++ b/app/system/healthcheck.py
@@ -49,16 +49,27 @@ async def healthcheck(
             return "No Azure blob config provided."
 
         try:
-            async with BlobServiceClient(
-                account_url=settings.azure_blob_config.account_url,
-                credential=DefaultAzureCredential()
-                if settings.azure_blob_config.uses_managed_identity
-                else settings.azure_blob_config.credential,
-            ) as client:
-                container = client.get_container_client(
-                    settings.azure_blob_config.container
-                )
-                await container.get_container_properties()
+            if settings.azure_blob_config.uses_managed_identity:
+                # DefaultAzureCredential owns its own aiohttp session and is
+                # not closed by BlobServiceClient — we have to close it ourselves.
+                async with (
+                    DefaultAzureCredential() as credential,
+                    BlobServiceClient(
+                        account_url=settings.azure_blob_config.account_url,
+                        credential=credential,
+                    ) as client,
+                ):
+                    await client.get_container_client(
+                        settings.azure_blob_config.container
+                    ).get_container_properties()
+            else:
+                async with BlobServiceClient(
+                    account_url=settings.azure_blob_config.account_url,
+                    credential=settings.azure_blob_config.credential,
+                ) as client:
+                    await client.get_container_client(
+                        settings.azure_blob_config.container
+                    ).get_container_properties()
 
         except Exception:
             logger.exception("Blob storage connection failed.")

--- a/app/system/healthcheck.py
+++ b/app/system/healthcheck.py
@@ -50,8 +50,6 @@ async def healthcheck(
 
         try:
             if settings.azure_blob_config.uses_managed_identity:
-                # DefaultAzureCredential owns its own aiohttp session and is
-                # not closed by BlobServiceClient — we have to close it ourselves.
                 async with (
                     DefaultAzureCredential() as credential,
                     BlobServiceClient(

--- a/app/system/routes.py
+++ b/app/system/routes.py
@@ -95,6 +95,12 @@ system_utility_auth = CachingStrategyAuth(
 )
 
 
+@router.get("/ping/", status_code=status.HTTP_200_OK)
+async def get_ping() -> JSONResponse:
+    """Cheap liveness probe."""
+    return JSONResponse(content={"status": "ok"})
+
+
 @router.get("/healthcheck/", status_code=status.HTTP_200_OK)
 async def get_healthcheck(
     healthcheck_options: Annotated[HealthCheckOptions, Depends()],

--- a/infra/app/frontdoor.tf
+++ b/infra/app/frontdoor.tf
@@ -30,7 +30,7 @@ resource "azurerm_cdn_frontdoor_origin_group" "api" {
   health_probe {
     protocol            = "Https"
     interval_in_seconds = 100
-    path                = "/v1/system/healthcheck/"
+    path                = "/v1/system/ping/"
     request_type        = "GET"
   }
 }

--- a/tests/routers/test_system.py
+++ b/tests/routers/test_system.py
@@ -44,6 +44,14 @@ async def client(app: FastAPI) -> AsyncGenerator[AsyncClient]:
         yield client
 
 
+async def test_ping(client: AsyncClient) -> None:
+    """Ping should return 200 without touching any dependencies."""
+    response = await client.get("/system/ping/")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"status": "ok"}
+
+
 async def test_healthcheck_success(app: FastAPI, client: AsyncClient) -> None:
     """Test the happy path of the healthcheck."""
     mock_session = AsyncMock()


### PR DESCRIPTION
Since #638, FrontDoor has been calling the `/healthcheck/` endpoint for system health. This endpoint is pretty heavy and checks auxiliary services, and also had a context manager leak that was polluting our telemetry with errors.

This PR addresses two deficiencies:
- Fix the credential scope leak in `/healthcheck/`
  - NB we have this problem at an application level (so much less churn), I've added a [comment](https://github.com/destiny-evidence/destiny-repository/issues/255#issuecomment-4349349747) to #255 
- Create a `/ping/` endpoint that is much more lightweight for networking health information