### PR TITLE
Full text enhancement structure

### DIFF
--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -364,6 +364,19 @@ class FullTextEnhancement(DomainBaseModel):
         description="The timestamp when this full text was retrieved.",
     )
 
+    @property
+    def fingerprint(self) -> str:
+        """
+        The unique fingerprint of this full text enhancement.
+
+        Excludes retrieved_at: refetching the same file shouldn't produce
+        a different fingerprint.
+        """
+        return json.dumps(
+            self.model_dump(mode="json", exclude={"retrieved_at"}, exclude_none=True),
+            sort_keys=True,
+        )
+
 
 EnhancementContent = Annotated[
     destiny_sdk.enhancements.BibliographicMetadataEnhancement

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -349,7 +349,21 @@ class FullTextEnhancement(DomainBaseModel):
     license: str | None = Field(
         default=None,
         description="The publishing license for this full text.",
-        examples=["cc0", "cc-by"],
+        examples=[
+            "apache-2-0",
+            "cc-by",
+            "cc-by-nc",
+            "cc-by-nc-nd",
+            "cc-by-nc-sa",
+            "cc-by-nd",
+            "cc-by-sa",
+            "gpl-v2",
+            "gpl-v3",
+            "isc",
+            "mit",
+            "other-oa",
+            "public-domain",
+        ],
     )
     source: str | None = Field(
         default=None,

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -3,17 +3,20 @@
 import datetime
 import json
 from enum import StrEnum, auto
-from typing import Any, Literal, Self
+from typing import Annotated, Any, Literal, Self
 from uuid import UUID
 
 import destiny_sdk
 
-# Explicitly import these models for easy use in the rest of the codebase
-from destiny_sdk.enhancements import EnhancementContent, EnhancementType  # noqa: F401
+# Explicitly import these models for easy importing in the rest of the codebase
+# This allows us to abstract them later if we need (as has already happened with
+# EnhancementContent!)
+from destiny_sdk.enhancements import EnhancementType
 from destiny_sdk.identifiers import ExternalIdentifier, ExternalIdentifierType
 from pydantic import (
     BaseModel,
     Field,
+    HttpUrl,
     PositiveInt,
     TypeAdapter,
     field_validator,
@@ -296,6 +299,84 @@ class GenericExternalIdentifier(DomainBaseModel):
 
 class IdentifierLookup(GenericExternalIdentifier):
     """Model to search for an external identifier."""
+
+
+class FullTextEnhancement(DomainBaseModel):
+    """
+    An enhancement for storing a link to the full text and its metadata.
+
+    We separate this from the SDK model as it contains a file pointer, not
+    the URL to the file itself.
+    """
+
+    enhancement_type: Literal[EnhancementType.FULL_TEXT] = EnhancementType.FULL_TEXT
+    blob: BlobStorageFile = Field(
+        description="Blob storage pointer to the full text file.",
+    )
+    byte_size: int | None = Field(
+        default=None,
+        description=(
+            "Size of the file in bytes. "
+            "If provided on import, will be used to validate the file size. "
+            "Will always be present on enhancements from the repository."
+        ),
+    )
+    sha256_checksum: str | None = Field(
+        default=None,
+        description=(
+            "SHA256 checksum of the file. "
+            "If provided on import, will be used to verify the integrity of the file. "
+            "Will always be present on enhancements from the repository."
+        ),
+    )
+    mime_type: str = Field(
+        default="application/pdf",
+        description="The MIME type of the file.",
+    )
+    version: destiny_sdk.enhancements.DriverVersion | None = Field(
+        default=None,
+        description=(
+            "The version (according to the DRIVER versioning scheme) of this full text."
+        ),
+    )
+    is_oa: bool | None = Field(
+        default=None,
+        description=(
+            "If this full text is Open Access. "
+            "May be left as null if this is unknown."
+        ),
+    )
+    license: str | None = Field(
+        default=None,
+        description="The publishing license for this full text.",
+        examples=["cc0", "cc-by"],
+    )
+    source: str | None = Field(
+        default=None,
+        description="The source from which this full text was obtained.",
+    )
+    source_url: HttpUrl | None = Field(
+        default=None,
+        description="The URL of the source from which this full text was obtained.",
+    )
+    retrieved_at: datetime.datetime | None = Field(
+        default=None,
+        description="The timestamp when this full text was retrieved.",
+    )
+
+
+EnhancementContent = Annotated[
+    destiny_sdk.enhancements.BibliographicMetadataEnhancement
+    | destiny_sdk.enhancements.AbstractContentEnhancement
+    | destiny_sdk.enhancements.AnnotationEnhancement
+    | destiny_sdk.enhancements.LocationEnhancement
+    | destiny_sdk.enhancements.ReferenceAssociationEnhancement
+    | destiny_sdk.enhancements.LinkedDataEnhancement
+    # Domain defines its own FullTextEnhancement
+    | FullTextEnhancement
+    | destiny_sdk.enhancements.RawEnhancement,
+    Field(discriminator="enhancement_type"),
+]
 
 
 class Enhancement(DomainBaseModel, SQLTimestampMixin):

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -369,11 +369,14 @@ class FullTextEnhancement(DomainBaseModel):
         """
         The unique fingerprint of this full text enhancement.
 
-        Excludes retrieved_at: refetching the same file shouldn't produce
-        a different fingerprint.
+        Excludes retrieved_at and blob location.
         """
         return json.dumps(
-            self.model_dump(mode="json", exclude={"retrieved_at"}, exclude_none=True),
+            self.model_dump(
+                mode="json",
+                exclude={"retrieved_at", "blob"},
+                exclude_none=True,
+            ),
             sort_keys=True,
         )
 

--- a/app/domain/references/models/sql.py
+++ b/app/domain/references/models/sql.py
@@ -52,7 +52,6 @@ from app.domain.references.models.models import (
 from app.domain.references.models.models import (
     RobotEnhancementBatch as DomainRobotEnhancementBatch,
 )
-from app.persistence.blob.models import BlobStorageFile
 from app.persistence.sql.generics import GenericSQLPreloadableType
 from app.persistence.sql.persistence import (
     GenericSQLPersistence,
@@ -387,13 +386,13 @@ class EnhancementRequest(GenericSQLPersistence[DomainEnhancementRequest]):
             if domain_obj.enhancement_parameters
             else None,
             error=domain_obj.error,
-            reference_data_file=domain_obj.reference_data_file.to_sql()
+            reference_data_file=domain_obj.reference_data_file.to_uri()
             if domain_obj.reference_data_file
             else None,
-            result_file=domain_obj.result_file.to_sql()
+            result_file=domain_obj.result_file.to_uri()
             if domain_obj.result_file
             else None,
-            validation_result_file=domain_obj.validation_result_file.to_sql()
+            validation_result_file=domain_obj.validation_result_file.to_uri()
             if domain_obj.validation_result_file
             else None,
             pending_enhancements=[
@@ -417,15 +416,9 @@ class EnhancementRequest(GenericSQLPersistence[DomainEnhancementRequest]):
             if self.enhancement_parameters
             else {},
             error=self.error,
-            reference_data_file=BlobStorageFile.from_sql(self.reference_data_file)
-            if self.reference_data_file
-            else None,
-            result_file=BlobStorageFile.from_sql(self.result_file)
-            if self.result_file
-            else None,
-            validation_result_file=BlobStorageFile.from_sql(self.validation_result_file)
-            if self.validation_result_file
-            else None,
+            reference_data_file=self.reference_data_file,
+            result_file=self.result_file,
+            validation_result_file=self.validation_result_file,
             pending_enhancements=[pe.to_domain() for pe in self.pending_enhancements]
             if "pending_enhancements" in (preload or [])
             else [],
@@ -692,13 +685,13 @@ class RobotEnhancementBatch(GenericSQLPersistence[DomainRobotEnhancementBatch]):
         return cls(
             id=domain_obj.id,
             robot_id=domain_obj.robot_id,
-            reference_data_file=domain_obj.reference_data_file.to_sql()
+            reference_data_file=domain_obj.reference_data_file.to_uri()
             if domain_obj.reference_data_file
             else None,
-            result_file=domain_obj.result_file.to_sql()
+            result_file=domain_obj.result_file.to_uri()
             if domain_obj.result_file
             else None,
-            validation_result_file=domain_obj.validation_result_file.to_sql()
+            validation_result_file=domain_obj.validation_result_file.to_uri()
             if domain_obj.validation_result_file
             else None,
             error=domain_obj.error,
@@ -718,15 +711,9 @@ class RobotEnhancementBatch(GenericSQLPersistence[DomainRobotEnhancementBatch]):
         return DomainRobotEnhancementBatch(
             id=self.id,
             robot_id=self.robot_id,
-            reference_data_file=BlobStorageFile.from_sql(self.reference_data_file)
-            if self.reference_data_file
-            else None,
-            result_file=BlobStorageFile.from_sql(self.result_file)
-            if self.result_file
-            else None,
-            validation_result_file=BlobStorageFile.from_sql(self.validation_result_file)
-            if self.validation_result_file
-            else None,
+            reference_data_file=self.reference_data_file,
+            result_file=self.result_file,
+            validation_result_file=self.validation_result_file,
             error=self.error,
             pending_enhancements=[pe.to_domain() for pe in self.pending_enhancements]
             if "pending_enhancements" in (preload or [])

--- a/app/domain/references/services/enhancement_service.py
+++ b/app/domain/references/services/enhancement_service.py
@@ -188,8 +188,8 @@ class EnhancementService(GenericService[ReferenceAntiCorruptionService]):
 
         return await self.sql_uow.robot_enhancement_batches.update_by_pk(
             pk=robot_enhancement_batch.id,
-            reference_data_file=reference_data_file.to_sql(),
-            result_file=result_file.to_sql(),
+            reference_data_file=reference_data_file.to_uri(),
+            result_file=result_file.to_uri(),
         )
 
     async def add_validation_result_file_to_enhancement_request(
@@ -200,7 +200,7 @@ class EnhancementService(GenericService[ReferenceAntiCorruptionService]):
         """Add a validation result file to a enhancement request."""
         return await self.sql_uow.enhancement_requests.update_by_pk(
             pk=enhancement_request_id,
-            validation_result_file=validation_result_file.to_sql(),
+            validation_result_file=validation_result_file.to_uri(),
         )
 
     async def add_validation_result_file_to_robot_enhancement_batch(
@@ -211,7 +211,7 @@ class EnhancementService(GenericService[ReferenceAntiCorruptionService]):
         """Add a validation result file to a robot enhancement batch."""
         return await self.sql_uow.robot_enhancement_batches.update_by_pk(
             pk=robot_enhancement_batch_id,
-            validation_result_file=validation_result_file.to_sql(),
+            validation_result_file=validation_result_file.to_uri(),
         )
 
     async def build_robot_request(
@@ -238,8 +238,8 @@ class EnhancementService(GenericService[ReferenceAntiCorruptionService]):
 
         enhancement_request = await self.sql_uow.enhancement_requests.update_by_pk(
             enhancement_request.id,
-            reference_data_file=enhancement_request.reference_data_file.to_sql(),
-            result_file=enhancement_request.result_file.to_sql(),
+            reference_data_file=enhancement_request.reference_data_file.to_uri(),
+            result_file=enhancement_request.result_file.to_uri(),
         )
 
         return await self._anti_corruption_service.enhancement_request_to_sdk_robot(

--- a/app/persistence/blob/models.py
+++ b/app/persistence/blob/models.py
@@ -3,7 +3,7 @@
 from enum import StrEnum, auto
 from typing import Self
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_serializer, model_validator
 
 from app.core.exceptions import BlobStorageError
 from app.core.telemetry.logger import get_logger
@@ -61,17 +61,17 @@ class BlobStorageFile(BaseModel):
                 logger.warning(msg, filename=self.filename)
                 return "application/octet-stream"
 
-    def to_sql(self) -> str:
-        """Return the SQL persistence representation of the file."""
+    def to_uri(self) -> str:
+        """Return the URI representation of the file."""
         return f"{self.location}://{self.container}/{self.path}/{self.filename}"
 
     @classmethod
-    def from_sql(cls, sql: str) -> Self:
-        """Populate the model from a SQL representation."""
-        location, url = sql.split("://")
-        parts = url.split("/")
+    def from_uri(cls, uri: str) -> Self:
+        """Populate the model from its URI representation."""
+        location, _, rest = uri.partition("://")
+        parts = rest.split("/")
         if len(parts) < 3:  # noqa: PLR2004
-            msg = f"Invalid SQL representation {sql} for BlobStorageFile."
+            msg = f"Invalid blob URI {uri!r} for BlobStorageFile."
             raise BlobStorageError(msg)
         return cls(
             location=location,
@@ -79,5 +79,18 @@ class BlobStorageFile(BaseModel):
             path="/".join(parts[1:-1]),
             filename=parts[-1],
         )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_from_uri(cls, value: object) -> object:
+        """Allow construction/validation from a URI string."""
+        if isinstance(value, str):
+            return cls.from_uri(value).model_dump()
+        return value
+
+    @model_serializer(mode="plain", when_used="json")
+    def _serialize_to_uri(self) -> str:
+        """Serialize to a URI string when dumping in JSON mode."""
+        return self.to_uri()
 
     model_config = ConfigDict(frozen=True)

--- a/libs/sdk/pyproject.toml
+++ b/libs/sdk/pyproject.toml
@@ -36,7 +36,7 @@ license = "Apache-2.0"
 name = "destiny_sdk"
 readme = "README.md"
 requires-python = ">=3.12, <4"
-version = "0.11.5"
+version = "0.12.0"
 
 [project.optional-dependencies]
 labs = []

--- a/libs/sdk/src/destiny_sdk/enhancements.py
+++ b/libs/sdk/src/destiny_sdk/enhancements.py
@@ -520,7 +520,13 @@ class LinkedDataEnhancement(BaseModel):
 
 
 class FullTextEnhancement(BaseModel):
-    """An enhancement for storing a link to the full text and its metadata."""
+    """
+    An enhancement for storing a link to the full text and its metadata.
+
+    Full texts are not for the sharing of copyrighted material without a license.
+    They are to maintain files for validation and to allow permitted text and data
+    mining activities.
+    """
 
     enhancement_type: Literal[EnhancementType.FULL_TEXT] = EnhancementType.FULL_TEXT
     file_url: HttpUrl = Field(

--- a/libs/sdk/src/destiny_sdk/enhancements.py
+++ b/libs/sdk/src/destiny_sdk/enhancements.py
@@ -41,7 +41,7 @@ class EnhancementType(StrEnum):
     RAW = auto()
     """A free form enhancement for arbitrary/unstructured data."""
     FULL_TEXT = auto()
-    """The full text of the reference. (To be implemented)"""
+    """The full text of the reference."""
 
 
 class AuthorPosition(StrEnum):
@@ -519,6 +519,65 @@ class LinkedDataEnhancement(BaseModel):
         )
 
 
+class FullTextEnhancement(BaseModel):
+    """An enhancement for storing a link to the full text and its metadata."""
+
+    enhancement_type: Literal[EnhancementType.FULL_TEXT] = EnhancementType.FULL_TEXT
+    file_url: HttpUrl = Field(
+        description="Signed URL to the full text file",
+    )
+    byte_size: int | None = Field(
+        default=None,
+        description=(
+            "Size of the file in bytes. "
+            "If provided on import, will be used to validate the file size. "
+            "Will always be present on enhancements from the repository."
+        ),
+    )
+    sha256_checksum: str | None = Field(
+        default=None,
+        description=(
+            "SHA256 checksum of the file. "
+            "If provided on import, will be used to verify the integrity of the file. "
+            "Will always be present on enhancements from the repository."
+        ),
+    )
+    mime_type: str = Field(
+        default="application/pdf",
+        description="The MIME type of the file.",
+    )
+    version: DriverVersion | None = Field(
+        default=None,
+        description=(
+            "The version (according to the DRIVER versioning scheme) of this full text."
+        ),
+    )
+    is_oa: bool | None = Field(
+        default=None,
+        description=(
+            "If this full text is Open Access. "
+            "May be left as null if this is unknown."
+        ),
+    )
+    license: str | None = Field(
+        default=None,
+        description="The publishing license for this full text.",
+        examples=["cc0", "cc-by"],
+    )
+    source: str | None = Field(
+        default=None,
+        description="The source from which this full text was obtained.",
+    )
+    source_url: HttpUrl | None = Field(
+        default=None,
+        description="The URL of the source from which this full text was obtained.",
+    )
+    retrieved_at: datetime.datetime | None = Field(
+        default=None,
+        description="The timestamp when this full text was retrieved.",
+    )
+
+
 class RawEnhancement(BaseModel):
     """
     An enhancement for storing raw/arbitrary/unstructured data.
@@ -578,6 +637,7 @@ EnhancementContent = Annotated[
     | LocationEnhancement
     | ReferenceAssociationEnhancement
     | LinkedDataEnhancement
+    | FullTextEnhancement
     | RawEnhancement,
     Field(discriminator="enhancement_type"),
 ]

--- a/libs/sdk/src/destiny_sdk/enhancements.py
+++ b/libs/sdk/src/destiny_sdk/enhancements.py
@@ -577,7 +577,21 @@ class FullTextEnhancement(BaseModel):
     license: str | None = Field(
         default=None,
         description="The publishing license for this full text.",
-        examples=["cc0", "cc-by"],
+        examples=[
+            "apache-2-0",
+            "cc-by",
+            "cc-by-nc",
+            "cc-by-nc-nd",
+            "cc-by-nc-sa",
+            "cc-by-nd",
+            "cc-by-sa",
+            "gpl-v2",
+            "gpl-v3",
+            "isc",
+            "mit",
+            "other-oa",
+            "public-domain",
+        ],
     )
     source: str | None = Field(
         default=None,

--- a/libs/sdk/src/destiny_sdk/enhancements.py
+++ b/libs/sdk/src/destiny_sdk/enhancements.py
@@ -524,8 +524,17 @@ class FullTextEnhancement(BaseModel):
 
     enhancement_type: Literal[EnhancementType.FULL_TEXT] = EnhancementType.FULL_TEXT
     file_url: HttpUrl = Field(
-        description="Signed URL to the full text file",
+        description="Signed https URL to the full text file",
     )
+
+    @field_validator("file_url", mode="after")
+    @classmethod
+    def _file_url_must_be_https(cls, value: HttpUrl) -> HttpUrl:
+        if value.scheme != "https":
+            msg = f"file_url must use https, got {value.scheme!r}"
+            raise ValueError(msg)
+        return value
+
     byte_size: int | None = Field(
         default=None,
         description=(

--- a/libs/sdk/src/destiny_sdk/labs/references.py
+++ b/libs/sdk/src/destiny_sdk/labs/references.py
@@ -15,6 +15,7 @@ from destiny_sdk.enhancements import (
     AnnotationType,
     AuthorPosition,
     BibliographicMetadataEnhancement,
+    BooleanAnnotation,
     EnhancementType,
 )
 from destiny_sdk.identifiers import ExternalIdentifierType
@@ -160,7 +161,7 @@ class LabsReference(BaseModel):
             scheme=scheme,
             label=label,
         ):
-            if annotation.value == expected_value:
+            if cast(BooleanAnnotation, annotation).value == expected_value:
                 return True
             found_annotation = True
         return False if found_annotation else None

--- a/libs/sdk/src/destiny_sdk/parsers/eppi_parser.py
+++ b/libs/sdk/src/destiny_sdk/parsers/eppi_parser.py
@@ -79,7 +79,7 @@ class EPPIParser:
     def _parse_identifiers(
         self, ref_to_import: dict[str, Any]
     ) -> list[ExternalIdentifier]:
-        identifiers = []
+        identifiers: list[ExternalIdentifier] = []
         if doi := ref_to_import.get("DOI"):
             doi_identifier = self._parse_doi(doi=doi)
             if doi_identifier:
@@ -111,7 +111,7 @@ class EPPIParser:
     def _parse_url_to_identifier(self, url: str) -> ExternalIdentifier | None:
         """Attempt to parse an external identifier from a url string."""
         url = url.strip()
-        identifier_cls = None
+        identifier_cls: type[ExternalIdentifier] | None = None
         if "eric" in url:
             identifier_cls = ERICIdentifier
         elif "proquest" in url:

--- a/libs/sdk/src/destiny_sdk/references.py
+++ b/libs/sdk/src/destiny_sdk/references.py
@@ -9,7 +9,9 @@ from destiny_sdk.enhancements import Enhancement, EnhancementFileInput
 from destiny_sdk.identifiers import ExternalIdentifier
 from destiny_sdk.visibility import Visibility
 
-external_identifier_adapter = TypeAdapter(ExternalIdentifier)
+external_identifier_adapter: TypeAdapter[ExternalIdentifier] = TypeAdapter(
+    ExternalIdentifier
+)
 
 
 class Reference(_JsonlFileInputMixIn, BaseModel):

--- a/libs/sdk/tests/unit/test_enhancements.py
+++ b/libs/sdk/tests/unit/test_enhancements.py
@@ -419,6 +419,14 @@ def test_full_text_enhancement_invalid_file_url():
         destiny_sdk.enhancements.FullTextEnhancement(file_url="not-a-url")
 
 
+def test_full_text_enhancement_rejects_http_file_url():
+    """file_url must be https, not http."""
+    with pytest.raises(ValidationError):
+        destiny_sdk.enhancements.FullTextEnhancement(
+            file_url="http://example.com/full.pdf",
+        )
+
+
 def test_full_text_enhancement_discriminator_resolution():
     """Enhancement.content resolves to FullTextEnhancement via discriminator."""
     full_text = destiny_sdk.enhancements.FullTextEnhancement(

--- a/libs/sdk/tests/unit/test_enhancements.py
+++ b/libs/sdk/tests/unit/test_enhancements.py
@@ -381,6 +381,66 @@ def test_linked_data_enhancement_non_string_context():
         )
 
 
+def test_full_text_enhancement_valid():
+    full_text = destiny_sdk.enhancements.FullTextEnhancement(
+        file_url="https://example.com/full.pdf",
+        byte_size=12345,
+        sha256_checksum="abc123",
+        version=destiny_sdk.enhancements.DriverVersion.PUBLISHED_VERSION,
+        is_oa=True,
+        license="cc-by",
+        source="openalex",
+        source_url="https://example.com/source",
+        retrieved_at=datetime.datetime.now(tz=datetime.UTC),
+    )
+    assert (
+        full_text.enhancement_type == destiny_sdk.enhancements.EnhancementType.FULL_TEXT
+    )
+    assert full_text.mime_type == "application/pdf"
+
+
+def test_full_text_enhancement_minimal_defaults():
+    full_text = destiny_sdk.enhancements.FullTextEnhancement(
+        file_url="https://example.com/full.pdf",
+    )
+    assert full_text.mime_type == "application/pdf"
+    assert full_text.byte_size is None
+    assert full_text.sha256_checksum is None
+    assert full_text.version is None
+
+
+def test_full_text_enhancement_requires_file_url():
+    with pytest.raises(ValidationError):
+        destiny_sdk.enhancements.FullTextEnhancement()
+
+
+def test_full_text_enhancement_invalid_file_url():
+    with pytest.raises(ValidationError):
+        destiny_sdk.enhancements.FullTextEnhancement(file_url="not-a-url")
+
+
+def test_full_text_enhancement_discriminator_resolution():
+    """Enhancement.content resolves to FullTextEnhancement via discriminator."""
+    full_text = destiny_sdk.enhancements.FullTextEnhancement(
+        file_url="https://example.com/full.pdf",
+        mime_type="application/pdf",
+    )
+    enhancement = destiny_sdk.enhancements.Enhancement(
+        id=uuid7(),
+        source="test_source",
+        visibility="public",
+        content=full_text,
+        reference_id=uuid7(),
+        created_at=datetime.datetime.now(tz=datetime.UTC),
+    )
+    assert isinstance(enhancement.content, destiny_sdk.enhancements.FullTextEnhancement)
+
+    dumped = enhancement.to_jsonl()
+    restored = destiny_sdk.enhancements.Enhancement.model_validate_json(dumped)
+    assert isinstance(restored.content, destiny_sdk.enhancements.FullTextEnhancement)
+    assert str(restored.content.file_url) == "https://example.com/full.pdf"
+
+
 def test_pagination_empty_string_to_none():
     """Test that empty pagination strings are converted to None."""
     pagination = destiny_sdk.enhancements.Pagination(

--- a/libs/sdk/uv.lock
+++ b/libs/sdk/uv.lock
@@ -257,7 +257,7 @@ wheels = [
 
 [[package]]
 name = "destiny-sdk"
-version = "0.11.5"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ version = "2.0.0"
 
 [tool.mypy]
 explicit_package_bases = true
+mypy_path = "libs/sdk/src"
 namespace_packages = true
 plugins = ["pydantic.mypy"]
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -40,6 +40,7 @@ from faker.providers import BaseProvider
 
 from app.domain.references.models.models import (
     Enhancement,
+    FullTextEnhancement,
     LinkedExternalIdentifier,
     PendingEnhancement,
     PendingEnhancementStatus,
@@ -49,6 +50,7 @@ from app.domain.references.models.models import (
 )
 from app.domain.references.models.projections import ReferenceSearchFieldsProjection
 from app.domain.robots.models.models import Robot
+from app.persistence.blob.models import BlobStorageFile, BlobStorageLocation
 from app.utils.time_and_date import utc_now
 
 
@@ -310,6 +312,33 @@ class LinkedDataEnhancementFactory(factory.Factory):
         lambda: fake.pydict(value_types=[str, int, float, bool])
         | {"@context": fake.uri()}
     )
+
+
+class BlobStorageFileFactory(factory.Factory):
+    class Meta:
+        model = BlobStorageFile
+
+    location = BlobStorageLocation.MINIO
+    container = factory.Faker("word")
+    path = factory.LazyFunction(lambda: "/".join(fake.words(nb=2)))
+    filename = factory.LazyFunction(lambda: f"{fake.word()}.pdf")
+
+
+class FullTextEnhancementFactory(factory.Factory):
+    class Meta:
+        model = FullTextEnhancement
+
+    enhancement_type = EnhancementType.FULL_TEXT
+    blob = factory.LazyFunction(lambda: BlobStorageFileFactory.build())
+    byte_size = factory.Faker("pyint", min_value=1, max_value=10_000_000)
+    sha256_checksum = factory.Faker("sha256")
+    mime_type = "application/pdf"
+    version = factory.Faker("enum", enum_cls=DriverVersion)
+    is_oa = factory.Faker("pybool")
+    license = factory.Faker("license_plate")
+    source = factory.Faker("company")
+    source_url = factory.Faker("url")
+    retrieved_at = factory.Faker("date_time_this_month")
 
 
 class RawEnhancementFactory(factory.Factory):

--- a/tests/integration/test_es_references.py
+++ b/tests/integration/test_es_references.py
@@ -298,9 +298,11 @@ async def test_es_repository_cycle(
     es_reference_repository: ReferenceESRepository, reference: Reference
 ):
     """Test saving and getting a reference by primary key from Elasticsearch."""
-    bibliographic_enhancement: destiny_sdk.enhancements.BibliographicMetadataEnhancement = reference.enhancements[
-        2
-    ].content  # type: ignore[index]
+    content = reference.enhancements[2].content  # type: ignore[index]
+    assert isinstance(
+        content, destiny_sdk.enhancements.BibliographicMetadataEnhancement
+    )
+    bibliographic_enhancement = content
 
     await es_reference_repository.add(to_indexable(reference))
 

--- a/tests/unit/domain/references/models/test_models.py
+++ b/tests/unit/domain/references/models/test_models.py
@@ -74,6 +74,19 @@ def test_full_text_enhancement_discriminator_resolves_to_domain():
     assert restored.content.blob == full_text.blob
 
 
+def test_full_text_enhancement_json_mode_round_trip():
+    """blob serializes to a URI string in JSON mode and re-parses on validate."""
+    full_text = FullTextEnhancementFactory.build()
+    enhancement = EnhancementFactory.build(content=full_text)
+
+    dumped = enhancement.model_dump(mode="json")
+    assert isinstance(dumped["content"]["blob"], str)
+
+    restored = Enhancement.model_validate(dumped)
+    assert isinstance(restored.content, FullTextEnhancement)
+    assert restored.content.blob == full_text.blob
+
+
 def test_full_text_enhancement_fingerprint_stable_across_identical_content():
     """Two full-texts with identical content fields share a fingerprint."""
     a = FullTextEnhancementFactory.build()

--- a/tests/unit/domain/references/models/test_models.py
+++ b/tests/unit/domain/references/models/test_models.py
@@ -70,6 +70,27 @@ def test_full_text_enhancement_discriminator_resolves_to_domain():
     assert restored.content.blob == full_text.blob
 
 
+def test_full_text_enhancement_fingerprint_stable_across_identical_content():
+    """Two full-texts with identical content fields share a fingerprint."""
+    a = FullTextEnhancementFactory.build()
+    b = a.model_copy(deep=True)
+    assert a.fingerprint == b.fingerprint
+
+
+def test_full_text_enhancement_fingerprint_ignores_retrieved_at():
+    """retrieved_at describes when we fetched, not what we fetched."""
+    a = FullTextEnhancementFactory.build()
+    b = a.model_copy(update={"retrieved_at": datetime(2020, 1, 1, tzinfo=UTC)})
+    assert a.fingerprint == b.fingerprint
+
+
+def test_full_text_enhancement_fingerprint_changes_with_content():
+    """Changing the sha256 (the canonical content-identity field) shifts it."""
+    a = FullTextEnhancementFactory.build()
+    b = a.model_copy(update={"sha256_checksum": "different"})
+    assert a.fingerprint != b.fingerprint
+
+
 @pytest.fixture
 def anti_corruption_service(fake_repository) -> ReferenceAntiCorruptionService:
     return ReferenceAntiCorruptionService(fake_repository)

--- a/tests/unit/domain/references/models/test_models.py
+++ b/tests/unit/domain/references/models/test_models.py
@@ -9,12 +9,16 @@ import pytest
 from app.core.exceptions import SDKToDomainError
 from app.domain.references.models.models import (
     CandidateCanonicalSearchFields,
+    Enhancement,
+    FullTextEnhancement,
     GenericExternalIdentifier,
 )
 from app.domain.references.models.validators import ReferenceCreateResult
 from app.domain.references.services.anti_corruption_service import (
     ReferenceAntiCorruptionService,
 )
+from app.persistence.blob.models import BlobStorageFile
+from tests.factories import EnhancementFactory, FullTextEnhancementFactory
 
 
 async def test_generic_external_identifier_from_specific_without_other():
@@ -46,6 +50,24 @@ def test_reference_create_result_error_str_multiple():
     result = ReferenceCreateResult(errors=["first error", " second error "])
     # strips and joins with blank line
     assert result.error_str == "first error\n\nsecond error"
+
+
+def test_full_text_enhancement_discriminator_resolves_to_domain():
+    """
+    A FULL_TEXT payload resolves to the domain FullTextEnhancement.
+
+    The SDK ships its own FullTextEnhancement with file_url: HttpUrl. The
+    domain variant uses BlobStorageFile. If someone reorders the union or
+    accidentally lists the SDK type in EnhancementContent, this round trip
+    would fail.
+    """
+    full_text = FullTextEnhancementFactory.build()
+    enhancement = EnhancementFactory.build(content=full_text)
+
+    restored = Enhancement.model_validate(enhancement.model_dump())
+    assert isinstance(restored.content, FullTextEnhancement)
+    assert isinstance(restored.content.blob, BlobStorageFile)
+    assert restored.content.blob == full_text.blob
 
 
 @pytest.fixture

--- a/tests/unit/domain/references/models/test_models.py
+++ b/tests/unit/domain/references/models/test_models.py
@@ -18,7 +18,11 @@ from app.domain.references.services.anti_corruption_service import (
     ReferenceAntiCorruptionService,
 )
 from app.persistence.blob.models import BlobStorageFile
-from tests.factories import EnhancementFactory, FullTextEnhancementFactory
+from tests.factories import (
+    BlobStorageFileFactory,
+    EnhancementFactory,
+    FullTextEnhancementFactory,
+)
 
 
 async def test_generic_external_identifier_from_specific_without_other():
@@ -77,10 +81,15 @@ def test_full_text_enhancement_fingerprint_stable_across_identical_content():
     assert a.fingerprint == b.fingerprint
 
 
-def test_full_text_enhancement_fingerprint_ignores_retrieved_at():
-    """retrieved_at describes when we fetched, not what we fetched."""
+def test_full_text_enhancement_fingerprint_ignores_retrieved_at_and_blob():
+    """blob describes where we stored it, not what it is."""
     a = FullTextEnhancementFactory.build()
-    b = a.model_copy(update={"retrieved_at": datetime(2020, 1, 1, tzinfo=UTC)})
+    b = a.model_copy(
+        update={
+            "retrieved_at": datetime(2020, 1, 1, tzinfo=UTC),
+            "blob": BlobStorageFileFactory.build(),
+        }
+    )
     assert a.fingerprint == b.fingerprint
 
 

--- a/tests/unit/persistence/blob/test_blob.py
+++ b/tests/unit/persistence/blob/test_blob.py
@@ -125,20 +125,40 @@ def test_blobstoragefile_content_type(
 
 
 @pytest.mark.asyncio
-async def test_blobstoragefile_to_sql_and_from_sql():
+async def test_blobstoragefile_to_uri_and_from_uri():
     file = BlobStorageFile(
         location=BlobStorageLocation.AZURE,
         container="cont",
         path="some/path",
         filename="file.txt",
     )
-    sql = file.to_sql()
-    assert sql == "azure://cont/some/path/file.txt"
-    new_file = BlobStorageFile.from_sql(sql)
+    uri = file.to_uri()
+    assert uri == "azure://cont/some/path/file.txt"
+    new_file = BlobStorageFile.from_uri(uri)
     assert new_file.location == "azure"
     assert new_file.container == "cont"
     assert new_file.path == "some/path"
     assert new_file.filename == "file.txt"
+
+
+@pytest.mark.asyncio
+async def test_blobstoragefile_coerces_from_uri_string():
+    """Pydantic validation accepts the URI string form transparently."""
+    uri = "azure://cont/some/path/file.txt"
+    file = BlobStorageFile.model_validate(uri)
+    assert file.location == "azure"
+    assert file.filename == "file.txt"
+
+
+@pytest.mark.asyncio
+async def test_blobstoragefile_serializes_to_uri_in_json_mode():
+    file = BlobStorageFile(
+        location=BlobStorageLocation.AZURE,
+        container="cont",
+        path="some/path",
+        filename="file.txt",
+    )
+    assert file.model_dump(mode="json") == "azure://cont/some/path/file.txt"
 
 
 class DummyClient(GenericBlobStorageClient):

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ test = [
 
 [[package]]
 name = "destiny-sdk"
-version = "0.11.5"
+version = "0.12.0"
 source = { editable = "libs/sdk" }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
Closes #666

This adds SDK and domain models. These are equivalent, except the SDK model contains a URL while the domain model contains a `BlobStorageFile`.

Also makes the `BlobStorageFile` serializing/parsing natively pydantic so that it is stored in `enhancement.content` the same way we store it elsewhere. (and renames from `_sql` to `_uri`).

The SDK was not being included in mypy type-checking, it is now - as such there are a couple of minor typing changes in the SDK.