### PR TITLE
Add second pass to reindex duplicates in bulk sync

### DIFF
--- a/app/domain/references/services/synchronizer_service.py
+++ b/app/domain/references/services/synchronizer_service.py
@@ -116,17 +116,37 @@ class ReferenceSynchronizer(GenericSynchronizer[Reference]):
             AsyncGenerator[ReferenceSearchProjection, None]
         ):
             """Generate references for indexing."""
-            for reference_id_chunk in list_chunker(
-                ids,
-                chunk_size,
-            ):
+            indexed_ids: set[UUID] = set()
+            redirect_ids: set[UUID] = set()
+
+            for reference_id_chunk in list_chunker(ids, chunk_size):
                 references = await self.sql_uow.references.get_by_pks(
                     reference_id_chunk,
                     preload=self._required_preloads,
                 )
                 for reference in references:
                     if reference.is_canonical_like:
+                        indexed_ids.add(reference.id)
                         yield await self._to_indexable(reference)
+                    elif reference.duplicate_decision and (
+                        canonical_id := (
+                            reference.duplicate_decision.canonical_reference_id
+                        )
+                    ):
+                        redirect_ids.add(canonical_id)
+
+            # Re-index the canonicals of any duplicates we saw, skipping any that were
+            # already indexed directly in the pass above.
+            for canonical_id_chunk in list_chunker(
+                list(redirect_ids - indexed_ids), chunk_size
+            ):
+                canonicals = await self.sql_uow.references.get_by_pks(
+                    canonical_id_chunk,
+                    preload=self._required_preloads,
+                )
+                for canonical in canonicals:
+                    if canonical.is_canonical_like:
+                        yield await self._to_indexable(canonical)
 
         return await self.es_uow.references.add_bulk(reference_generator())
 

--- a/app/domain/references/services/synchronizer_service.py
+++ b/app/domain/references/services/synchronizer_service.py
@@ -116,7 +116,6 @@ class ReferenceSynchronizer(GenericSynchronizer[Reference]):
             AsyncGenerator[ReferenceSearchProjection, None]
         ):
             """Generate references for indexing."""
-            indexed_ids: set[UUID] = set()
             redirect_ids: set[UUID] = set()
 
             for reference_id_chunk in list_chunker(ids, chunk_size):
@@ -126,7 +125,6 @@ class ReferenceSynchronizer(GenericSynchronizer[Reference]):
                 )
                 for reference in references:
                     if reference.is_canonical_like:
-                        indexed_ids.add(reference.id)
                         yield await self._to_indexable(reference)
                     elif reference.duplicate_decision and (
                         canonical_id := (
@@ -135,11 +133,8 @@ class ReferenceSynchronizer(GenericSynchronizer[Reference]):
                     ):
                         redirect_ids.add(canonical_id)
 
-            # Re-index the canonicals of any duplicates we saw, skipping any that were
-            # already indexed directly in the pass above.
-            for canonical_id_chunk in list_chunker(
-                list(redirect_ids - indexed_ids), chunk_size
-            ):
+            # Re-index the canonicals of any duplicates we saw.
+            for canonical_id_chunk in list_chunker(list(redirect_ids), chunk_size):
                 canonicals = await self.sql_uow.references.get_by_pks(
                     canonical_id_chunk,
                     preload=self._required_preloads,

--- a/tests/integration/test_es_repair.py
+++ b/tests/integration/test_es_repair.py
@@ -18,7 +18,7 @@ from app.api.exception_handlers import (
 from app.core.config import Environment
 from app.core.exceptions import InvalidPayloadError, NotFoundError
 from app.domain.references import tasks as reference_tasks
-from app.domain.references.models.models import Visibility
+from app.domain.references.models.models import DuplicateDetermination, Visibility
 from app.domain.references.models.sql import (
     Enhancement as SQLEnhancement,
 )
@@ -27,6 +27,9 @@ from app.domain.references.models.sql import (
 )
 from app.domain.references.models.sql import (
     Reference as SQLReference,
+)
+from app.domain.references.models.sql import (
+    ReferenceDuplicateDecision as SQLReferenceDuplicateDecision,
 )
 from app.domain.references.models.sql import (
     RobotAutomation as SQLRobotAutomation,
@@ -38,6 +41,7 @@ from app.system import routes as system_routes
 from app.tasks import broker
 from tests.factories import (
     AnnotationEnhancementFactory,
+    BibliographicMetadataEnhancementFactory,
     DOIIdentifierFactory,
     EnhancementFactory,
     LinkedExternalIdentifierFactory,
@@ -545,6 +549,80 @@ async def test_repair_reference_index_subset_indexes_only_supplied_ids(
     assert indexed_ids == {str(rid) for rid in targeted_ids}
     for rid in untargeted_ids:
         assert str(rid) not in indexed_ids
+
+
+async def test_repair_subset_reindexes_canonical_when_duplicate_supplied(
+    client: AsyncClient,
+    es_client: AsyncElasticsearch,
+    session: AsyncSession,
+) -> None:
+    """An enhancement on a duplicate surfaces on its canonical's ES document."""
+    index_manager = system_routes.reference_index_manager(es_client)
+    await index_manager.initialize_index()
+    index_name = index_manager.alias_name
+
+    canonical_id = uuid7()
+    duplicate_id = uuid7()
+    session.add(SQLReference(id=canonical_id, visibility=Visibility.PUBLIC))
+    session.add(SQLReference(id=duplicate_id, visibility=Visibility.PUBLIC))
+    session.add(
+        SQLReferenceDuplicateDecision(
+            id=uuid7(),
+            reference_id=canonical_id,
+            active_decision=True,
+            duplicate_determination=DuplicateDetermination.CANONICAL,
+            candidate_canonical_ids=[],
+        )
+    )
+    session.add(
+        SQLReferenceDuplicateDecision(
+            id=uuid7(),
+            reference_id=duplicate_id,
+            active_decision=True,
+            duplicate_determination=DuplicateDetermination.DUPLICATE,
+            canonical_reference_id=canonical_id,
+            candidate_canonical_ids=[],
+        )
+    )
+
+    # A bibliographic enhancement that exists *only* on the duplicate. The
+    # canonical has no enhancements of its own, so its deduplicated projection
+    # must absorb this title from the duplicate.
+    duplicate_title = "A Distinctive Title Only On The Duplicate"
+    session.add(
+        SQLEnhancement.from_domain(
+            EnhancementFactory.build(
+                reference_id=duplicate_id,
+                source="duplicate_source",
+                content=BibliographicMetadataEnhancementFactory.build(
+                    title=duplicate_title
+                ),
+            )
+        )
+    )
+    await session.commit()
+
+    response = await client.post(
+        f"/system/indices/{index_name}/repair/",
+        json={"document_ids": [str(duplicate_id)]},
+    )
+    assert response.status_code == status.HTTP_202_ACCEPTED
+
+    await wait_for_all_tasks()
+    await es_client.indices.refresh(index=index_name)
+
+    # The duplicate itself is never indexed.
+    duplicate_hits = await es_client.search(
+        index=index_name, body={"query": {"term": {"_id": str(duplicate_id)}}}
+    )
+    assert duplicate_hits["hits"]["total"]["value"] == 0
+
+    # The canonical is indexed and carries the duplicate's title.
+    canonical_hits = await es_client.search(
+        index=index_name, body={"query": {"term": {"_id": str(canonical_id)}}}
+    )
+    assert canonical_hits["hits"]["total"]["value"] == 1
+    assert canonical_hits["hits"]["hits"][0]["_source"]["title"] == duplicate_title
 
 
 async def test_repair_subset_rejects_unsupported_index(

--- a/tests/unit/domain/references/services/test_synchronizer_service.py
+++ b/tests/unit/domain/references/services/test_synchronizer_service.py
@@ -1,0 +1,132 @@
+"""Unit tests for the reference synchronizer service."""
+
+from collections.abc import AsyncGenerator
+from typing import cast
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid7
+
+import pytest
+
+from app.domain.references.models.models import (
+    DuplicateDetermination,
+    Reference,
+    ReferenceDuplicateDecision,
+)
+from app.domain.references.services.synchronizer_service import ReferenceSynchronizer
+
+
+def _canonical(reference_id: UUID | None = None) -> Reference:
+    """A canonical-like reference."""
+    reference_id = reference_id or uuid7()
+    return Reference(
+        id=reference_id,
+        duplicate_decision=ReferenceDuplicateDecision(
+            reference_id=reference_id,
+            duplicate_determination=DuplicateDetermination.CANONICAL,
+            active_decision=True,
+        ),
+    )
+
+
+def _duplicate(canonical_id: UUID, reference_id: UUID | None = None) -> Reference:
+    """A determined duplicate pointing at ``canonical_id``."""
+    reference_id = reference_id or uuid7()
+    return Reference(
+        id=reference_id,
+        duplicate_decision=ReferenceDuplicateDecision(
+            reference_id=reference_id,
+            duplicate_determination=DuplicateDetermination.DUPLICATE,
+            canonical_reference_id=canonical_id,
+            active_decision=True,
+        ),
+    )
+
+
+@pytest.fixture
+def synchronizer() -> ReferenceSynchronizer:
+    """A synchronizer with mocked units of work and a stubbed projection."""
+    sync = ReferenceSynchronizer(sql_uow=AsyncMock(), es_uow=AsyncMock())
+    # Project to the reference's id so we can assert which references were indexed.
+    sync._to_indexable = AsyncMock(side_effect=lambda ref: ref.id)  # type: ignore[method-assign] # noqa: SLF001
+    return sync
+
+
+async def _drain(synchronizer: ReferenceSynchronizer) -> list[UUID]:
+    """Run add_bulk against the generator and return what was indexed."""
+    indexed: list[UUID] = []
+
+    async def add_bulk(gen: AsyncGenerator) -> int:
+        indexed.extend([item async for item in gen])
+        return len(indexed)
+
+    cast(AsyncMock, synchronizer.es_uow.references.add_bulk).side_effect = add_bulk
+    return indexed
+
+
+def _serve(synchronizer: ReferenceSynchronizer, *references: Reference) -> None:
+    """Make get_by_pks return whichever of ``references`` are requested."""
+    by_id = {ref.id: ref for ref in references}
+
+    async def get_by_pks(
+        pks: list[UUID],
+        preload: object = None,  # noqa: ARG001
+    ) -> list[Reference]:
+        return [by_id[pk] for pk in pks if pk in by_id]
+
+    cast(AsyncMock, synchronizer.sql_uow.references.get_by_pks).side_effect = get_by_pks
+
+
+async def test_canonicals_indexed_directly(
+    synchronizer: ReferenceSynchronizer,
+) -> None:
+    """Canonical-like references are indexed as themselves."""
+    canonical = _canonical()
+    _serve(synchronizer, canonical)
+    indexed = await _drain(synchronizer)
+
+    count = await synchronizer.bulk_sql_to_es([canonical.id])
+
+    assert indexed == [canonical.id]
+    assert count == 1
+
+
+async def test_duplicate_redirects_to_canonical(
+    synchronizer: ReferenceSynchronizer,
+) -> None:
+    """A passed-in duplicate causes its canonical to be re-indexed instead."""
+    canonical = _canonical()
+    duplicate = _duplicate(canonical.id)
+    _serve(synchronizer, canonical, duplicate)
+    indexed = await _drain(synchronizer)
+
+    await synchronizer.bulk_sql_to_es([duplicate.id])
+
+    assert indexed == [canonical.id]
+
+
+async def test_multiple_duplicates_reindex_canonical_once(
+    synchronizer: ReferenceSynchronizer,
+) -> None:
+    """Several duplicates of one canonical re-index that canonical a single time."""
+    canonical = _canonical()
+    duplicates = [_duplicate(canonical.id) for _ in range(3)]
+    _serve(synchronizer, canonical, *duplicates)
+    indexed = await _drain(synchronizer)
+
+    await synchronizer.bulk_sql_to_es([d.id for d in duplicates])
+
+    assert indexed == [canonical.id]
+
+
+async def test_canonical_not_double_indexed(
+    synchronizer: ReferenceSynchronizer,
+) -> None:
+    """A canonical passed in alongside its duplicate is indexed exactly once."""
+    canonical = _canonical()
+    duplicate = _duplicate(canonical.id)
+    _serve(synchronizer, canonical, duplicate)
+    indexed = await _drain(synchronizer)
+
+    await synchronizer.bulk_sql_to_es([canonical.id, duplicate.id])
+
+    assert indexed == [canonical.id]

--- a/tests/unit/domain/references/services/test_synchronizer_service.py
+++ b/tests/unit/domain/references/services/test_synchronizer_service.py
@@ -116,17 +116,3 @@ async def test_multiple_duplicates_reindex_canonical_once(
     await synchronizer.bulk_sql_to_es([d.id for d in duplicates])
 
     assert indexed == [canonical.id]
-
-
-async def test_canonical_not_double_indexed(
-    synchronizer: ReferenceSynchronizer,
-) -> None:
-    """A canonical passed in alongside its duplicate is indexed exactly once."""
-    canonical = _canonical()
-    duplicate = _duplicate(canonical.id)
-    _serve(synchronizer, canonical, duplicate)
-    indexed = await _drain(synchronizer)
-
-    await synchronizer.bulk_sql_to_es([canonical.id, duplicate.id])
-
-    assert indexed == [canonical.id]


### PR DESCRIPTION
Closes #693 by adding a second pass that reindexes the canonicals of any duplicates requested for reindexing.