### PR TITLE
Add country and World Bank region facet aggregations

### DIFF
--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -1104,6 +1104,10 @@ class FacetType(StrEnum):
 
     CONCEPTS = auto()
     """Counts of references per linked-data concept URI."""
+    COUNTRIES = auto()
+    """Counts of references per ISO 3166-1 alpha-2 country code."""
+    COUNTRY_WB_REGIONS = auto()
+    """Counts of references per World Bank region ID."""
 
 
 class SearchQuery(BaseModel):

--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -259,6 +259,8 @@ class ReferenceESRepository(
 
     _FACET_FIELDS: ClassVar[dict[FacetType, str]] = {
         FacetType.CONCEPTS: "linked_data_concepts",
+        FacetType.COUNTRIES: "linked_data_countries",
+        FacetType.COUNTRY_WB_REGIONS: "linked_data_country_wb_regions",
     }
     """Mapping from a facet type to the ES field its counts are aggregated on."""
 

--- a/app/domain/references/routes.py
+++ b/app/domain/references/routes.py
@@ -495,8 +495,10 @@ async def search_references(
     description=(
         "Return per-facet counts across the references matching the search.\n\n"
         "Accepts the same filter parameters as `/references/search/`, plus one or "
-        "more `?facet=` values. Only the requested facet types appear in the response."
-        "\n\n"
+        "more `?facet=` values. Counts are available for linked-data concepts "
+        "(`concepts`), ISO 3166-1 alpha-2 country codes (`countries`), and World "
+        "Bank region IDs (`country_wb_regions`). Only the requested facet types "
+        "appear in the response.\n\n"
         "⚠️ **Filters apply to facet counts of the same type.** If you filter on "
         "a concept and request concept counts, the response shows co-occurrence "
         "with your selection - siblings of selected concepts will typically appear "

--- a/app/domain/references/services/anti_corruption_service.py
+++ b/app/domain/references/services/anti_corruption_service.py
@@ -418,6 +418,20 @@ class ReferenceAntiCorruptionService(GenericAntiCorruptionService):
                     )
                     for bucket in buckets
                 ]
+            elif facet is FacetType.COUNTRIES:
+                fields["countries"] = [
+                    destiny_sdk.references.CountryFacetCount(
+                        country=bucket.key, count=bucket.count
+                    )
+                    for bucket in buckets
+                ]
+            elif facet is FacetType.COUNTRY_WB_REGIONS:
+                fields["country_wb_regions"] = [
+                    destiny_sdk.references.CountryWBRegionFacetCount(
+                        country_wb_region=bucket.key, count=bucket.count
+                    )
+                    for bucket in buckets
+                ]
             else:
                 msg = f"facets_to_sdk has no SDK mapping for FacetType.{facet.name}"
                 raise NotImplementedError(msg)

--- a/libs/sdk/pyproject.toml
+++ b/libs/sdk/pyproject.toml
@@ -36,7 +36,7 @@ license = "Apache-2.0"
 name = "destiny_sdk"
 readme = "README.md"
 requires-python = ">=3.12, <4"
-version = "0.12.1"
+version = "0.12.2"
 
 [project.optional-dependencies]
 labs = []

--- a/libs/sdk/src/destiny_sdk/references.py
+++ b/libs/sdk/src/destiny_sdk/references.py
@@ -83,6 +83,10 @@ class FacetType(StrEnum):
 
     CONCEPTS = auto()
     """Counts of references per linked-data concept URI."""
+    COUNTRIES = auto()
+    """Counts of references per ISO 3166-1 alpha-2 country code."""
+    COUNTRY_WB_REGIONS = auto()
+    """Counts of references per World Bank region ID."""
 
 
 class ConceptFacetCount(BaseModel):
@@ -94,12 +98,40 @@ class ConceptFacetCount(BaseModel):
     )
 
 
+class CountryFacetCount(BaseModel):
+    """The count of matching references for a single country."""
+
+    country: str = Field(description="The ISO 3166-1 alpha-2 country code.")
+    count: int = Field(
+        description="Number of matching references tagged with this country.",
+    )
+
+
+class CountryWBRegionFacetCount(BaseModel):
+    """The count of matching references for a single World Bank region."""
+
+    country_wb_region: str = Field(description="The World Bank region ID.")
+    count: int = Field(
+        description="Number of matching references tagged with this region.",
+    )
+
+
 class ReferenceFacetResult(BaseModel):
     """Facet counts for a reference search."""
 
     concepts: list[ConceptFacetCount] | None = Field(
         default=None,
         description="Counts of matching references per linked-data concept URI.",
+    )
+    countries: list[CountryFacetCount] | None = Field(
+        default=None,
+        description=(
+            "Counts of matching references per ISO 3166-1 alpha-2 country code."
+        ),
+    )
+    country_wb_regions: list[CountryWBRegionFacetCount] | None = Field(
+        default=None,
+        description="Counts of matching references per World Bank region ID.",
     )
 
 

--- a/libs/sdk/uv.lock
+++ b/libs/sdk/uv.lock
@@ -257,7 +257,7 @@ wheels = [
 
 [[package]]
 name = "destiny-sdk"
-version = "0.12.1"
+version = "0.12.2"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },

--- a/tests/integration/test_facets.py
+++ b/tests/integration/test_facets.py
@@ -24,6 +24,13 @@ CONCEPT_A = "https://vocab.example.org/A"
 CONCEPT_B = "https://vocab.example.org/B"
 CONCEPT_C = "https://vocab.example.org/C"
 
+# ISO 3166-1 alpha-2 codes and their World Bank region IDs (KE/UG -> SSF, US -> NAC).
+COUNTRY_KE = "KE"
+COUNTRY_UG = "UG"
+COUNTRY_US = "US"
+REGION_SSF = "SSF"
+REGION_NAC = "NAC"
+
 
 @pytest.fixture
 def app() -> FastAPI:
@@ -54,20 +61,22 @@ async def client(
 @pytest.fixture
 async def facet_references(es_client: AsyncElasticsearch) -> None:
     """
-    Index references with known `linked_data_concepts` for facet counting.
+    Index references with known facet fields for counting.
 
     Indexing ReferenceDocument directly (rather than via factories +
     projections) keeps the test focused on the aggregation behaviour.
 
     Layout:
-      - doc 1 (climate): A, B
-      - doc 2 (climate): A
-      - doc 3 (medical): A, C
-      - doc 4 (medical): B
-      - doc 5 (medical): (no concepts)
+      - doc 1 (climate): A, B; KE, UG; SSF
+      - doc 2 (climate): A;    KE;     SSF
+      - doc 3 (medical): A, C; US;     NAC
+      - doc 4 (medical): B;    UG;     SSF
+      - doc 5 (medical): (no facet fields)
 
     Expected concept counts unrestricted: A=3, B=2, C=1
     Expected concept counts for `q=climate`:    A=2, B=1
+    Expected country counts unrestricted: KE=2, UG=2, US=1
+    Expected region counts unrestricted: SSF=3, NAC=1
     """
     docs = [
         ReferenceDocument(
@@ -75,24 +84,32 @@ async def facet_references(es_client: AsyncElasticsearch) -> None:
             visibility=Visibility.PUBLIC,
             title="Climate adaptation strategies",
             linked_data_concepts=[CONCEPT_A, CONCEPT_B],
+            linked_data_countries=[COUNTRY_KE, COUNTRY_UG],
+            linked_data_country_wb_regions=[REGION_SSF],
         ),
         ReferenceDocument(
             meta={"id": uuid7()},
             visibility=Visibility.PUBLIC,
             title="Climate modelling primer",
             linked_data_concepts=[CONCEPT_A],
+            linked_data_countries=[COUNTRY_KE],
+            linked_data_country_wb_regions=[REGION_SSF],
         ),
         ReferenceDocument(
             meta={"id": uuid7()},
             visibility=Visibility.PUBLIC,
             title="Medical imaging review",
             linked_data_concepts=[CONCEPT_A, CONCEPT_C],
+            linked_data_countries=[COUNTRY_US],
+            linked_data_country_wb_regions=[REGION_NAC],
         ),
         ReferenceDocument(
             meta={"id": uuid7()},
             visibility=Visibility.PUBLIC,
             title="Medical diagnostics overview",
             linked_data_concepts=[CONCEPT_B],
+            linked_data_countries=[COUNTRY_UG],
+            linked_data_country_wb_regions=[REGION_SSF],
         ),
         ReferenceDocument(
             meta={"id": uuid7()},
@@ -154,3 +171,78 @@ async def test_concept_facet_no_matches(
     )
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {"concepts": []}
+
+
+async def test_country_facet_counts_unrestricted(
+    client: AsyncClient,
+    facet_references: None,  # noqa: ARG001
+) -> None:
+    """Country buckets are keyed by ISO-2 code with descending counts."""
+    response = await client.get(
+        "/v1/references/search/facets/",
+        params={"q": "*", "facet": "countries"},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    buckets = response.json()["countries"]
+    # KE and UG tie at 2; only assert US trails them.
+    assert {(b["country"], b["count"]) for b in buckets} == {
+        (COUNTRY_KE, 2),
+        (COUNTRY_UG, 2),
+        (COUNTRY_US, 1),
+    }
+
+
+async def test_region_facet_counts_unrestricted(
+    client: AsyncClient,
+    facet_references: None,  # noqa: ARG001
+) -> None:
+    """World Bank region buckets are keyed by region ID with descending counts."""
+    response = await client.get(
+        "/v1/references/search/facets/",
+        params={"q": "*", "facet": "country_wb_regions"},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["country_wb_regions"] == [
+        {"country_wb_region": REGION_SSF, "count": 3},
+        {"country_wb_region": REGION_NAC, "count": 1},
+    ]
+
+
+async def test_multiple_facets_returned_together(
+    client: AsyncClient,
+    facet_references: None,  # noqa: ARG001
+) -> None:
+    """Requesting several facets returns each requested type and omits the rest."""
+    response = await client.get(
+        "/v1/references/search/facets/",
+        params=[("q", "*"), ("facet", "concepts"), ("facet", "countries")],
+    )
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert set(body) == {"concepts", "countries"}
+    assert "country_wb_regions" not in body
+
+
+async def test_concept_filter_does_not_drop_country_facet(
+    client: AsyncClient,
+    facet_references: None,  # noqa: ARG001
+) -> None:
+    """
+    A concept filter must not drop a co-requested non-concept facet.
+
+    Guards the sibling-aware aggregation path (destiny-repository#714), whose
+    concept handling must still return every other facet it was asked for.
+    """
+    response = await client.get(
+        "/v1/references/search/facets/",
+        params=[
+            ("q", "*"),
+            ("concept", CONCEPT_A),
+            ("facet", "concepts"),
+            ("facet", "countries"),
+        ],
+    )
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert "concepts" in body
+    assert "countries" in body

--- a/tests/routers/test_references.py
+++ b/tests/routers/test_references.py
@@ -1442,6 +1442,46 @@ async def test_search_facets_concepts_happy_path(
     assert list(facets) == [FacetType.CONCEPTS]
 
 
+async def test_search_facets_concepts_and_countries(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concept and country facets are surfaced together under their own keys."""
+    from app.domain.references.models.models import FacetType
+
+    mock_aggregate = AsyncMock(
+        return_value={
+            FacetType.CONCEPTS: [ESFacetBucket(key="http://example.org/c/a", count=7)],
+            FacetType.COUNTRIES: [
+                ESFacetBucket(key="KE", count=3),
+                ESFacetBucket(key="UG", count=1),
+            ],
+        }
+    )
+    monkeypatch.setattr(ReferenceService, "aggregate_facets", mock_aggregate)
+
+    response = await client.get(
+        "/v1/references/search/facets/",
+        params=[
+            ("q", "climate"),
+            ("facet", "concepts"),
+            ("facet", "countries"),
+        ],
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "concepts": [{"concept": "http://example.org/c/a", "count": 7}],
+        "countries": [
+            {"country": "KE", "count": 3},
+            {"country": "UG", "count": 1},
+        ],
+    }
+
+    _, facets = mock_aggregate.call_args.args
+    assert list(facets) == [FacetType.CONCEPTS, FacetType.COUNTRIES]
+
+
 async def test_search_facets_unrequested_keys_omitted(
     client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/uv.lock
+++ b/uv.lock
@@ -690,7 +690,7 @@ test = [
 
 [[package]]
 name = "destiny-sdk"
-version = "0.12.1"
+version = "0.12.2"
 source = { editable = "libs/sdk" }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
Closes #710

Adds `countries` and `country_wb_regions` facet types to `/references/search/facets/`, counting the already-indexed `linked_data_countries` (ISO-2) and `linked_data_country_wb_regions` (WB region IDs) keyword fields. Mirrors the existing `concepts` facet — naive term aggregation, no new query parameters.

WB region aggregation was out of scope in the issue but folded in here since it's the identical wiring and easier to review together. The structured country *search* parameter remains split out into a separate ticket.

### Note on #714
This is the naive aggregation. It overlaps the facet methods #714 reworks, so the second of the two to land rebases. `test_concept_filter_does_not_drop_country_facet` guards against #714's concept sibling-aware path silently dropping a co-requested country facet.