### PR TITLE
Project country codes from linked data enhancements (#696)

### DIFF
--- a/app/domain/references/models/es.py
+++ b/app/domain/references/models/es.py
@@ -356,18 +356,18 @@ class ReferenceSearchFieldsMixin(InnerDoc):
             annotations=search_fields.annotations,
             evaluated_schemes=search_fields.evaluated_schemes,
             inclusion_destiny=search_fields.destiny_inclusion_score,
-            linked_data_concepts=sorted(linked_data_projection.concepts)
+            linked_data_concepts=list(linked_data_projection.concepts)
             if linked_data_projection
             else None,
-            linked_data_labels=sorted(linked_data_projection.labels)
+            linked_data_labels=list(linked_data_projection.labels)
             if linked_data_projection
             else None,
-            linked_data_evaluated_properties=sorted(
+            linked_data_evaluated_properties=list(
                 linked_data_projection.evaluated_properties
             )
             if linked_data_projection
             else None,
-            linked_data_countries=sorted(linked_data_projection.countries)
+            linked_data_countries=list(linked_data_projection.countries)
             if linked_data_projection
             else None,
         )

--- a/app/domain/references/models/es.py
+++ b/app/domain/references/models/es.py
@@ -334,6 +334,12 @@ class ReferenceSearchFieldsMixin(InnerDoc):
     )
     """Property URIs for all evaluated linked data dimensions."""
 
+    linked_data_countries: list[str] | None = mapped_field(
+        Keyword(required=False),
+        default=None,
+    )
+    """ISO country codes from LinkedDataEnhancements, for exact-match filtering."""
+
     @classmethod
     def from_projections(
         cls,
@@ -359,6 +365,9 @@ class ReferenceSearchFieldsMixin(InnerDoc):
             linked_data_evaluated_properties=sorted(
                 linked_data_projection.evaluated_properties
             )
+            if linked_data_projection
+            else None,
+            linked_data_countries=sorted(linked_data_projection.countries)
             if linked_data_projection
             else None,
         )

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -745,6 +745,7 @@ class LinkedDataProjection(ProjectedBaseModel):
     concepts: set[str] = Field(default_factory=set)
     labels: set[str] = Field(default_factory=set)
     evaluated_properties: set[str] = Field(default_factory=set)
+    countries: set[str] = Field(default_factory=set)
 
 
 class ReferenceSearchProjection(SQLAttributeMixin):

--- a/app/domain/references/services/linked_data_projection_service.py
+++ b/app/domain/references/services/linked_data_projection_service.py
@@ -43,7 +43,7 @@ class LinkedDataProjectionService:
         self._vocabularies: dict[str, _LoadedVocabulary] = {}
 
     async def project(self, enhancement: LinkedDataEnhancement) -> LinkedDataProjection:
-        """Extract concepts, labels, and evaluated properties."""
+        """Extract concepts, labels, evaluated properties, and countries."""
         vocab = await self._get_vocabulary(str(enhancement.vocabulary_uri))
         context_uri = enhancement.data.get("@context")
         if context_uri is None:

--- a/app/domain/references/services/linked_data_projection_service.py
+++ b/app/domain/references/services/linked_data_projection_service.py
@@ -4,13 +4,19 @@ import json
 from dataclasses import dataclass
 
 from destiny_sdk.enhancements import LinkedDataEnhancement
-from rdflib import Graph, Namespace, URIRef
+from rdflib import Graph, Literal, Namespace, URIRef
 from rdflib.namespace import RDF, SKOS
 
 from app.domain.references.models.models import LinkedDataProjection
 from app.external.vocabulary.client import VocabularyArtifactClient
 
 EVREPO = Namespace("https://vocab.evidence-repository.org/")
+ESEA = Namespace("https://vocab.esea.education/")
+
+# Vocabulary properties whose StringCodingAnnotation values are ISO 3166-1
+# alpha-2 country codes. New vocabularies that introduce a country property
+# must register it here for the values to become searchable.
+_COUNTRY_PROPERTIES: frozenset[URIRef] = frozenset({ESEA.country})
 
 
 @dataclass(frozen=True)
@@ -86,7 +92,25 @@ class LinkedDataProjectionService:
             concepts=concepts,
             labels=labels,
             evaluated_properties=evaluated_properties,
+            countries=self._extract_countries(data_graph),
         )
+
+    def _extract_countries(self, data_graph: Graph) -> set[str]:
+        """Extract ISO country codes from registered country-typed properties."""
+        countries: set[str] = set()
+        for country_property in _COUNTRY_PROPERTIES:
+            for _, _, annotation in data_graph.triples((None, country_property, None)):
+                status = self._get_status(data_graph, annotation)
+                if status not in (EVREPO.coded, None):
+                    continue
+                for _, _, value in data_graph.triples(
+                    (annotation, EVREPO.codedValue, None)
+                ):
+                    if isinstance(value, Literal):
+                        code = str(value).strip().upper()
+                        if code:
+                            countries.add(code)
+        return countries
 
     # -- vocabulary resolution with derived-lookup caching ---------------------
 

--- a/docs/procedures/search.rst
+++ b/docs/procedures/search.rst
@@ -232,3 +232,7 @@ Linked Data
 .. autoattribute:: app.domain.references.models.es.ReferenceSearchFieldsMixin.linked_data_evaluated_properties
     :no-index:
     :annotation: list[str]
+
+.. autoattribute:: app.domain.references.models.es.ReferenceSearchFieldsMixin.linked_data_countries
+    :no-index:
+    :annotation: list[str]

--- a/tests/unit/domain/references/services/test_linked_data_projection_service.py
+++ b/tests/unit/domain/references/services/test_linked_data_projection_service.py
@@ -250,7 +250,11 @@ class TestLinkedDataProjectionService:
         assert result.countries == {"KE"}
 
     @pytest.mark.asyncio
-    async def test_excludes_not_reported_country(self, projector):
+    @pytest.mark.parametrize(
+        "status",
+        ["evrepo:notReported", "evrepo:notApplicable"],
+    )
+    async def test_excludes_uncoded_country(self, projector, status):
         data = {
             "@context": "https://vocab.esea.education/context/v1.jsonld",
             "@type": "Investigation",
@@ -266,7 +270,7 @@ class TestLinkedDataProjectionService:
                                     "@type": "xsd:string",
                                     "@value": "KE",
                                 },
-                                "status": "evrepo:notReported",
+                                "status": status,
                             },
                         ],
                     },

--- a/tests/unit/domain/references/services/test_linked_data_projection_service.py
+++ b/tests/unit/domain/references/services/test_linked_data_projection_service.py
@@ -172,6 +172,149 @@ class TestLinkedDataProjectionService:
         assert result.concepts == set()
         assert result.labels == set()
         assert result.evaluated_properties == set()
+        assert result.countries == set()
+
+    @pytest.mark.asyncio
+    async def test_extracts_country_codes(self, projector):
+        data = {
+            "@context": "https://vocab.esea.education/context/v1.jsonld",
+            "@type": "Investigation",
+            "hasFinding": [
+                {
+                    "@type": "Finding",
+                    "hasContext": {
+                        "@type": "Context",
+                        "country": [
+                            {
+                                "@type": "StringCodingAnnotation",
+                                "codedValue": {
+                                    "@type": "xsd:string",
+                                    "@value": "KE",
+                                },
+                                "status": "evrepo:coded",
+                                "supportingText": "Kenya",
+                            },
+                            {
+                                "@type": "StringCodingAnnotation",
+                                "codedValue": {
+                                    "@type": "xsd:string",
+                                    "@value": "GH",
+                                },
+                                "status": "evrepo:coded",
+                            },
+                        ],
+                    },
+                }
+            ],
+        }
+        enhancement = LinkedDataEnhancement(
+            context_uri="https://vocab.esea.education/context/v1.jsonld",
+            vocabulary_uri="https://vocab.esea.education/vocabulary/v1",
+            data=data,
+        )
+        result = await projector.project(enhancement)
+
+        assert result.countries == {"KE", "GH"}
+
+    @pytest.mark.asyncio
+    async def test_normalises_country_codes_to_uppercase(self, projector):
+        data = {
+            "@context": "https://vocab.esea.education/context/v1.jsonld",
+            "@type": "Investigation",
+            "hasFinding": [
+                {
+                    "@type": "Finding",
+                    "hasContext": {
+                        "@type": "Context",
+                        "country": [
+                            {
+                                "@type": "StringCodingAnnotation",
+                                "codedValue": {
+                                    "@type": "xsd:string",
+                                    "@value": "ke",
+                                },
+                                "status": "evrepo:coded",
+                            },
+                        ],
+                    },
+                }
+            ],
+        }
+        enhancement = LinkedDataEnhancement(
+            context_uri="https://vocab.esea.education/context/v1.jsonld",
+            vocabulary_uri="https://vocab.esea.education/vocabulary/v1",
+            data=data,
+        )
+        result = await projector.project(enhancement)
+
+        assert result.countries == {"KE"}
+
+    @pytest.mark.asyncio
+    async def test_excludes_not_reported_country(self, projector):
+        data = {
+            "@context": "https://vocab.esea.education/context/v1.jsonld",
+            "@type": "Investigation",
+            "hasFinding": [
+                {
+                    "@type": "Finding",
+                    "hasContext": {
+                        "@type": "Context",
+                        "country": [
+                            {
+                                "@type": "StringCodingAnnotation",
+                                "codedValue": {
+                                    "@type": "xsd:string",
+                                    "@value": "KE",
+                                },
+                                "status": "evrepo:notReported",
+                            },
+                        ],
+                    },
+                }
+            ],
+        }
+        enhancement = LinkedDataEnhancement(
+            context_uri="https://vocab.esea.education/context/v1.jsonld",
+            vocabulary_uri="https://vocab.esea.education/vocabulary/v1",
+            data=data,
+        )
+        result = await projector.project(enhancement)
+
+        assert result.countries == set()
+
+    @pytest.mark.asyncio
+    async def test_ignores_other_string_coding_annotations(self, projector):
+        """Only `country` properties are projected, not every StringCodingAnnotation."""
+        data = {
+            "@context": "https://vocab.esea.education/context/v1.jsonld",
+            "@type": "Investigation",
+            "hasFinding": [
+                {
+                    "@type": "Finding",
+                    "hasContext": {
+                        "@type": "Context",
+                        "participants": [
+                            {
+                                "@type": "StringCodingAnnotation",
+                                "codedValue": {
+                                    "@type": "xsd:string",
+                                    "@value": "Students",
+                                },
+                                "status": "evrepo:coded",
+                            },
+                        ],
+                    },
+                }
+            ],
+        }
+        enhancement = LinkedDataEnhancement(
+            context_uri="https://vocab.esea.education/context/v1.jsonld",
+            vocabulary_uri="https://vocab.esea.education/vocabulary/v1",
+            data=data,
+        )
+        result = await projector.project(enhancement)
+
+        assert result.countries == set()
 
     @pytest.mark.asyncio
     async def test_scheme_to_property_mapping(self, projector):

--- a/tests/unit/persistence/es/test_repository.py
+++ b/tests/unit/persistence/es/test_repository.py
@@ -374,6 +374,7 @@ async def linked_data_ref(
             "https://vocab.esea.education/documentType",
             "https://vocab.esea.education/educationLevel",
         ],
+        linked_data_countries=["KE", "GH"],
     )
     await doc.save(using=es_client)
     await es_client.indices.refresh(index=ReferenceDocument.Index.name)
@@ -403,6 +404,10 @@ ESEA_PROP = "https://vocab.esea.education/documentType"
         ),
         # Field existence
         ("_exists_:linked_data_concepts", True),
+        # Country code match (Keyword field)
+        ("linked_data_countries:KE", True),
+        ("linked_data_countries:GH", True),
+        ("linked_data_countries:ZZ", False),
     ],
 )
 async def test_linked_data_field_search(


### PR DESCRIPTION
Closes #696.

## Summary

- Adds `LinkedDataProjection.countries` and a new `linked_data_countries` Keyword field on the reference index, projected from `esea:country` StringCodingAnnotations.
- Registers country properties in a `_COUNTRY_PROPERTIES` set so future vocabularies opt in by URI.
- ISO codes normalised to uppercase on write; `notReported` / `notApplicable` country annotations excluded.

## Test plan

- [x] `uv run pytest tests/unit/domain/references/services/test_linked_data_projection_service.py` — 13 pass, including 4 new country tests (extraction, uppercase normalisation, `notReported` exclusion, and a regression that other StringCodingAnnotations like `participants` are not projected).
- [x] `uv run pytest tests/unit/persistence/es/test_repository.py::test_linked_data_field_search` against local ES — 11 pass, including 3 new country search cases (`KE`, `GH`, negative `ZZ`).
- [ ] After merge: run the ES mapping migration and reproject the Jacobs-domain corpus to populate `linked_data_countries` on existing documents.