### PR TITLE
Restore utf-8 default in eppi_importer to fix mojibake on imports

### DIFF
--- a/libs/eppi_importer/import_from_eppi.py
+++ b/libs/eppi_importer/import_from_eppi.py
@@ -38,8 +38,8 @@ def main() -> None:
         "--input-codec",
         "-ic",
         type=str,
-        default="latin-1",
-        help="The codec to decode the input file with, defaults to 'latin-1'",
+        default="utf-8",
+        help="The codec to decode the input file with, defaults to 'utf-8'",
     )
 
     arg_parser.add_argument(
@@ -97,7 +97,11 @@ def main() -> None:
         file_bytes = f.read()
         checksum = base64.b64encode(hashlib.md5(file_bytes).digest()).decode("ascii")  # noqa: S324
 
-    data = json.loads(file_bytes.decode(args.input_codec))
+    # errors='replace' is deliberate: EPPI exports occasionally contain CESU-8
+    # surrogate pairs for non-BMP chars (e.g. mathematical italics) that strict
+    # UTF-8 rejects. We'd rather degrade those rare chars to U+FFFD than fail
+    # the whole import.
+    data = json.loads(file_bytes.decode(args.input_codec, errors="replace"))
 
     eppi_parser = EPPIParser(
         tags=args.tags,

--- a/libs/eppi_importer/tests/test_import_from_eppi.py
+++ b/libs/eppi_importer/tests/test_import_from_eppi.py
@@ -1,0 +1,81 @@
+"""Tests for the EPPI importer CLI."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from libs.eppi_importer import import_from_eppi
+
+
+def _bibliographic_title(record: dict) -> str | None:
+    for enh in record.get("enhancements", []):
+        content = enh.get("content") or {}
+        if content.get("enhancement_type") == "bibliographic":
+            return content.get("title")
+    return None
+
+
+@pytest.fixture
+def utf8_eppi_export(tmp_path: Path) -> Path:
+    """
+    Build an EPPI export written as UTF-8 with U+2019 in the title.
+
+    Mirrors the byte pattern at offset 1895095 in eef_export-2025-12-03 (the
+    EEF EPPI export that triggered the mojibake bug).
+    """
+    data = {
+        "CodeSets": [],
+        "References": [
+            {
+                "Title": "Teachers’ training, class size and students’ outcomes",  # noqa: RUF001
+                "DOI": "10.1111/j.1468-0297.2008.02247.x",
+            }
+        ],
+    }
+    path = tmp_path / "eppi_utf8.json"
+    path.write_bytes(json.dumps(data, ensure_ascii=False).encode("utf-8"))
+    return path
+
+
+def test_cli_default_codec_preserves_utf8_apostrophe(
+    utf8_eppi_export: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    r"""
+    The default --input-codec must decode UTF-8 EPPI exports correctly.
+
+    Regression for the EEF 2025-12-03 mojibake bug: latin-1 was the default,
+    so \xe2\x80\x99 (U+2019) decoded into U+00E2 + U+0080 + U+0099 (mojibake)
+    instead of a clean right single quotation mark.
+    """
+    output_path = tmp_path / "out.jsonl"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "import_from_eppi",
+            "--input",
+            str(utf8_eppi_export),
+            "--output",
+            str(output_path),
+            "--source",
+            "test-eef-utf8",
+        ],
+    )
+
+    import_from_eppi.main()
+
+    lines = output_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1, "Expected one reference in output"
+    record = json.loads(lines[0])
+
+    title = _bibliographic_title(record)
+    assert title is not None, "Expected a bibliographic enhancement with a title"
+    assert "’" in title, f"Expected U+2019 in title, got: {title!r}"  # noqa: RUF001
+    # Mojibake codepoints from latin-1 misdecode of \xe2\x80\x99:
+    assert "â" not in title, f"Latin-1 mojibake leaked into title: {title!r}"
+    assert "\u0080" not in title, f"C1 control char in title: {title!r}"
+    assert "\u0099" not in title, f"C1 control char in title: {title!r}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ filterwarnings = [
 ]
 norecursedirs = ["tests/e2e"]
 pythonpath = "."
-testpaths = ["libs/ad_hoc/tests", "libs/sdk/tests", "tests"]
+testpaths = ["libs/ad_hoc/tests", "libs/eppi_importer/tests", "libs/sdk/tests", "tests"]
 
 [tool.ruff]
 extend-exclude = ["app/migrations/versions/*.py", "docs/*.py"]


### PR DESCRIPTION
## Summary

- Restores `--input-codec` default to `utf-8` (was flipped to `latin-1`
  in aade7fac, 2025-12-08).
- Adds `errors="replace"` so the CESU-8 surrogate pairs in EPPI exports
  degrade to U+FFFD rather than failing the import.
- Adds a regression test covering the U+2019 apostrophe byte pattern
  from the EEF 2025-12-03 export (offset 1895095).

See #697 for the full bug analysis and the lossy-vs-lossless codec
tradeoff. This PR ships the minimum viable fix that closes the immediate
regression; the broader CESU-8 fidelity question (custom codec vs
surrogatepass vs ftfy) stays open in the Issue.

Existing mojibake'd records in prod are bijectively repairable (see
the Issue's "Repair note"); a one-shot fix script for affected rows is
a follow-up, not part of this PR.

## Validation performed

- [x] `uv run pytest libs/eppi_importer/tests/test_import_from_eppi.py`
      passed against the fix.
- [x] `uv run pyright libs/eppi_importer/import_from_eppi.py
      libs/eppi_importer/tests/test_import_from_eppi.py` — 0 errors.
- [x] `uv run pre-commit run --files <changed files>` clean.
- [x] Ran importer on the actual EEF 2025-12-03 export and confirmed
      U+2019 in the title round-trips as UTF-8 bytes `\xe2\x80\x99`,
      not the byte-doubled `\xc3\xa2\xc2\x80\xc2\x99`.

Addresses the regression portion of #697; broader codec strategy stays
open there.