### PR TITLE
Move entitlements into a core-level file

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -30,6 +30,7 @@ from joserfc.jwk import KeySet
 from opentelemetry import trace
 
 from app.core.config import get_settings
+from app.core.entitlements import Entitlement
 from app.core.exceptions import AuthError, NotFoundError
 from app.core.telemetry.attributes import Attributes
 
@@ -88,13 +89,6 @@ class SubjectType(StrEnum):
     SERVICE = auto()
     ROBOT = auto()
     BYPASS = auto()
-
-
-class Entitlement(StrEnum):
-    """Capabilities that can be granted to an authenticated principal."""
-
-    FULL_TEXT = auto()
-    ROBOT_ENTITLEMENT_WRITER = auto()
 
 
 _ENTITLEMENT_TO_GRANTS: dict[Entitlement, frozenset[str]] = {

--- a/app/core/entitlements.py
+++ b/app/core/entitlements.py
@@ -1,0 +1,10 @@
+"""Entitlements granted to authenticated principals."""
+
+from enum import StrEnum, auto
+
+
+class Entitlement(StrEnum):
+    """Capabilities that can be granted to an authenticated principal."""
+
+    FULL_TEXT = auto()
+    ROBOT_ENTITLEMENT_WRITER = auto()

--- a/app/domain/references/routes.py
+++ b/app/domain/references/routes.py
@@ -32,7 +32,6 @@ from app.api.auth import (
     AuthRole,
     AuthScope,
     CachingStrategyAuth,
-    Entitlement,
     HMACClientType,
     choose_auth_strategy,
     choose_hybrid_auth_strategy,
@@ -41,6 +40,7 @@ from app.api.auth import (
 from app.api.decorators import experimental
 from app.api.exception_handlers import APIExceptionContent, APIExceptionResponse
 from app.core.config import get_settings
+from app.core.entitlements import Entitlement
 from app.core.exceptions import (
     DeduplicationValueError,
     ParseError,

--- a/app/domain/references/services/access_control_service.py
+++ b/app/domain/references/services/access_control_service.py
@@ -4,7 +4,7 @@ from typing import NewType
 
 from destiny_sdk.enhancements import EnhancementType
 
-from app.api.auth import Entitlement
+from app.core.entitlements import Entitlement
 from app.domain.references.models.models import Enhancement, Reference
 from app.domain.service import GenericAccessControlService
 

--- a/app/domain/references/tasks.py
+++ b/app/domain/references/tasks.py
@@ -7,8 +7,8 @@ from uuid import UUID
 from opentelemetry import trace
 from structlog.contextvars import bound_contextvars
 
-from app.api.auth import Entitlement
 from app.core.config import Environment, get_settings
+from app.core.entitlements import Entitlement
 from app.core.exceptions import SQLIntegrityError
 from app.core.telemetry.attributes import (
     Attributes,

--- a/app/domain/robots/models/models.py
+++ b/app/domain/robots/models/models.py
@@ -2,7 +2,7 @@
 
 from pydantic import ConfigDict, Field, SecretStr
 
-from app.api.auth import Entitlement
+from app.core.entitlements import Entitlement
 from app.domain.base import DomainBaseModel, SQLAttributeMixin
 
 

--- a/app/domain/robots/models/sql.py
+++ b/app/domain/robots/models/sql.py
@@ -6,7 +6,7 @@ from sqlalchemy import String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.orm import Mapped, mapped_column
 
-from app.api.auth import Entitlement
+from app.core.entitlements import Entitlement
 from app.domain.robots.models.models import (
     Robot as DomainRobot,
 )

--- a/app/domain/robots/routes.py
+++ b/app/domain/robots/routes.py
@@ -10,10 +10,10 @@ from app.api.auth import (
     AuthMethod,
     AuthScope,
     CachingStrategyAuth,
-    Entitlement,
     choose_auth_strategy,
 )
 from app.core.config import get_settings
+from app.core.entitlements import Entitlement
 from app.core.telemetry.fastapi import PayloadAttributeTracer
 from app.core.telemetry.logger import get_logger
 from app.domain.robots.service import RobotService

--- a/app/domain/robots/services/access_control_service.py
+++ b/app/domain/robots/services/access_control_service.py
@@ -2,7 +2,7 @@
 
 from fastapi import status
 
-from app.api.auth import Entitlement
+from app.core.entitlements import Entitlement
 from app.core.exceptions import AuthError
 from app.domain.service import GenericAccessControlService
 

--- a/app/domain/service.py
+++ b/app/domain/service.py
@@ -2,7 +2,7 @@
 
 from typing import Generic, TypeVar
 
-from app.api.auth import Entitlement
+from app.core.entitlements import Entitlement
 from app.domain.base import GenericDomainBaseModelType
 from app.persistence.es.uow import AsyncESUnitOfWork
 from app.persistence.sql.uow import AsyncSqlUnitOfWork

--- a/tests/unit/domain/references/services/test_access_control_service.py
+++ b/tests/unit/domain/references/services/test_access_control_service.py
@@ -2,7 +2,7 @@
 
 from destiny_sdk.enhancements import EnhancementType
 
-from app.api.auth import Entitlement
+from app.core.entitlements import Entitlement
 from app.domain.references.services.access_control_service import (
     ReferenceAccessControlService,
 )

--- a/tests/unit/domain/robots/services/test_robot_access_control_service.py
+++ b/tests/unit/domain/robots/services/test_robot_access_control_service.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from app.api.auth import Entitlement
+from app.core.entitlements import Entitlement
 from app.core.exceptions import AuthError
 from app.domain.robots.services.access_control_service import (
     RobotAccessControlService,

--- a/tests/unit/domain/robots/test_service.py
+++ b/tests/unit/domain/robots/test_service.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from app.api.auth import Entitlement
+from app.core.entitlements import Entitlement
 from app.core.exceptions import AuthError
 from app.domain.robots.service import RobotService
 from app.domain.robots.services.access_control_service import (

--- a/tests/unit/domain/robots/test_sql.py
+++ b/tests/unit/domain/robots/test_sql.py
@@ -4,7 +4,7 @@ from uuid import uuid7
 import pytest
 from pydantic import SecretStr
 
-from app.api.auth import Entitlement
+from app.core.entitlements import Entitlement
 from app.domain.robots.models.sql import Robot
 
 


### PR DESCRIPTION
`Entitlements` lived at `api/auth.py`. When imported by the `Robot` SQL model (as we store entitlements on robots), this causes `Settings` to eagerly load.

When performing an alembic migration, the `Settings` fails loading as we don't provide the required configuration. The root of the problem though was the SQL models reaching into API auth concepts. This PR moves the entitlements into a separate `core.entitlements` file.