### PR TITLE
Add priority queue for export processing

### DIFF
--- a/app/core/azure_service_bus_broker.py
+++ b/app/core/azure_service_bus_broker.py
@@ -32,6 +32,7 @@ from taskiq import AckableMessage, AsyncBroker, BrokerMessage
 from app.core.config import get_settings
 from app.core.exceptions import MessageBrokerError, MessageTooLargeError
 from app.core.telemetry.logger import get_logger
+from app.core.telemetry.taskiq import TaskPriority
 
 _T = TypeVar("_T")
 
@@ -83,8 +84,9 @@ class AzureServiceBusBroker(AsyncBroker):
             If None, the namespace parameter must be provided.
         :param namespace: The fully qualified namespace of the Service Bus.
             Used with DefaultAzureCredential if connection_string is None.
-        :param queue_name: queue that used to get incoming messages.
-        :param connection_kwargs: additional keyword arguments.
+        :param queue_name: queue used to get normal priority incoming messages with.
+        :param priority_queue_name: queue used to get high priority incoming
+            messages with.
         """
         super().__init__()
 
@@ -165,6 +167,26 @@ class AzureServiceBusBroker(AsyncBroker):
         if self.credential:
             await self.credential.close()
 
+    def _resolve_priority(self, message: BrokerMessage) -> TaskPriority:
+        """
+        Resolve the ``priority`` label on a broker message to a TaskPriority.
+
+        Unrecognised or unparseable values log a warning and fall back to
+        ``TaskPriority.NORMAL`` so an unknown sender can never block routing.
+        """
+        raw_priority = parse_val(int, message.labels.get("priority"))
+        if raw_priority is None:
+            return TaskPriority.NORMAL
+        try:
+            return TaskPriority(raw_priority)
+        except ValueError:
+            logger.warning(
+                "Unknown priority value, defaulting to NORMAL",
+                priority=raw_priority,
+                task_id=message.task_id,
+            )
+            return TaskPriority.NORMAL
+
     async def kick(self, message: BrokerMessage) -> None:
         """
         Send message to the queue.
@@ -172,17 +194,21 @@ class AzureServiceBusBroker(AsyncBroker):
         This function constructs a service bus message and sends it with the
         appropriate metadata and routing.
 
+        Messages with TaskPriority.HIGH label are sent to the priority queue;
+
         :raises MessageBrokerError:detail= if startup wasn't called.
         :raises MessageTooLargeError:detail= if the message is too large.
         :param message: message to send.
         """
-        if self.sender is None or self.service_bus_client is None:
+        if (
+            self.sender is None
+            or self.priority_sender is None
+            or self.service_bus_client is None
+        ):
             raise MessageBrokerError(detail="Please run startup before kicking.")
 
-        headers = {}
-        priority = parse_val(int, message.labels.get("priority"))
-        if priority is not None:
-            headers["priority"] = priority
+        priority = self._resolve_priority(message)
+        sender = self.priority_sender if priority > TaskPriority.NORMAL else self.sender
 
         body = message.message
         compressed = False
@@ -193,7 +219,6 @@ class AzureServiceBusBroker(AsyncBroker):
         # Create service bus message
         service_bus_message = AmqpAnnotatedMessage(
             data_body=body,
-            header=headers,
             properties={
                 "message_id": message.task_id,
                 "correlation_id": message.task_id,
@@ -208,134 +233,150 @@ class AzureServiceBusBroker(AsyncBroker):
         try:
             # Handle delay
             delay = parse_val(int, message.labels.get("delay"))
-            logger.debug("Sending message...", task_id=message.task_id, delay=delay)
+            logger.debug(
+                "Sending message...",
+                task_id=message.task_id,
+                delay=delay,
+                priority=priority,
+            )
 
             if delay is None:
-                # Send message directly to main queue
                 async with self._send_lock:
-                    await self.sender.send_messages(service_bus_message)
+                    await sender.send_messages(service_bus_message)
             else:
                 # Use Azure's built-in scheduled messages feature
                 scheduled_time = datetime.now(UTC) + timedelta(seconds=delay)
                 async with self._send_lock:
-                    await self.sender.schedule_messages(
-                        service_bus_message, scheduled_time
-                    )
+                    await sender.schedule_messages(service_bus_message, scheduled_time)
         except MessageSizeExceededError as exc:
             raise MessageTooLargeError(detail=exc.message) from exc
 
+    def _build_ackable(
+        self,
+        sb_message: ServiceBusReceivedMessage,
+        receiver: ServiceBusReceiver,
+    ) -> AckableMessage:
+        """
+        Wrap a received Service Bus message as an AckableMessage.
+
+        Captures ``receiver`` in the ack closure so completion and lock
+        renewal re-registration target the queue the message actually came
+        from — critical now that we listen on two queues.
+        """
+        if self.auto_lock_renewer is None:
+            msg = "auto_lock_renewer must be set on the worker process"
+            raise MessageBrokerError(detail=msg)
+
+        async def ack_message(
+            sb_message: ServiceBusReceivedMessage = sb_message,
+            receiver: ServiceBusReceiver = receiver,
+        ) -> None:
+            task_id = sb_message.application_properties.get(
+                b"message_id",
+                sb_message.application_properties.get("message_id"),
+            )
+            logger.info("Attempting to complete message", task_id=task_id)
+            async with self._receive_lock:
+                logger.info("Completing message", task_id=task_id)
+                await receiver.complete_message(sb_message)
+                logger.info("Completed message", task_id=task_id)
+
+        async def lock_renewal_failure_callback(
+            sb_message: ServiceBusReceivedMessage | ServiceBusSession,
+            exception: Exception | None = None,
+        ) -> None:
+            logger.error(
+                "Lock renewal failed for message",
+                task_id=sb_message.application_properties.get(
+                    b"message_id",
+                    sb_message.application_properties.get("message_id"),
+                ),
+                exception=exception,
+            )
+            logger.info("Attempting to re-register lock renewal")
+            if self.auto_lock_renewer is not None:
+                self.auto_lock_renewer.register(
+                    receiver,
+                    sb_message,
+                    # Don't try it again if it fails
+                    on_lock_renew_failure=None,
+                )
+                logger.info("Re-registered lock renewal")
+
+        properties = sb_message.application_properties
+        if properties and TypeAdapter(bool).validate_python(
+            # Try binary then string key
+            properties.get(b"renew_lock", properties.get("renew_lock", False))
+        ):
+            logger.info("Registering message for auto lock renewal")
+            self.auto_lock_renewer.register(
+                receiver,
+                sb_message,
+                on_lock_renew_failure=lock_renewal_failure_callback,
+            )
+            logger.info("Registered message for auto lock renewal")
+
+        body_type = sb_message.body_type
+        raw_body = sb_message.body
+
+        if body_type == AmqpMessageBodyType.DATA:
+            # Join all byte chunks together
+            data = b"".join(raw_body)
+        else:
+            logger.warning(
+                "Unsupported body type, defaulting to string encoding",
+                body_type=body_type,
+            )
+            data = str(raw_body).encode("utf-8")
+
+        if TypeAdapter(bool).validate_python(
+            properties.get(b"compressed", properties.get("compressed", False))
+            if properties
+            else False
+        ):
+            data = gzip.decompress(data)
+
+        return AckableMessage(data=data, ack=ack_message)
+
     async def listen(self) -> AsyncGenerator[AckableMessage, None]:
         """
-        Listen to queue.
+        Listen on the priority queue first, then the default queue.
 
-        This function listens to the queue and yields every new message.
+        Each iteration drains the priority queue with a short wait, then
+        polls the default queue with a longer wait. A backlog of priority
+        messages keeps re-entering the priority branch via ``continue``, so
+        normal work cannot leak through while priority work is available.
 
         :yields: parsed broker message.
         :raises MessageBrokerError:detail= if startup wasn't called.
         """
-        if self.receiver is None or self.auto_lock_renewer is None:
+        if (
+            self.receiver is None
+            or self.priority_receiver is None
+            or self.auto_lock_renewer is None
+        ):
             raise MessageBrokerError(detail="Call startup before starting listening.")
 
         while True:
             try:
-                # Receive a batch of messages
+                async with self._receive_lock:
+                    priority_batch = await self.priority_receiver.receive_messages(
+                        max_wait_time=1
+                    )
+                for sb_message in priority_batch:
+                    logger.info("Yielding priority message")
+                    yield self._build_ackable(sb_message, self.priority_receiver)
+                if priority_batch:
+                    # Keep draining priority before touching the default queue
+                    continue
+
                 async with self._receive_lock:
                     batch_messages = await self.receiver.receive_messages(
-                        max_wait_time=10
+                        max_wait_time=5
                     )
-
-                # Process each message
                 for sb_message in batch_messages:
-
-                    async def ack_message(
-                        sb_message: ServiceBusReceivedMessage = sb_message,
-                    ) -> None:
-                        task_id = sb_message.application_properties.get(
-                            b"message_id",
-                            sb_message.application_properties.get("message_id"),
-                        )
-                        logger.info("Attempting to complete message", task_id=task_id)
-                        if self.receiver is not None:
-                            async with self._receive_lock:
-                                logger.info("Completing message", task_id=task_id)
-                                await self.receiver.complete_message(sb_message)
-                                logger.info("Completed message", task_id=task_id)
-                        else:
-                            logger.error(
-                                "Receiver is None. Cannot complete the message.",
-                                task_id=task_id,
-                            )
-
-                    async def lock_renewal_failure_callback(
-                        sb_message: ServiceBusReceivedMessage | ServiceBusSession,
-                        exception: Exception | None = None,
-                    ) -> None:
-                        logger.error(
-                            "Lock renewal failed for message",
-                            task_id=sb_message.application_properties.get(
-                                b"message_id",
-                                sb_message.application_properties.get("message_id"),
-                            ),
-                            exception=exception,
-                        )
-                        logger.info("Attempting to re-register lock renewal")
-                        if (
-                            self.auto_lock_renewer is not None
-                            and self.receiver is not None
-                        ):
-                            self.auto_lock_renewer.register(
-                                self.receiver,
-                                sb_message,
-                                # Don't try it again if it fails
-                                on_lock_renew_failure=None,
-                            )
-                            logger.info("Re-registered lock renewal")
-
-                    properties = sb_message.application_properties
-                    if properties and TypeAdapter(bool).validate_python(
-                        # Try binary then string key
-                        properties.get(
-                            b"renew_lock", properties.get("renew_lock", False)
-                        )
-                    ):
-                        logger.info("Registering message for auto lock renewal")
-                        self.auto_lock_renewer.register(
-                            self.receiver,
-                            sb_message,
-                            on_lock_renew_failure=lock_renewal_failure_callback,
-                        )
-                        logger.info("Registered message for auto lock renewal")
-
-                    body_type = sb_message.body_type
-                    raw_body = sb_message.body
-
-                    if body_type == AmqpMessageBodyType.DATA:
-                        # Join all byte chunks together
-                        data = b"".join(raw_body)
-                    else:
-                        logger.warning(
-                            "Unsupported body type, defaulting to string encoding",
-                            body_type=body_type,
-                        )
-                        data = str(raw_body).encode("utf-8")
-
-                    if TypeAdapter(bool).validate_python(
-                        properties.get(
-                            b"compressed", properties.get("compressed", False)
-                        )
-                        if properties
-                        else False
-                    ):
-                        data = gzip.decompress(data)
-
-                    ackable = AckableMessage(
-                        data=data,
-                        ack=ack_message,
-                    )
-
                     logger.info("Yielding message")
-                    yield ackable
-                    logger.info("Yielded message")
+                    yield self._build_ackable(sb_message, self.receiver)
             except Exception:
                 logger.exception("Error receiving messages")
                 # Wait a bit before retrying

--- a/app/core/azure_service_bus_broker.py
+++ b/app/core/azure_service_bus_broker.py
@@ -172,7 +172,7 @@ class AzureServiceBusBroker(AsyncBroker):
         Resolve the ``priority`` label on a broker message to a TaskPriority.
 
         Unrecognised or unparseable values log a warning and fall back to
-        ``TaskPriority.NORMAL`` so an unknown sender can never block routing.
+        ``TaskPriority.NORMAL``.
         """
         raw_priority = parse_val(int, message.labels.get("priority"))
         if raw_priority is None:
@@ -260,8 +260,7 @@ class AzureServiceBusBroker(AsyncBroker):
         Wrap a received Service Bus message as an AckableMessage.
 
         Captures ``receiver`` in the ack closure so completion and lock
-        renewal re-registration target the queue the message actually came
-        from — critical now that we listen on two queues.
+        renewal re-registration target queue message was received from.
         """
         if self.auto_lock_renewer is None:
             msg = "auto_lock_renewer must be set on the worker process"
@@ -343,9 +342,11 @@ class AzureServiceBusBroker(AsyncBroker):
         Listen on the priority queue first, then the default queue.
 
         Each iteration drains the priority queue with a short wait, then
-        polls the default queue with a longer wait. A backlog of priority
-        messages keeps re-entering the priority branch via ``continue``, so
-        normal work cannot leak through while priority work is available.
+        polls the default queue with a longer wait.
+
+        If priority messages are received, re-enter priority branch to ensure
+        full consumption of priority messages before moving to
+        normal priority queue.
 
         :yields: parsed broker message.
         :raises MessageBrokerError:detail= if startup wasn't called.
@@ -372,7 +373,7 @@ class AzureServiceBusBroker(AsyncBroker):
 
                 async with self._receive_lock:
                     batch_messages = await self.receiver.receive_messages(
-                        max_wait_time=5
+                        max_wait_time=2
                     )
                 for sb_message in batch_messages:
                     logger.info("Yielding message")

--- a/app/core/azure_service_bus_broker.py
+++ b/app/core/azure_service_bus_broker.py
@@ -362,7 +362,7 @@ class AzureServiceBusBroker(AsyncBroker):
             try:
                 async with self._receive_lock:
                     priority_batch = await self.priority_receiver.receive_messages(
-                        max_wait_time=1
+                        max_wait_time=settings.message_broker_queue_max_wait
                     )
                 for sb_message in priority_batch:
                     logger.info("Yielding priority message")
@@ -373,7 +373,7 @@ class AzureServiceBusBroker(AsyncBroker):
 
                 async with self._receive_lock:
                     batch_messages = await self.receiver.receive_messages(
-                        max_wait_time=2
+                        max_wait_time=settings.message_broker_priority_queue_max_wait
                     )
                 for sb_message in batch_messages:
                     logger.info("Yielding message")

--- a/app/core/azure_service_bus_broker.py
+++ b/app/core/azure_service_bus_broker.py
@@ -194,7 +194,7 @@ class AzureServiceBusBroker(AsyncBroker):
         This function constructs a service bus message and sends it with the
         appropriate metadata and routing.
 
-        Messages with TaskPriority.HIGH label are sent to the priority queue;
+        Messages with TaskPriority.HIGH label are sent to the priority queue.
 
         :raises MessageBrokerError:detail= if startup wasn't called.
         :raises MessageTooLargeError:detail= if the message is too large.
@@ -260,7 +260,7 @@ class AzureServiceBusBroker(AsyncBroker):
         Wrap a received Service Bus message as an AckableMessage.
 
         Captures ``receiver`` in the ack closure so completion and lock
-        renewal re-registration target queue message was received from.
+        renewal re-registration target the queue the message was received from.
         """
         if self.auto_lock_renewer is None:
             msg = "auto_lock_renewer must be set on the worker process"

--- a/app/core/azure_service_bus_broker.py
+++ b/app/core/azure_service_bus_broker.py
@@ -364,7 +364,7 @@ class AzureServiceBusBroker(AsyncBroker):
             try:
                 async with self._receive_lock:
                     priority_batch = await self.priority_receiver.receive_messages(
-                        max_wait_time=settings.message_broker_queue_max_wait
+                        max_wait_time=settings.message_broker_priority_queue_max_wait
                     )
                 for sb_message in priority_batch:
                     logger.info("Yielding priority message")
@@ -375,7 +375,7 @@ class AzureServiceBusBroker(AsyncBroker):
 
                 async with self._receive_lock:
                     batch_messages = await self.receiver.receive_messages(
-                        max_wait_time=settings.message_broker_priority_queue_max_wait
+                        max_wait_time=settings.message_broker_queue_max_wait
                     )
                 for sb_message in batch_messages:
                     logger.info("Yielding message")

--- a/app/core/azure_service_bus_broker.py
+++ b/app/core/azure_service_bus_broker.py
@@ -174,11 +174,13 @@ class AzureServiceBusBroker(AsyncBroker):
         Unrecognised or unparseable values log a warning and fall back to
         ``TaskPriority.NORMAL``.
         """
-        raw_priority = parse_val(int, message.labels.get("priority"))
+        raw_priority = parse_val(str, message.labels.get("priority"))
+
         if raw_priority is None:
             return TaskPriority.NORMAL
+
         try:
-            return TaskPriority(raw_priority)
+            return TaskPriority(int(raw_priority))
         except ValueError:
             logger.warning(
                 "Unknown priority value, defaulting to NORMAL",

--- a/app/core/azure_service_bus_broker.py
+++ b/app/core/azure_service_bus_broker.py
@@ -74,6 +74,7 @@ class AzureServiceBusBroker(AsyncBroker):
         connection_string: str | None = None,
         namespace: str | None = None,
         queue_name: str = "taskiq",
+        priority_queue_name: str = "taskiq-priority",
     ) -> None:
         """
         Construct a new broker.
@@ -90,11 +91,14 @@ class AzureServiceBusBroker(AsyncBroker):
         self.connection_string = connection_string
         self.namespace = namespace
         self._queue_name = queue_name
+        self._priority_queue_name = priority_queue_name
         self.max_lock_renewal_duration = max_lock_renewal_duration
 
         self.service_bus_client: ServiceBusClient | None = None
         self.sender: ServiceBusSender | None = None
         self.receiver: ServiceBusReceiver | None = None
+        self.priority_sender: ServiceBusSender | None = None
+        self.priority_receiver: ServiceBusReceiver | None = None
         self.credential: DefaultAzureCredential | None = None
         self.auto_lock_renewer: AutoLockRenewer | None = None
 
@@ -124,11 +128,21 @@ class AzureServiceBusBroker(AsyncBroker):
             queue_name=self._queue_name
         )
 
+        self.priority_sender = self.service_bus_client.get_queue_sender(
+            queue_name=self._priority_queue_name
+        )
+
         if self.is_worker_process:
             self.receiver = self.service_bus_client.get_queue_receiver(
                 queue_name=self._queue_name,
                 receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
             )
+
+            self.priority_receiver = self.service_bus_client.get_queue_receiver(
+                queue_name=self._priority_queue_name,
+                receive_mode=ServiceBusReceiveMode.PEEK_LOCK,
+            )
+
             if not self.auto_lock_renewer:
                 self.auto_lock_renewer = AutoLockRenewer(
                     max_lock_renewal_duration=self.max_lock_renewal_duration
@@ -140,8 +154,12 @@ class AzureServiceBusBroker(AsyncBroker):
 
         if self.sender:
             await self.sender.close()
+        if self.priority_sender:
+            await self.priority_sender.close()
         if self.receiver:
             await self.receiver.close()
+        if self.priority_receiver:
+            await self.priority_receiver.close()
         if self.service_bus_client:
             await self.service_bus_client.close()
         if self.credential:

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -444,6 +444,21 @@ class Settings(BaseSettings):
     message_broker_namespace: str | None = None
     message_broker_queue_name: str = "taskiq"
     message_broker_priority_queue_name: str = "taskiq-priority"
+    message_broker_queue_max_wait: int = Field(
+        default=2,
+        description=(
+            "Max time to wait to receive messages on the normal priority task queue "
+            "(in seconds)."
+        ),
+    )
+    message_broker_priority_queue_max_wait: int = Field(
+        default=1,
+        description=(
+            "Max time to wait to receive messages on the high priority task queue "
+            "(in seconds)."
+        ),
+    )
+
     cli_client_id: str | None = None
     app_name: str
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -443,6 +443,7 @@ class Settings(BaseSettings):
     message_broker_url: str | None = None
     message_broker_namespace: str | None = None
     message_broker_queue_name: str = "taskiq"
+    message_broker_priority_queue_name = "taskiq-priority"
     cli_client_id: str | None = None
     app_name: str
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -443,7 +443,7 @@ class Settings(BaseSettings):
     message_broker_url: str | None = None
     message_broker_namespace: str | None = None
     message_broker_queue_name: str = "taskiq"
-    message_broker_priority_queue_name = "taskiq-priority"
+    message_broker_priority_queue_name: str = "taskiq-priority"
     cli_client_id: str | None = None
     app_name: str
 

--- a/app/core/telemetry/taskiq.py
+++ b/app/core/telemetry/taskiq.py
@@ -53,7 +53,7 @@ async def queue_task_with_trace(
     :type args: object
     :param long_running: Whether the task is long-running and needs lock renewal.
     :type long_running: bool
-    :param priority: Priority of the class.
+    :param priority: Priority of the task.
     :type priority: TaskPriority
     :param kwargs: Keyword arguments for the task.
     :type kwargs: object

--- a/app/core/telemetry/taskiq.py
+++ b/app/core/telemetry/taskiq.py
@@ -28,10 +28,8 @@ class TaskPriority(IntEnum):
     """
     Priority levels for queued tasks.
 
-    The integer value is the on-wire ``priority`` label brokers read: the
-    Azure Service Bus broker routes any value > 0 to its priority queue, and
-    the RabbitMQ (``AioPikaBroker``) consumer uses it as the AMQP priority
-    property when ``max_priority`` is set on the queue.
+    May be used to set on-wire priority header, or to route to different
+    queues depending on broker implementation.
     """
 
     NORMAL = 0
@@ -72,12 +70,8 @@ async def queue_task_with_trace(
             raise TypeError(msg)
         task = imported_task
 
-    # Use a per-call kicker so labels don't leak across submissions of the
-    # same task (the decorated task object's labels dict is shared state).
-    kicker = task.kicker().with_labels(
-        renew_lock=long_running,
-        priority=priority.value,
-    )
+    task.labels["renew_lock"] = long_running
+    task.labels["priority"] = priority.value
 
     logger.info(
         "Queueing task",
@@ -87,7 +81,7 @@ async def queue_task_with_trace(
     )
     if not otel_enabled:
         # If OpenTelemetry is not enabled, just queue the task normally
-        await kicker.kiq(*args, **kwargs)
+        await task.kiq(*args, **kwargs)
         return
 
     # Pass span context for linking (not propagation) so tasks
@@ -97,7 +91,7 @@ async def queue_task_with_trace(
         "trace_id": format(span_context.trace_id, "032x"),
         "span_id": format(span_context.span_id, "016x"),
     }
-    await kicker.kiq(
+    await task.kiq(
         *args,
         **kwargs,
         trace_link=trace_link,

--- a/app/core/telemetry/taskiq.py
+++ b/app/core/telemetry/taskiq.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextvars
 import importlib
+from enum import IntEnum
 from typing import Any
 
 from opentelemetry import context, trace
@@ -23,10 +24,25 @@ tracer = trace.get_tracer(__name__)
 logger = get_logger(__name__)
 
 
+class TaskPriority(IntEnum):
+    """
+    Priority levels for queued tasks.
+
+    The integer value is the on-wire ``priority`` label brokers read: the
+    Azure Service Bus broker routes any value > 0 to its priority queue, and
+    the RabbitMQ (``AioPikaBroker``) consumer uses it as the AMQP priority
+    property when ``max_priority`` is set on the queue.
+    """
+
+    NORMAL = 0
+    HIGH = 5
+
+
 async def queue_task_with_trace(
     task: AsyncTaskiqDecoratedTask | tuple[str, str],
     *args: object,
     long_running: bool = False,
+    priority: TaskPriority = TaskPriority.NORMAL,
     otel_enabled: bool,
     **kwargs: object,
 ) -> None:
@@ -39,6 +55,8 @@ async def queue_task_with_trace(
     :type args: object
     :param long_running: Whether the task is long-running and needs lock renewal.
     :type long_running: bool
+    :param priority: Priority of the class.
+    :type priority: TaskPriority
     :param kwargs: Keyword arguments for the task.
     :type kwargs: object
 
@@ -54,16 +72,22 @@ async def queue_task_with_trace(
             raise TypeError(msg)
         task = imported_task
 
-    task.labels["renew_lock"] = long_running
+    # Use a per-call kicker so labels don't leak across submissions of the
+    # same task (the decorated task object's labels dict is shared state).
+    kicker = task.kicker().with_labels(
+        renew_lock=long_running,
+        priority=priority.value,
+    )
 
     logger.info(
         "Queueing task",
         task_name=task.task_name,
+        priority=priority.name,
         **{k: str(v) for k, v in kwargs.items()},
     )
     if not otel_enabled:
         # If OpenTelemetry is not enabled, just queue the task normally
-        await task.kiq(*args, **kwargs)
+        await kicker.kiq(*args, **kwargs)
         return
 
     # Pass span context for linking (not propagation) so tasks
@@ -73,7 +97,7 @@ async def queue_task_with_trace(
         "trace_id": format(span_context.trace_id, "032x"),
         "span_id": format(span_context.span_id, "016x"),
     }
-    await task.kiq(
+    await kicker.kiq(
         *args,
         **kwargs,
         trace_link=trace_link,

--- a/app/domain/references/routes.py
+++ b/app/domain/references/routes.py
@@ -47,7 +47,7 @@ from app.core.exceptions import (
 )
 from app.core.telemetry.fastapi import PayloadAttributeTracer
 from app.core.telemetry.logger import get_logger
-from app.core.telemetry.taskiq import queue_task_with_trace
+from app.core.telemetry.taskiq import TaskPriority, queue_task_with_trace
 from app.domain.references.models.models import (
     AnnotationFilter,
     PendingEnhancementStatus,
@@ -442,6 +442,7 @@ async def request_search_export(
         await queue_task_with_trace(
             run_search_export_task,
             long_running=True,
+            priority=TaskPriority.HIGH,
             search_export_id=search_export.id,
             otel_enabled=settings.otel_enabled,
         )

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -21,6 +21,7 @@ logger_configurer.configure_console_logger(
 broker: AsyncBroker = AzureServiceBusBroker(
     namespace=settings.message_broker_namespace,
     queue_name=settings.message_broker_queue_name,
+    priority_queue_name=settings.message_broker_priority_queue_name,
     max_lock_renewal_duration=settings.message_lock_renewal_duration,
 )
 
@@ -28,7 +29,9 @@ if settings.env == Environment.LOCAL or settings.tests_use_rabbitmq:
     from opentelemetry.instrumentation.aio_pika import AioPikaInstrumentor
 
     AioPikaInstrumentor().instrument()
-    broker = AioPikaBroker(settings.message_broker_url)
+    # Declares the queue with x-max-priority so RabbitMQ honours
+    # the AMQP priority property set from the "priority" label.
+    broker = AioPikaBroker(settings.message_broker_url, max_priority=10)
 
 elif settings.env == "test":
     broker = InMemoryBroker()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,7 @@ services:
     environment:
       MESSAGE_BROKER_URL: amqp://guest:guest@rabbitmq:5672
       DB_CONFIG: '{"DB_URL":"postgresql+asyncpg://localuser:localpass@db:5432/destiny_dev"}'
-      MINIO_CONFIG: '{"HOST":"fs:9000","ACCESS_KEY":"localuser","SECRET_KEY":"localpass"}'
+      MINIO_CONFIG: '{"HOST":"fs:9000","ACCESS_KEY":"localuser","SECRET_KEY":"localpass", "CONTAINERS": {"operations": "destiny-repository", "full_texts": "destiny-repository"}}'
       ES_CONFIG: '{"ES_URL": "https://elasticsearch:9200", "ES_USER": "elastic", "ES_PASS": "destiny", "ES_CA_PATH": "/app/certs/ca/ca.crt"}'
       APP_NAME: destiny-app
       CORS_ALLOW_ORIGINS: '["*"]'

--- a/infra/app/main.tf
+++ b/infra/app/main.tf
@@ -85,6 +85,10 @@ locals {
       value = local.active_servicebus_queue.name
     },
     {
+      name  = "MESSAGE_BROKER_PRIORITY_QUEUE_NAME"
+      value = local.active_servicebus_priority_queue.name
+    },
+    {
       name = "AZURE_BLOB_CONFIG"
       value = jsonencode({
         storage_account_name = azurerm_storage_account.this.name
@@ -368,9 +372,10 @@ module "container_app_ui" {
 }
 
 locals {
-  servicebus_is_premium   = var.prod_servicebus_is_premium && var.environment == "production"
-  active_servicebus_ns    = local.servicebus_is_premium ? azurerm_servicebus_namespace.premium[0] : azurerm_servicebus_namespace.this
-  active_servicebus_queue = local.servicebus_is_premium ? azurerm_servicebus_queue.taskiq_premium[0] : azurerm_servicebus_queue.taskiq
+  servicebus_is_premium            = var.prod_servicebus_is_premium && var.environment == "production"
+  active_servicebus_ns             = local.servicebus_is_premium ? azurerm_servicebus_namespace.premium[0] : azurerm_servicebus_namespace.this
+  active_servicebus_queue          = local.servicebus_is_premium ? azurerm_servicebus_queue.taskiq_premium[0] : azurerm_servicebus_queue.taskiq
+  active_servicebus_priority_queue = local.servicebus_is_premium ? azurerm_servicebus_queue.taskiq_priority_premium[0] : azurerm_servicebus_queue.taskiq_priority
 }
 
 resource "azurerm_servicebus_namespace" "this" {
@@ -384,6 +389,13 @@ resource "azurerm_servicebus_namespace" "this" {
 
 resource "azurerm_servicebus_queue" "taskiq" {
   name         = "taskiq"
+  namespace_id = azurerm_servicebus_namespace.this.id
+
+  partitioning_enabled = true
+}
+
+resource "azurerm_servicebus_queue" "taskiq_priority" {
+  name         = "taskiq-priority"
   namespace_id = azurerm_servicebus_namespace.this.id
 
   partitioning_enabled = true
@@ -406,6 +418,15 @@ resource "azurerm_servicebus_queue" "taskiq_premium" {
   count = local.servicebus_is_premium ? 1 : 0
 
   name         = "taskiq"
+  namespace_id = azurerm_servicebus_namespace.premium[0].id
+
+  partitioning_enabled = true
+}
+
+resource "azurerm_servicebus_queue" "taskiq_priority_premium" {
+  count = local.servicebus_is_premium ? 1 : 0
+
+  name         = "taskiq-priority"
   namespace_id = azurerm_servicebus_namespace.premium[0].id
 
   partitioning_enabled = true

--- a/infra/app/main.tf
+++ b/infra/app/main.tf
@@ -305,6 +305,19 @@ module "container_app_tasks" {
         trigger_parameter = "connection"
       }
     },
+    {
+      name             = "priority-queue-length-scale-rule"
+      custom_rule_type = "azure-servicebus"
+      metadata = {
+        namespace    = local.active_servicebus_ns.name
+        queueName    = local.active_servicebus_priority_queue.name
+        messageCount = var.priority_queue_active_jobs_scaling_threshold
+      }
+      authentication = {
+        secret_name       = "servicebus-connection-string"
+        trigger_parameter = "connection"
+      }
+    },
   ]
 }
 

--- a/infra/app/variables.tf
+++ b/infra/app/variables.tf
@@ -154,6 +154,13 @@ variable "queue_active_jobs_scaling_threshold" {
   default     = 100
 }
 
+variable "priority_queue_active_jobs_scaling_threshold" {
+  description = "Active jobs threshold for scaling the tasks container app for high priority tasks."
+  type        = number
+  default     = 20
+}
+
+
 variable "created_by" {
   description = "Who created this infrastructure. Required tag for resource groups"
   type        = string

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -14,16 +14,19 @@ from app.core.config import get_settings
 
 settings = get_settings()
 
-pending_tasks = []
-
 
 class FakeServiceBusSender:
     """
     Fake Service Bus sender for testing.
 
-    This class is used to mock the behavior of the actual
-    Azure Service Bus sender during unit tests.
+    Each instance is bound to a queue (via the FakeServiceBusClient that
+    created it) and writes into that queue's pending-task list, so tests
+    can assert which queue a message was routed to.
     """
+
+    def __init__(self, pending_tasks: list[asyncio.Task[AmqpAnnotatedMessage]]) -> None:
+        """Bind the sender to its queue's pending-task list."""
+        self._pending_tasks = pending_tasks
 
     async def schedule_messages(
         self, message: AmqpAnnotatedMessage, scheduled_time: datetime | None = None
@@ -44,7 +47,7 @@ class FakeServiceBusSender:
             return message
 
         task = asyncio.create_task(_delayed_append())
-        pending_tasks.append(task)
+        self._pending_tasks.append(task)
 
     async def send_messages(
         self,
@@ -66,9 +69,13 @@ class FakeServiceBusReceiver:
     """
     Fake Service Bus receiver for testing.
 
-    This class is used to mock the behavior of the actual
-    Azure Service Bus receiver during unit tests.
+    Reads from a per-queue pending-task list so the priority queue and the
+    default queue are observable independently.
     """
+
+    def __init__(self, pending_tasks: list[asyncio.Task[AmqpAnnotatedMessage]]) -> None:
+        """Bind the receiver to its queue's pending-task list."""
+        self._pending_tasks = pending_tasks
 
     async def receive_messages(
         self,
@@ -84,7 +91,7 @@ class FakeServiceBusReceiver:
         deadline = asyncio.get_event_loop().time() + (max_wait_time or 60)
 
         while True:
-            results = [t.result() for t in pending_tasks if t.done()]
+            results = [t.result() for t in self._pending_tasks if t.done()]
 
             if results:
                 return results
@@ -98,9 +105,9 @@ class FakeServiceBusReceiver:
 
     async def complete_message(self, message: AmqpAnnotatedMessage) -> None:
         """Simulate completing a message."""
-        for task in pending_tasks:
+        for task in self._pending_tasks:
             if task.done() and task.result() == message:
-                pending_tasks.remove(task)
+                self._pending_tasks.remove(task)
 
     async def close(self) -> None:
         """Simulate closing the receiver."""
@@ -110,24 +117,28 @@ class FakeServiceBusClient:
     """
     Fake Service Bus client for testing.
 
-    This class is used to mock the behavior of the actual
-    Azure Service Bus client during unit tests.
+    Keeps a separate pending-task list per queue so default/priority queue
+    routing can be verified.
     """
 
     def __init__(self) -> None:
-        """Get ServiceBusSender for the specific queue."""
+        """Create an empty registry of per-queue pending-task lists."""
+        self.queues: dict[str, list[asyncio.Task[AmqpAnnotatedMessage]]] = {}
 
-    def get_queue_sender(self, queue_name: str) -> FakeServiceBusSender:  # noqa: ARG002
+    def _get_queue(self, queue_name: str) -> list[asyncio.Task[AmqpAnnotatedMessage]]:
+        return self.queues.setdefault(queue_name, [])
+
+    def get_queue_sender(self, queue_name: str) -> FakeServiceBusSender:
         """Get ServiceBusSender for the specific queue."""
-        return FakeServiceBusSender()
+        return FakeServiceBusSender(self._get_queue(queue_name))
 
     def get_queue_receiver(
         self,
-        queue_name: str,  # noqa: ARG002
+        queue_name: str,
         receive_mode: ServiceBusReceiveMode,  # noqa: ARG002
     ) -> FakeServiceBusReceiver:
         """Get ServiceBusReceiver for the specific queue."""
-        return FakeServiceBusReceiver()
+        return FakeServiceBusReceiver(self._get_queue(queue_name))
 
     async def close(self) -> None:
         """Close the client."""
@@ -161,6 +172,16 @@ def queue_name() -> str:
 
 
 @pytest.fixture
+def priority_queue_name() -> str:
+    """
+    Get test priority queue name.
+
+    :return: test priority queue name.
+    """
+    return "taskiq-test-queue-priority"
+
+
+@pytest.fixture
 def connection_string() -> str | None:
     """
     Get custom Azure Service Bus connection string.
@@ -177,6 +198,7 @@ def connection_string() -> str | None:
 async def broker(
     connection_string: str,
     queue_name: str,
+    priority_queue_name: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> AsyncGenerator[AzureServiceBusBroker, None]:
     """
@@ -186,17 +208,14 @@ async def broker(
     run startup, and shutdown after test.
 
     :param connection_string: connection string for Azure Service Bus.
-    :param namespace: Azure Service Bus namespace.
     :param queue_name: test queue name.
+    :param priority_queue_name: test priority queue name.
     :yield: broker.
     """
-    # Clear global pending_tasks before each test for isolation
-    global pending_tasks  # noqa: PLW0602
-    pending_tasks.clear()
-
     broker = AzureServiceBusBroker(
         connection_string=connection_string,
         queue_name=queue_name,
+        priority_queue_name=priority_queue_name,
     )
     broker.auto_lock_renewer = FakeServiceBusAutoLockRenewer()
     broker.is_worker_process = True

--- a/tests/core/test_azure_service_bus_broker.py
+++ b/tests/core/test_azure_service_bus_broker.py
@@ -211,12 +211,7 @@ async def test_priority_message_routes_to_priority_sender(
     broker: AzureServiceBusBroker,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """
-    Priority messages go to the priority queue, normal messages to default.
-
-    Azure Service Bus does not honour the AMQP priority header — the queue
-    choice IS the priority signal.
-    """
+    """Priority messages go to the priority queue, normal messages to default."""
     assert broker.sender is not None
     assert broker.priority_sender is not None
     default_sends: list[AmqpAnnotatedMessage] = []

--- a/tests/core/test_azure_service_bus_broker.py
+++ b/tests/core/test_azure_service_bus_broker.py
@@ -156,9 +156,9 @@ async def test_kick_success(
 
     await broker.kick(sent)
 
-    # listen() drains the priority queue first (max_wait_time=1s) before
-    # falling through to the default queue, so allow >1s for the message
-    # to land here even when nothing is in priority.
+    # listen() drains the priority queue first (max_wait_time default is 1s)
+    # before falling through to the default queue.
+    # So allow >1s for the message to land here even when nothing is in priority.
     message = await asyncio.wait_for(get_first_task(broker), timeout=3.0)
 
     assert message.data == sent.message

--- a/tests/core/test_azure_service_bus_broker.py
+++ b/tests/core/test_azure_service_bus_broker.py
@@ -286,7 +286,16 @@ async def test_unknown_priority_warns_and_falls_back_to_default(
             )
         )
 
-    assert len(default_sends) == 1
+        await broker.kick(
+            BrokerMessage(
+                task_id="unknown-priority-string",
+                task_name="unknown-priority-string",
+                message=b"oddball",
+                labels={"priority": "normal"},
+            )
+        )
+
+    assert len(default_sends) == 2
     assert len(priority_sends) == 0
     assert any("Unknown priority value" in record.message for record in caplog.records)
 

--- a/tests/core/test_azure_service_bus_broker.py
+++ b/tests/core/test_azure_service_bus_broker.py
@@ -6,6 +6,7 @@ including initialization, message sending, and delayed message delivery.
 """
 
 import asyncio
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid7
 
@@ -33,8 +34,9 @@ async def get_first_task(broker: AzureServiceBusBroker):
     :param broker: async message broker.
     :return: first message from listen method
     """
-    async for message in broker.listen():  # noqa: RET503
+    async for message in broker.listen():
         return message
+    return None
 
 
 @pytest.mark.asyncio
@@ -154,7 +156,10 @@ async def test_kick_success(
 
     await broker.kick(sent)
 
-    message = await asyncio.wait_for(get_first_task(broker), timeout=1.0)
+    # listen() drains the priority queue first (max_wait_time=1s) before
+    # falling through to the default queue, so allow >1s for the message
+    # to land here even when nothing is in priority.
+    message = await asyncio.wait_for(get_first_task(broker), timeout=3.0)
 
     assert message.data == sent.message
     await maybe_awaitable(message.ack())
@@ -202,27 +207,30 @@ async def test_delayed_message(
 
 
 @pytest.mark.anyio
-async def test_priority_handling(
+async def test_priority_message_routes_to_priority_sender(
     broker: AzureServiceBusBroker,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    Test that priority is correctly set in the message headers.
+    Priority messages go to the priority queue, normal messages to default.
 
-    :param broker: current broker.
-    :param test_sender: test sender.
-    :param test_receiver: test receiver.
+    Azure Service Bus does not honour the AMQP priority header — the queue
+    choice IS the priority signal.
     """
     assert broker.sender is not None
-    original_send_messages = broker.sender.send_messages
-    sent_message = None
+    assert broker.priority_sender is not None
+    default_sends: list[AmqpAnnotatedMessage] = []
+    priority_sends: list[AmqpAnnotatedMessage] = []
 
-    async def mock_send_messages(message: AmqpAnnotatedMessage) -> None:
-        nonlocal sent_message
-        sent_message = message
-        await original_send_messages(message)
+    async def capture_default(message: AmqpAnnotatedMessage) -> None:
+        default_sends.append(message)
 
-    monkeypatch.setattr(broker.sender, "send_messages", mock_send_messages)
+    async def capture_priority(message: AmqpAnnotatedMessage) -> None:
+        priority_sends.append(message)
+
+    monkeypatch.setattr(broker.sender, "send_messages", capture_default)
+    monkeypatch.setattr(broker.priority_sender, "send_messages", capture_priority)
+
     await broker.kick(
         BrokerMessage(
             task_id="priority-task",
@@ -231,10 +239,149 @@ async def test_priority_handling(
             labels={"priority": "5"},
         )
     )
+    await broker.kick(
+        BrokerMessage(
+            task_id="normal-task",
+            task_name="normal-name",
+            message=b"normal-message",
+            labels={"priority": "0"},
+        )
+    )
+    await broker.kick(
+        BrokerMessage(
+            task_id="no-label-task",
+            task_name="no-label-name",
+            message=b"no-label-message",
+            labels={},
+        )
+    )
 
-    assert isinstance(sent_message, AmqpAnnotatedMessage)
-    assert sent_message.header is not None
-    assert sent_message.header.priority == 5
+    assert len(priority_sends) == 1
+    assert len(default_sends) == 2
+
+
+@pytest.mark.anyio
+async def test_unknown_priority_warns_and_falls_back_to_default(
+    broker: AzureServiceBusBroker,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unrecognised priority value logs a warning and routes to default."""
+    assert broker.sender is not None
+    assert broker.priority_sender is not None
+    default_sends: list[AmqpAnnotatedMessage] = []
+    priority_sends: list[AmqpAnnotatedMessage] = []
+
+    async def capture_default(message: AmqpAnnotatedMessage) -> None:
+        default_sends.append(message)
+
+    async def capture_priority(message: AmqpAnnotatedMessage) -> None:
+        priority_sends.append(message)
+
+    monkeypatch.setattr(broker.sender, "send_messages", capture_default)
+    monkeypatch.setattr(broker.priority_sender, "send_messages", capture_priority)
+
+    with caplog.at_level("WARNING"):
+        await broker.kick(
+            BrokerMessage(
+                task_id="unknown-priority",
+                task_name="unknown-priority",
+                message=b"oddball",
+                labels={"priority": "99"},
+            )
+        )
+
+    assert len(default_sends) == 1
+    assert len(priority_sends) == 0
+    assert any("Unknown priority value" in record.message for record in caplog.records)
+
+
+@pytest.mark.anyio
+async def test_priority_scheduled_message_routes_to_priority_sender(
+    broker: AzureServiceBusBroker,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Delayed priority messages must also hit the priority sender."""
+    assert broker.sender is not None
+    assert broker.priority_sender is not None
+    default_schedules: list[AmqpAnnotatedMessage] = []
+    priority_schedules: list[AmqpAnnotatedMessage] = []
+
+    async def capture_default(
+        message: AmqpAnnotatedMessage,
+        scheduled_time: datetime | None = None,  # noqa: ARG001
+    ) -> None:
+        default_schedules.append(message)
+
+    async def capture_priority(
+        message: AmqpAnnotatedMessage,
+        scheduled_time: datetime | None = None,  # noqa: ARG001
+    ) -> None:
+        priority_schedules.append(message)
+
+    monkeypatch.setattr(broker.sender, "schedule_messages", capture_default)
+    monkeypatch.setattr(broker.priority_sender, "schedule_messages", capture_priority)
+
+    await broker.kick(
+        BrokerMessage(
+            task_id="delayed-priority",
+            task_name="delayed-priority",
+            message=b"hi",
+            labels={"priority": "5", "delay": "2"},
+        )
+    )
+    await broker.kick(
+        BrokerMessage(
+            task_id="delayed-normal",
+            task_name="delayed-normal",
+            message=b"hi",
+            labels={"delay": "2"},
+        )
+    )
+
+    assert len(priority_schedules) == 1
+    assert len(default_schedules) == 1
+
+
+@pytest.mark.anyio
+async def test_listen_drains_priority_before_default(
+    broker: AzureServiceBusBroker,
+) -> None:
+    """Priority messages must yield before any default-queue work."""
+    await broker.kick(
+        BrokerMessage(
+            task_id="normal-1",
+            task_name="normal",
+            message=b"normal-1",
+            labels={},
+        )
+    )
+    await broker.kick(
+        BrokerMessage(
+            task_id="normal-2",
+            task_name="normal",
+            message=b"normal-2",
+            labels={},
+        )
+    )
+    await broker.kick(
+        BrokerMessage(
+            task_id="priority-1",
+            task_name="priority",
+            message=b"priority-1",
+            labels={"priority": "5"},
+        )
+    )
+
+    yielded: list[bytes] = []
+    async for ackable in broker.listen():
+        yielded.append(ackable.data)
+        await maybe_awaitable(ackable.ack())
+        if len(yielded) == 3:
+            break
+
+    assert yielded[0] == b"priority-1"
+    assert set(yielded[1:]) == {b"normal-1", b"normal-2"}
 
 
 @pytest.mark.anyio
@@ -298,7 +445,7 @@ async def test_large_message_is_compressed_and_decompressed(
     assert len(wire_body) < len(original_body)
 
     # Confirm the received data is transparently decompressed back to the original
-    message = await asyncio.wait_for(get_first_task(broker), timeout=1.0)
+    message = await asyncio.wait_for(get_first_task(broker), timeout=3.0)
     assert message.data == original_body
     await maybe_awaitable(message.ack())
 
@@ -333,7 +480,7 @@ async def test_small_message_is_not_compressed(
 
     assert isinstance(sent_message, AmqpAnnotatedMessage)
     assert sent_message.application_properties.get("compressed") is False
-    message = await asyncio.wait_for(get_first_task(broker), timeout=1.0)
+    message = await asyncio.wait_for(get_first_task(broker), timeout=3.0)
     assert message.data == small_body
     await maybe_awaitable(message.ack())
 
@@ -367,7 +514,7 @@ async def test_only_renew_lock_when_specified(
         msg.labels["renew_lock"] = renew_lock
 
     await broker.kick(msg)
-    await asyncio.wait_for(get_first_task(broker), timeout=1.0)
+    await asyncio.wait_for(get_first_task(broker), timeout=3.0)
     if renew_lock:
         mock_lock_renewer.register.assert_called_once()
     else:

--- a/tests/core/test_azure_service_bus_broker.py
+++ b/tests/core/test_azure_service_bus_broker.py
@@ -123,7 +123,9 @@ async def test_happy_startup(broker: AzureServiceBusBroker) -> None:
     """
     assert broker.service_bus_client is not None
     assert broker.sender is not None
+    assert broker.priority_sender is not None
     assert broker.receiver is not None
+    assert broker.priority_receiver is not None
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Closes #682 

## Context 
Exports used to run on the same task queue as all other tasks, meaning they could get caught behind large imports and not process for an extended period. As exports are a user triggered tasks we need appropriate response times and therefore need to process them ahead of other tasks. Enter priority queue. 

Azure Servicebus is first-in first-out and does not support message ordering, so this implements a separate priority queue. Routing to each queue is determined by set task priority. Exports are the only high priority task. 

## What's Changed
* Tasks now take an optional priority, defaulting to normal 
* Additional priority queue created in the same servicebus namespace 
* Works now poll priority queue prior to polling normal queue
    * Also reduced the max wait time on polling the normal queue to ensure export tasks start in a timely manner. 
* High priority tasks are sent to the priority queue by the service bus broker. 

Prioritization is implemented at the broker level based on set task priorities. 

## Want to test?

This is currently deployed in development, so you can trigger a download and see the tasks hitting the priority queue. 