### PR TITLE
Fix linked_data_concepts missing EffectEstimate concept properties

### DIFF
--- a/app/domain/references/services/linked_data_projection_service.py
+++ b/app/domain/references/services/linked_data_projection_service.py
@@ -28,7 +28,7 @@ class _LoadedVocabulary:
     concept_labels: dict[str, str]
     concept_schemes: dict[str, str]
     scheme_to_property: dict[str, str]
-    unwrapped_concept_properties: dict[str, str]
+    unwrapped_concept_properties: set[str]
 
 
 class LinkedDataProjectionService:
@@ -90,7 +90,7 @@ class LinkedDataProjectionService:
                 if prop_uri is not None:
                     evaluated_properties.add(prop_uri)
 
-        _project_unwrapped_concept_properties(
+        self._project_unwrapped_concept_properties(
             data_graph, vocab, concepts, labels, evaluated_properties
         )
 
@@ -119,6 +119,34 @@ class LinkedDataProjectionService:
                         if code:
                             countries.add(code)
         return countries
+
+    @staticmethod
+    def _project_unwrapped_concept_properties(
+        data_graph: Graph,
+        vocab: _LoadedVocabulary,
+        concepts: set[str],
+        labels: set[str],
+        evaluated_properties: set[str],
+    ) -> None:
+        """
+        Project values discovered by ``_build_unwrapped_concept_properties``.
+
+        Without a CodingAnnotation wrapper there is no provenance, so any present
+        value is treated as coded.
+        """
+        for prop_uri_str in vocab.unwrapped_concept_properties:
+            predicate = URIRef(prop_uri_str)
+            for _, _, value in data_graph.triples((None, predicate, None)):
+                if not isinstance(value, URIRef):
+                    continue
+                if (value, RDF.type, SKOS.Concept) not in vocab.graph:
+                    continue
+                concept_uri = str(value)
+                concepts.add(concept_uri)
+                label = vocab.concept_labels.get(concept_uri)
+                if label is not None:
+                    labels.add(label)
+                evaluated_properties.add(prop_uri_str)
 
     # -- vocabulary resolution with derived-lookup caching ---------------------
 
@@ -194,9 +222,9 @@ class LinkedDataProjectionService:
         return {str(row.scheme): str(row.prop) for row in results}
 
     @staticmethod
-    def _build_unwrapped_concept_properties(graph: Graph) -> dict[str, str]:
+    def _build_unwrapped_concept_properties(graph: Graph) -> set[str]:
         """
-        Build property URI -> scheme URI mapping for unwrapped concept references.
+        Build a set of property URIs for unwrapped concept references.
 
         "Unwrapped" describes the data shape: the value is a direct concept
         reference at the property's slot, with no CodingAnnotation envelope.
@@ -206,49 +234,20 @@ class LinkedDataProjectionService:
         """
         results = graph.query(
             """
-            SELECT DISTINCT ?prop ?scheme WHERE {
+            SELECT DISTINCT ?prop WHERE {
                 ?prop a owl:ObjectProperty ;
                       rdfs:range ?range .
                 {
                     ?range a skos:ConceptScheme .
-                    BIND(?range AS ?scheme)
                 }
                 UNION
                 {
                     ?range rdfs:subClassOf+ skos:Concept .
                     FILTER(?range != skos:Concept)
                     ?concept a ?range ;
-                             skos:inScheme ?scheme .
+                             skos:inScheme [] .
                 }
             }
             """
         )
-        return {str(row.prop): str(row.scheme) for row in results}
-
-
-def _project_unwrapped_concept_properties(
-    data_graph: Graph,
-    vocab: _LoadedVocabulary,
-    concepts: set[str],
-    labels: set[str],
-    evaluated_properties: set[str],
-) -> None:
-    """
-    Project values for properties discovered by ``_build_unwrapped_concept_properties``.
-
-    Without a CodingAnnotation wrapper there is no provenance, so any present
-    value is treated as coded.
-    """
-    for prop_uri_str in vocab.unwrapped_concept_properties:
-        predicate = URIRef(prop_uri_str)
-        for _, _, value in data_graph.triples((None, predicate, None)):
-            if not isinstance(value, URIRef):
-                continue
-            if (value, RDF.type, SKOS.Concept) not in vocab.graph:
-                continue
-            concept_uri = str(value)
-            concepts.add(concept_uri)
-            label = vocab.concept_labels.get(concept_uri)
-            if label is not None:
-                labels.add(label)
-            evaluated_properties.add(prop_uri_str)
+        return {str(row.prop) for row in results}

--- a/app/domain/references/services/linked_data_projection_service.py
+++ b/app/domain/references/services/linked_data_projection_service.py
@@ -28,6 +28,7 @@ class _LoadedVocabulary:
     concept_labels: dict[str, str]
     concept_schemes: dict[str, str]
     scheme_to_property: dict[str, str]
+    unwrapped_concept_properties: dict[str, str]
 
 
 class LinkedDataProjectionService:
@@ -89,6 +90,10 @@ class LinkedDataProjectionService:
                 if prop_uri is not None:
                     evaluated_properties.add(prop_uri)
 
+        _project_unwrapped_concept_properties(
+            data_graph, vocab, concepts, labels, evaluated_properties
+        )
+
         countries = self._extract_countries(data_graph)
         return LinkedDataProjection(
             concepts=concepts,
@@ -126,6 +131,9 @@ class LinkedDataProjectionService:
                 concept_labels=self._build_concept_labels(graph),
                 concept_schemes=self._build_concept_schemes(graph),
                 scheme_to_property=self._build_scheme_to_property(graph),
+                unwrapped_concept_properties=self._build_unwrapped_concept_properties(
+                    graph
+                ),
             )
         return self._vocabularies[uri]
 
@@ -184,3 +192,63 @@ class LinkedDataProjectionService:
             """
         )
         return {str(row.scheme): str(row.prop) for row in results}
+
+    @staticmethod
+    def _build_unwrapped_concept_properties(graph: Graph) -> dict[str, str]:
+        """
+        Build property URI -> scheme URI mapping for unwrapped concept references.
+
+        "Unwrapped" describes the data shape: the value is a direct concept
+        reference at the property's slot, with no CodingAnnotation envelope.
+        We discover these properties via their concept-typed range: either
+        ``skos:ConceptScheme`` directly, or a class ``subClassOf skos:Concept``
+        joined to a scheme via concept instances.
+        """
+        results = graph.query(
+            """
+            SELECT DISTINCT ?prop ?scheme WHERE {
+                ?prop a owl:ObjectProperty ;
+                      rdfs:range ?range .
+                {
+                    ?range a skos:ConceptScheme .
+                    BIND(?range AS ?scheme)
+                }
+                UNION
+                {
+                    ?range rdfs:subClassOf+ skos:Concept .
+                    FILTER(?range != skos:Concept)
+                    ?concept a ?range ;
+                             skos:inScheme ?scheme .
+                }
+            }
+            """
+        )
+        return {str(row.prop): str(row.scheme) for row in results}
+
+
+def _project_unwrapped_concept_properties(
+    data_graph: Graph,
+    vocab: _LoadedVocabulary,
+    concepts: set[str],
+    labels: set[str],
+    evaluated_properties: set[str],
+) -> None:
+    """
+    Project values for properties discovered by ``_build_unwrapped_concept_properties``.
+
+    Without a CodingAnnotation wrapper there is no provenance, so any present
+    value is treated as coded.
+    """
+    for prop_uri_str in vocab.unwrapped_concept_properties:
+        predicate = URIRef(prop_uri_str)
+        for _, _, value in data_graph.triples((None, predicate, None)):
+            if not isinstance(value, URIRef):
+                continue
+            if (value, RDF.type, SKOS.Concept) not in vocab.graph:
+                continue
+            concept_uri = str(value)
+            concepts.add(concept_uri)
+            label = vocab.concept_labels.get(concept_uri)
+            if label is not None:
+                labels.add(label)
+            evaluated_properties.add(prop_uri_str)

--- a/tests/unit/domain/references/services/test_linked_data_projection_service.py
+++ b/tests/unit/domain/references/services/test_linked_data_projection_service.py
@@ -20,8 +20,11 @@ from app.domain.references.services.world_bank_regions import (
 from app.external.vocabulary.client import VocabularyArtifactClient
 
 ESEA_NS = "https://vocab.esea.education/"
+EVREPO_NS = "https://vocab.evidence-repository.org/"
 
 _STATIC_VOCAB_DIR = get_settings().project_root / "app" / "static" / "vocab" / "esea"
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
 @pytest.fixture
@@ -37,7 +40,23 @@ def projector() -> LinkedDataProjectionService:
     return LinkedDataProjectionService(client)
 
 
-FIXTURES_DIR = Path(__file__).parent / "fixtures"
+@pytest.fixture
+def projector_with_evrepo() -> LinkedDataProjectionService:
+    """Projector whose vocab graph also declares the evrepo core ontology.
+
+    Matches deployed reality: the ESEA project's published vocabulary embeds
+    the evrepo core concepts (EffectSizeMetricScheme, EstimateSourceScheme).
+    """
+    vocab_graph = Graph()
+    vocab_graph.parse(_STATIC_VOCAB_DIR / "esea-vocab.ttl", format="turtle")
+    vocab_graph.parse(FIXTURES_DIR / "evrepo-core.ttl", format="turtle")
+    with (_STATIC_VOCAB_DIR / "esea-context.jsonld").open() as f:
+        context = json.load(f)
+
+    client = MagicMock(spec=VocabularyArtifactClient)
+    client.get_vocabulary = AsyncMock(return_value=vocab_graph)
+    client.get_context = AsyncMock(return_value=context)
+    return LinkedDataProjectionService(client)
 
 
 @pytest.fixture
@@ -433,3 +452,103 @@ class TestLinkedDataProjectionService:
         assert mapping[f"{ESEA_NS}EducationLevelScheme"] == (f"{ESEA_NS}educationLevel")
         assert mapping[f"{ESEA_NS}EducationThemeScheme"] == (f"{ESEA_NS}educationTheme")
         assert mapping[f"{ESEA_NS}OutcomeScheme"] == f"{ESEA_NS}outcome"
+
+    @pytest.mark.asyncio
+    async def test_unwrapped_concept_properties_discovery(self, projector_with_evrepo):
+        """SPARQL discovers ObjectProperties whose range is a ConceptScheme.
+
+        These are the unwrapped concept references handled by the second-pass
+        walk (no CodingAnnotation envelope). With the evrepo core ontology
+        loaded, this returns exactly the two EffectEstimate concept properties.
+        """
+        vocab_uri = "https://vocab.esea.education/vocabulary/v1"
+        vocab = await projector_with_evrepo._get_vocabulary(vocab_uri)  # noqa: SLF001
+        mapping = vocab.unwrapped_concept_properties
+
+        assert mapping == {
+            f"{EVREPO_NS}effectSizeMetric": f"{EVREPO_NS}EffectSizeMetricScheme",
+            f"{EVREPO_NS}estimateSource": f"{EVREPO_NS}EstimateSourceScheme",
+        }
+
+    def test_unwrapped_concept_properties_discovers_direct_scheme_range(self):
+        """Property whose range IS skos:ConceptScheme (production vocab shape).
+
+        The shared evrepo-core.ttl fixture uses range = ConceptClass (a class
+        subClassOf skos:Concept), which exercises one UNION branch. This
+        synthetic graph covers the other branch.
+        """
+        graph = Graph()
+        graph.parse(
+            data="""
+            @prefix owl: <http://www.w3.org/2002/07/owl#> .
+            @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+            @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+            @prefix ex: <https://example.org/> .
+
+            ex:myConceptProperty a owl:ObjectProperty ;
+                rdfs:range ex:MyScheme .
+            ex:MyScheme a skos:ConceptScheme .
+            """,
+            format="turtle",
+        )
+
+        mapping = LinkedDataProjectionService._build_unwrapped_concept_properties(  # noqa: SLF001
+            graph
+        )
+
+        assert mapping == {
+            "https://example.org/myConceptProperty": "https://example.org/MyScheme",
+        }
+
+    @pytest.mark.asyncio
+    async def test_extracts_effect_size_metric_uri(
+        self, projector_with_evrepo, enhancement
+    ):
+        """EffectEstimate.effectSizeMetric is an unwrapped concept reference
+        (no CodingAnnotation wrapper, no codedValue triple). It must still be
+        projected when the vocab declares the URI as a skos:Concept."""
+        result = await projector_with_evrepo.project(enhancement)
+
+        assert f"{EVREPO_NS}hedgesG" in result.concepts
+        assert f"{EVREPO_NS}effectSizeMetric" in result.evaluated_properties
+
+    @pytest.mark.asyncio
+    async def test_extracts_both_effect_estimate_concept_properties(
+        self, projector_with_evrepo
+    ):
+        """Both unwrapped concept properties on EffectEstimate (effectSizeMetric
+        and estimateSource) must project. The realistic fixture omits
+        estimateSource (the EEF mapping robot doesn't emit it), so cover that
+        path with a synthetic graph."""
+        data = {
+            "@context": "https://vocab.esea.education/context/v1.jsonld",
+            "@type": "Investigation",
+            "hasInvestigation": [
+                {
+                    "@type": "Investigation",
+                    "hasFinding": [
+                        {
+                            "@type": "Finding",
+                            "hasEffectEstimate": [
+                                {
+                                    "@type": "EffectEstimate",
+                                    "effectSizeMetric": "evrepo:hedgesG",
+                                    "estimateSource": "evrepo:computedFromStats",
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+        enhancement = LinkedDataEnhancement(
+            context_uri="https://vocab.esea.education/context/v1.jsonld",
+            vocabulary_uri="https://vocab.esea.education/vocabulary/v1",
+            data=data,
+        )
+        result = await projector_with_evrepo.project(enhancement)
+
+        assert f"{EVREPO_NS}hedgesG" in result.concepts
+        assert f"{EVREPO_NS}computedFromStats" in result.concepts
+        assert f"{EVREPO_NS}effectSizeMetric" in result.evaluated_properties
+        assert f"{EVREPO_NS}estimateSource" in result.evaluated_properties

--- a/tests/unit/domain/references/services/test_linked_data_projection_service.py
+++ b/tests/unit/domain/references/services/test_linked_data_projection_service.py
@@ -463,11 +463,10 @@ class TestLinkedDataProjectionService:
         """
         vocab_uri = "https://vocab.esea.education/vocabulary/v1"
         vocab = await projector_with_evrepo._get_vocabulary(vocab_uri)  # noqa: SLF001
-        mapping = vocab.unwrapped_concept_properties
 
-        assert mapping == {
-            f"{EVREPO_NS}effectSizeMetric": f"{EVREPO_NS}EffectSizeMetricScheme",
-            f"{EVREPO_NS}estimateSource": f"{EVREPO_NS}EstimateSourceScheme",
+        assert vocab.unwrapped_concept_properties == {
+            f"{EVREPO_NS}effectSizeMetric",
+            f"{EVREPO_NS}estimateSource",
         }
 
     def test_unwrapped_concept_properties_discovers_direct_scheme_range(self):
@@ -492,13 +491,11 @@ class TestLinkedDataProjectionService:
             format="turtle",
         )
 
-        mapping = LinkedDataProjectionService._build_unwrapped_concept_properties(  # noqa: SLF001
+        properties = LinkedDataProjectionService._build_unwrapped_concept_properties(  # noqa: SLF001
             graph
         )
 
-        assert mapping == {
-            "https://example.org/myConceptProperty": "https://example.org/MyScheme",
-        }
+        assert properties == {"https://example.org/myConceptProperty"}
 
     @pytest.mark.asyncio
     async def test_extracts_effect_size_metric_uri(


### PR DESCRIPTION
## Summary

The linked-data projection walked only `evrepo:codedValue` triples, so concept references that appear bare on `EffectEstimate` (`effectSizeMetric`, `estimateSource`) never reached the `linked_data_concepts` or `linked_data_evaluated_properties` ES fields. The EffectSizeMetric scheme in the UI FilterDrawer rendered empty as a result.

This adds a second projection pass that picks up unwrapped concept references (concept values that appear at a property's slot without a `CodingAnnotation` envelope around them). The set of properties is discovered from the vocabulary itself via SPARQL (`owl:ObjectProperty` whose `rdfs:range` is, or resolves to, a `skos:ConceptScheme`), rather than encoded as a hardcoded registry. Currently this surfaces `effectSizeMetric` and `estimateSource`; any future unwrapped concept property added to the vocab will project automatically with no DR code change.

## Implementation notes

- The two traversals stay separate. `codedValue` properties carry status/provenance and need scheme-to-property indirection via the OWL restriction graph; unwrapped properties point straight at concepts and the predicate URI IS the scheme property. The asymmetry mirrors a deliberate vocab decision (taxonomy-builder #108): EffectEstimate carries class-level provenance, so its concept refs are unwrapped rather than CodingAnnotation-wrapped.
- The discovery SPARQL uses a UNION to handle two equivalent vocab patterns. Pattern A (production today): `rdfs:range` IS a `skos:ConceptScheme` directly. Pattern B (conventional SKOS, used in the test fixture): `rdfs:range` is a class `subClassOf skos:Concept`, with concept instances joined to the scheme via `skos:inScheme`. Both shapes are legitimate; the query returns the same `(property, scheme)` rows from either.
- Cached as a new `unwrapped_concept_properties: dict[str, str]` field on `_LoadedVocabulary` alongside `scheme_to_property`, populated once per vocab URI on first access (same pattern as the existing lookups).
- `estimateSource` is unpopulated in current EEF-derived LDEs by design (vocabulary-mapping-robot omits it per its issue #577), which is why one of the new tests is synthetic rather than fixture-driven.

## Validation performed

- All 13 projection unit tests pass; 4 new regression tests cover: discovery of concept-typed properties against the deployed-shape vocab fixture, discovery against a synthetic graph using the direct-`ConceptScheme` range pattern, `effectSizeMetric` projection against the existing real-data LDE fixture, and both predicates together via synthetic JSON-LD.
- Ruff and ruff format clean on the touched files.
- evidence-repo-ui FilterDrawer renders the Effect Size Metric scheme with vocab-resolved labels; with `q=music`, selecting 7 metrics narrows results from 64 to 46, confirming the filter parameter wires through ES end-to-end. Per-concept counts are not yet implemented in the UI, so verification used result-count delta rather than facet aggregations.

## Backfill

Existing LDEs need a reindex to populate `linked_data_concepts`. This can ride along with the already-scheduled country/regions reindex.
