### PR TITLE
Bump search export chunk size to 1000 (closes #700)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -536,7 +536,7 @@ class Settings(BaseSettings):
         ),
     )
     upload_file_chunk_size_override: dict[UploadFile, int] = Field(
-        default_factory=dict,
+        default_factory=lambda: {UploadFile.SEARCH_EXPORT: 1000},
         description=("Override the default upload file chunk size."),
     )
 

--- a/infra/app/main.tf
+++ b/infra/app/main.tf
@@ -119,6 +119,10 @@ locals {
       value = tostring(var.default_upload_file_chunk_size)
     },
     {
+      name  = "UPLOAD_FILE_CHUNK_SIZE_OVERRIDE",
+      value = jsonencode(var.upload_file_chunk_size_override)
+    },
+    {
       name  = "MAX_REFERENCE_LOOKUP_QUERY_LENGTH",
       value = var.max_reference_lookup_query_length
     },

--- a/infra/app/variables.tf
+++ b/infra/app/variables.tf
@@ -365,6 +365,14 @@ variable "default_upload_file_chunk_size" {
   default     = 1
 }
 
+variable "upload_file_chunk_size_override" {
+  description = "Per-UploadFile override of the upload file chunk size. Keys must match the UploadFile StrEnum values (e.g. search_export)."
+  type        = map(number)
+  default = {
+    search_export = 1000
+  }
+}
+
 variable "max_reference_lookup_query_length" {
   description = "Maximum number of identifiers to allow in a single reference lookup query"
   type        = number


### PR DESCRIPTION
Sets `upload_file_chunk_size_override[SEARCH_EXPORT] = 1000` (was 1) and exposes the override map as a Terraform variable so it can be tuned per-env without a code deploy.

Chunk size chosen against measured per-ref serialized cost (9.58 KiB, from the existing export blob) and the shared task worker memory budget. See #700 for the working.