### PR TITLE
Add cross-facet endpoint and functionality

### DIFF
--- a/app/api/exception_handlers.py
+++ b/app/api/exception_handlers.py
@@ -156,12 +156,16 @@ async def vocabulary_fetch_exception_handler(
     exception: VocabularyFetchError,
 ) -> APIExceptionResponse:
     """
-    Return bad request response when a vocabulary artifact can't be fetched or parsed.
+    Return a bad-gateway response when a vocabulary artifact can't be fetched.
 
-    The vocabulary host is validated before this point, so the remaining causes
-    (unresolvable/typo'd URI, unparseable document) are user-actionable input errors.
+    The vocabulary host is validated before this point, so the URI targets our own
+    vocab service rather than arbitrary client input. A failure fetching or parsing
+    it is therefore an upstream-dependency problem (service down, transient blip, or
+    a malformed/missing artifact), which a client can't act on — surface it as a
+    5xx so a trickle of these (e.g. a cache-miss window after a deploy) reads as an
+    upstream issue, not a client bug.
     """
     return APIExceptionResponse(
-        status_code=status.HTTP_400_BAD_REQUEST,
+        status_code=status.HTTP_502_BAD_GATEWAY,
         content=APIExceptionContent(detail=exception.detail),
     )

--- a/app/api/exception_handlers.py
+++ b/app/api/exception_handlers.py
@@ -19,6 +19,7 @@ from app.core.exceptions import (
     SDKToDomainError,
     SQLIntegrityError,
     SQLNotFoundError,
+    VocabularyFetchError,
 )
 
 
@@ -144,6 +145,22 @@ async def parse_error_exception_handler(
     exception: ParseError,
 ) -> APIExceptionResponse:
     """Return bad request response when a parsing error occurs."""
+    return APIExceptionResponse(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        content=APIExceptionContent(detail=exception.detail),
+    )
+
+
+async def vocabulary_fetch_exception_handler(
+    _request: Request,
+    exception: VocabularyFetchError,
+) -> APIExceptionResponse:
+    """
+    Return bad request response when a vocabulary artifact can't be fetched or parsed.
+
+    The vocabulary host is validated before this point, so the remaining causes
+    (unresolvable/typo'd URI, unparseable document) are user-actionable input errors.
+    """
     return APIExceptionResponse(
         status_code=status.HTTP_400_BAD_REQUEST,
         content=APIExceptionContent(detail=exception.detail),

--- a/app/api/root.py
+++ b/app/api/root.py
@@ -19,6 +19,7 @@ from app.api.exception_handlers import (
     not_found_exception_handler,
     parse_error_exception_handler,
     sdk_to_domain_exception_handler,
+    vocabulary_fetch_exception_handler,
 )
 from app.api.middleware import LoggerMiddleware
 from app.core.exceptions import (
@@ -29,6 +30,7 @@ from app.core.exceptions import (
     NotFoundError,
     ParseError,
     SDKToDomainError,
+    VocabularyFetchError,
 )
 from app.core.telemetry.fastapi import FastAPITracingMiddleware
 from app.core.telemetry.logger import get_logger
@@ -102,6 +104,7 @@ def register_api(
             ESMalformedDocumentError: es_exception_handler,
             ESQueryError: es_exception_handler,
             ParseError: parse_error_exception_handler,
+            VocabularyFetchError: vocabulary_fetch_exception_handler,
         },
         redoc_url=None,  # Custom definition of redoc below
         openapi_tags=[

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -565,6 +565,18 @@ class Settings(BaseSettings):
         ),
     )
 
+    es_cross_facet_max_cells: int = Field(
+        default=50_000,
+        ge=1,
+        le=65_536,
+        description=(
+            "Maximum cells (row buckets x column buckets) a cross-facet aggregation "
+            "may request. Kept below the Elasticsearch cluster default for "
+            "`search.max_buckets` so a large matrix is refused with a 400 rather than "
+            "aborting the query server-side."
+        ),
+    )
+
     vocabulary_host: str = Field(
         default="evidence-repository.org",
         description=(

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -570,10 +570,11 @@ class Settings(BaseSettings):
         ge=1,
         le=65_536,
         description=(
-            "Maximum cells (row buckets x column buckets) a cross-facet aggregation "
-            "may request. Kept below the Elasticsearch cluster default for "
-            "`search.max_buckets` so a large matrix is refused with a 400 rather than "
-            "aborting the query server-side."
+            "Maximum aggregation buckets a cross-facet matrix may materialise "
+            "(the nested terms agg counts parent buckets too, so for axes sized "
+            "(a, b) this is a + a*b). Kept below the Elasticsearch cluster default "
+            "for `search.max_buckets` so a large matrix is refused with a 400 rather "
+            "than aborting the query server-side."
         ),
     )
 

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -1201,6 +1201,37 @@ class SiblingGroup(BaseModel):
     )
 
 
+class CrossFacetAxis(BaseModel):
+    """One resolved axis of a cross-facet aggregation."""
+
+    model_config = ConfigDict(frozen=True)
+
+    token: str = Field(
+        description="The original axis request string (literal or scheme URI).",
+    )
+    facet_type: FacetType = Field(
+        description="The facet whose field this axis aggregates on.",
+    )
+    include: frozenset[str] | None = Field(
+        description=(
+            "The concept URIs scoping a scheme axis (used as the terms ``include`` "
+            "set). ``None`` for other axes, whose field domain is bounded."
+        ),
+    )
+    size: int = Field(
+        description="The terms ``size`` to request for this axis's bucket count.",
+        gt=0,
+    )
+
+
+class CrossFacetCell(BaseModel):
+    """A single non-zero cell of a cross-facet matrix."""
+
+    row: str = Field(description="The row axis value.")
+    column: str = Field(description="The column axis value.")
+    count: int = Field(description="References matching this row and column together.")
+
+
 class ReferenceSearchResult(BaseModel):
     """Wrapping class for Elasticsearch search results."""
 

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -1227,9 +1227,10 @@ class CrossFacetAxis(BaseModel):
 class CrossFacetCell(BaseModel):
     """A single non-zero cell of a cross-facet matrix."""
 
-    row: str = Field(description="The row axis value.")
-    column: str = Field(description="The column axis value.")
-    count: int = Field(description="References matching this row and column together.")
+    axes: tuple[str, str] = Field(
+        description="The cell's value on each axis, in requested axis order.",
+    )
+    count: int = Field(description="References matching both axis values together.")
 
 
 class ReferenceSearchResult(BaseModel):

--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -452,7 +452,7 @@ class ReferenceESRepository(
 
         # Build search query excluding the facet's own filter so its agg
         # includes sibling counts
-        search = self._aggregation_search(
+        search = self._build_aggregation_search(
             query.query_string,
             self.default_search_fields,
             self._build_filter_clauses(query, exclude_facet=facet),
@@ -569,13 +569,13 @@ class ReferenceESRepository(
         Returns the non-zero cells plus the exact grand total (``track_total_hits`` is
         enabled so the count isn't capped at the result window).
         """
-        search = self._aggregation_search(
+        search = self._build_aggregation_search(
             query.query_string,
             self.default_search_fields,
             self._build_filter_clauses(query),
         ).extra(track_total_hits=True)
-        outer = search.aggs.bucket("rows", "terms", **self._terms_agg_params(row))
-        outer.bucket("columns", "terms", **self._terms_agg_params(column))
+        outer = search.aggs.bucket("rows", "terms", **self._facet_agg_params(row))
+        outer.bucket("columns", "terms", **self._facet_agg_params(column))
 
         response = await self._execute_search(search)
         return (
@@ -586,7 +586,7 @@ class ReferenceESRepository(
             ),
         )
 
-    def _terms_agg_params(self, axis: CrossFacetAxis) -> dict[str, object]:
+    def _facet_agg_params(self, axis: CrossFacetAxis) -> dict[str, object]:
         """``terms`` agg params for an axis: field, size, and (for schemes) include."""
         params: dict[str, object] = {
             "field": self._FACET_FIELDS[axis.facet_type],

--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -560,8 +560,7 @@ class ReferenceESRepository(
     async def aggregate_cross_facet(
         self,
         query: SearchQuery,
-        row: CrossFacetAxis,
-        column: CrossFacetAxis,
+        axes: Sequence[CrossFacetAxis],
     ) -> tuple[list[CrossFacetCell], ESSearchTotal]:
         """
         Cross-tabulate two axes over references matching ``query``.
@@ -569,13 +568,14 @@ class ReferenceESRepository(
         Returns the non-zero cells plus the exact grand total (``track_total_hits`` is
         enabled so the count isn't capped at the result window).
         """
+        axis_0, axis_1 = axes
         search = self._build_aggregation_search(
             query.query_string,
             self.default_search_fields,
             self._build_filter_clauses(query),
         ).extra(track_total_hits=True)
-        outer = search.aggs.bucket("rows", "terms", **self._facet_agg_params(row))
-        outer.bucket("columns", "terms", **self._facet_agg_params(column))
+        outer = search.aggs.bucket("axis_0", "terms", **self._facet_agg_params(axis_0))
+        outer.bucket("axis_1", "terms", **self._facet_agg_params(axis_1))
 
         response = await self._execute_search(search)
         return (
@@ -598,17 +598,16 @@ class ReferenceESRepository(
 
     @staticmethod
     def _parse_cross_facet_cells(response: Response) -> list[CrossFacetCell]:
-        """Flatten nested ``rows > columns`` buckets into deterministic cells."""
+        """Flatten nested ``axis_0 > axis_1`` buckets into deterministic cells."""
         cells = [
             CrossFacetCell(
-                row=str(row_bucket.key),
-                column=str(col_bucket.key),
-                count=col_bucket.doc_count,
+                axes=(str(bucket_0.key), str(bucket_1.key)),
+                count=bucket_1.doc_count,
             )
-            for row_bucket in response.aggregations.rows.buckets
-            for col_bucket in row_bucket.columns.buckets
+            for bucket_0 in response.aggregations.axis_0.buckets
+            for bucket_1 in bucket_0.axis_1.buckets
         ]
-        cells.sort(key=lambda cell: (-cell.count, cell.row, cell.column))
+        cells.sort(key=lambda cell: (-cell.count, cell.axes))
         return cells
 
     @staticmethod

--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -1,7 +1,6 @@
 """Repositories for references and associated models."""
 
 import datetime
-import json
 from abc import ABC
 from collections.abc import Mapping, Sequence
 from typing import ClassVar, Literal
@@ -11,7 +10,6 @@ from elasticsearch import AsyncElasticsearch
 from elasticsearch.dsl import AsyncSearch, Q
 from elasticsearch.dsl.query import Bool, MatchAll, Prefix, Query, Range, Term, Terms
 from elasticsearch.dsl.response import Response
-from elasticsearch.exceptions import BadRequestError
 from opentelemetry import trace
 from sqlalchemy import (
     CompoundSelect,
@@ -28,8 +26,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
 from app.core.config import DedupCandidateScoringConfig, get_settings
-from app.core.exceptions import ESQueryError
-from app.core.telemetry.attributes import Attributes, trace_attribute
 from app.core.telemetry.repository import trace_repository_method
 from app.domain.references.models.es import (
     ReferenceDocument,
@@ -38,6 +34,8 @@ from app.domain.references.models.es import (
 from app.domain.references.models.models import (
     AnnotationFilter,
     CandidateCanonicalSearchFields,
+    CrossFacetAxis,
+    CrossFacetCell,
     DuplicateDetermination,
     FacetType,
     GenericExternalIdentifier,
@@ -106,6 +104,7 @@ from app.persistence.es.persistence import (
     ESFacetBucket,
     ESScoreResult,
     ESSearchResult,
+    ESSearchTotal,
 )
 from app.persistence.es.repository import GenericAsyncESRepository
 from app.persistence.generics import GenericPersistenceType
@@ -453,17 +452,10 @@ class ReferenceESRepository(
 
         # Build search query excluding the facet's own filter so its agg
         # includes sibling counts
-        search = (
-            AsyncSearch(using=self._client, index=self._persistence_cls.Index.name)
-            .extra(size=0)
-            .query(
-                self._compose_query(
-                    query.query_string,
-                    self.default_search_fields,
-                    self._build_filter_clauses(query, exclude_facet=facet),
-                )
-            )
-            .source(includes=[])
+        search = self._aggregation_search(
+            query.query_string,
+            self.default_search_fields,
+            self._build_filter_clauses(query, exclude_facet=facet),
         )
 
         # Attach aggregate groupings
@@ -479,12 +471,7 @@ class ReferenceESRepository(
                 )
             )
 
-        trace_attribute(Attributes.DB_QUERY, json.dumps(search.to_dict()))
-        try:
-            response = await search.execute()
-        except BadRequestError as exc:
-            msg = f"Elasticsearch sibling-aware facet aggregation failed: {exc}."
-            raise ESQueryError(msg) from exc
+        response = await self._execute_search(search)
 
         return self._parse_facet_buckets(response, agg_names)
 
@@ -568,6 +555,61 @@ class ReferenceESRepository(
             for name in agg_names
             for b in response.aggregations[name].inner.buckets
         ]
+
+    @trace_repository_method(tracer)
+    async def aggregate_cross_facet(
+        self,
+        query: SearchQuery,
+        row: CrossFacetAxis,
+        column: CrossFacetAxis,
+    ) -> tuple[list[CrossFacetCell], ESSearchTotal]:
+        """
+        Cross-tabulate two axes over references matching ``query``.
+
+        Returns the non-zero cells plus the exact grand total (``track_total_hits`` is
+        enabled so the count isn't capped at the result window).
+        """
+        search = self._aggregation_search(
+            query.query_string,
+            self.default_search_fields,
+            self._build_filter_clauses(query),
+        ).extra(track_total_hits=True)
+        outer = search.aggs.bucket("rows", "terms", **self._terms_agg_params(row))
+        outer.bucket("columns", "terms", **self._terms_agg_params(column))
+
+        response = await self._execute_search(search)
+        return (
+            self._parse_cross_facet_cells(response),
+            ESSearchTotal(
+                value=response.hits.total.value,  # type: ignore[attr-defined]
+                relation=response.hits.total.relation,  # type: ignore[attr-defined]
+            ),
+        )
+
+    def _terms_agg_params(self, axis: CrossFacetAxis) -> dict[str, object]:
+        """``terms`` agg params for an axis: field, size, and (for schemes) include."""
+        params: dict[str, object] = {
+            "field": self._FACET_FIELDS[axis.facet_type],
+            "size": axis.size,
+        }
+        if axis.include:
+            params["include"] = sorted(axis.include)
+        return params
+
+    @staticmethod
+    def _parse_cross_facet_cells(response: Response) -> list[CrossFacetCell]:
+        """Flatten nested ``rows > columns`` buckets into deterministic cells."""
+        cells = [
+            CrossFacetCell(
+                row=str(row_bucket.key),
+                column=str(col_bucket.key),
+                count=col_bucket.doc_count,
+            )
+            for row_bucket in response.aggregations.rows.buckets
+            for col_bucket in row_bucket.columns.buckets
+        ]
+        cells.sort(key=lambda cell: (-cell.count, cell.row, cell.column))
+        return cells
 
     @staticmethod
     def _build_author_dis_max_query(

--- a/app/domain/references/routes.py
+++ b/app/domain/references/routes.py
@@ -640,6 +640,81 @@ async def count_facets_for_search(
     return anti_corruption_service.facets_to_sdk(buckets_by_facet)
 
 
+@search_router.get(
+    "/cross-facets/",
+    status_code=status.HTTP_200_OK,
+    responses={
+        status.HTTP_400_BAD_REQUEST: {
+            "description": "Bad Query String",
+            "model": APIExceptionContent,
+        }
+    },
+    description=(
+        "Cross-tabulate two axes over the references matching the search, for "
+        "evidence maps. Accepts the same filters as `/references/search/`, plus a "
+        "`row` and `column` axis.\n\n"
+        "When an axis is a scheme  URI, supply `?vocabulary=`.\n\n"
+        "**Counting.** Each returned cell is a strict intersection: references "
+        "matching its row value, its column value, all panel filters and the query "
+        "string. Only non-zero cells are returned.\n\n"
+        "Cells may sum to more than `total` because a reference can carry multiple "
+        "values on an axis. `total` is exact. A matrix whose row x column bucket "
+        f"count would exceed {settings.es_cross_facet_max_cells:,} is rejected."
+    ),
+)
+async def cross_tabulate_facets(
+    reference_service: Annotated[ReferenceService, Depends(reference_service)],
+    anti_corruption_service: Annotated[
+        ReferenceAntiCorruptionService, Depends(reference_anti_corruption_service)
+    ],
+    query: Annotated[SearchQuery, Depends(parse_search_query)],
+    row: Annotated[
+        str,
+        Query(
+            min_length=1,
+            description=(
+                "The row axis: `countries`, `country_wb_regions`, or a concept-scheme "
+                "URI."
+            ),
+            examples=["country_wb_regions"],
+        ),
+    ],
+    column: Annotated[
+        str,
+        Query(
+            min_length=1,
+            description=(
+                "The column axis: `countries`, `country_wb_regions`, or a "
+                "concept-scheme URI."
+            ),
+            examples=["https://vocab.evidence-repository.org/scheme/Themes"],
+        ),
+    ],
+    vocabulary: Annotated[
+        HttpUrl,
+        AfterValidator(_validate_vocab_host),
+        Query(
+            description=(
+                "Vocabulary URI scoping concept-scheme axes to their members. "
+                "Required when `row` or `column` is a scheme URI. "
+                f"Host must be a subdomain of `{settings.vocabulary_host}`."
+            ),
+            examples=[
+                "https://vocab.evidence-repository.org/published/01935f56-2c8e-7000-8000-000000000001/vocabulary.ttl"
+            ],
+        ),
+    ] = None,
+) -> destiny_sdk.references.ReferenceCrossFacetResult:
+    """Cross-tabulate two axes for references matching the query."""
+    cells, total = await reference_service.aggregate_cross_facet(
+        query,
+        row,
+        column,
+        vocabulary_uri=str(vocabulary) if vocabulary else None,
+    )
+    return anti_corruption_service.cross_facet_to_sdk(cells, total)
+
+
 @exports_router.post(
     "/",
     status_code=status.HTTP_202_ACCEPTED,

--- a/app/domain/references/routes.py
+++ b/app/domain/references/routes.py
@@ -651,14 +651,15 @@ async def count_facets_for_search(
     },
     description=(
         "Cross-tabulate two axes over the references matching the search, for "
-        "evidence maps. Accepts the same filters as `/references/search/`, plus a "
-        "`row` and `column` axis.\n\n"
-        "When an axis is a scheme  URI, supply `?vocabulary=`.\n\n"
+        "evidence maps. Accepts the same filters as `/references/search/`, plus the "
+        "two `axes`.\n\n"
+        "When an axis is a concept-scheme URI, supply `?vocabulary=`.\n\n"
         "**Counting.** Each returned cell is a strict intersection: references "
-        "matching its row value, its column value, all panel filters and the query "
-        "string. Only non-zero cells are returned.\n\n"
+        "matching both its axis values, all panel filters and the query string. "
+        "Only non-zero cells are returned, sorted by descending count.\n\n"
         "Cells may sum to more than `total` because a reference can carry multiple "
-        "values on an axis. `total` is exact. A matrix whose row x column bucket "
+        "values on an axis (and to less, as a reference matching the filters need "
+        "not have a value on either axis). `total` is exact. A matrix whose bucket "
         f"count would exceed {settings.es_cross_facet_max_cells:,} is rejected."
     ),
 )
@@ -668,26 +669,23 @@ async def cross_tabulate_facets(
         ReferenceAntiCorruptionService, Depends(reference_anti_corruption_service)
     ],
     query: Annotated[SearchQuery, Depends(parse_search_query)],
-    row: Annotated[
-        str,
+    axes: Annotated[
+        tuple[str, str],
         Query(
-            min_length=1,
             description=(
-                "The row axis: `countries`, `country_wb_regions`, or a concept-scheme "
-                "URI."
+                "The two axes to cross-tabulate, in order. Each is one of:\n\n"
+                "- a concept-scheme URI\n"
+                "- the literal `countries`\n"
+                "- the literal `country_wb_regions`\n\n"
+                "Mixed types are allowed. Each cell reports its values in this same "
+                "axis order."
             ),
-            examples=["country_wb_regions"],
-        ),
-    ],
-    column: Annotated[
-        str,
-        Query(
-            min_length=1,
-            description=(
-                "The column axis: `countries`, `country_wb_regions`, or a "
-                "concept-scheme URI."
-            ),
-            examples=["https://vocab.evidence-repository.org/scheme/Themes"],
+            examples=[
+                [
+                    "country_wb_regions",
+                    "https://vocab.evidence-repository.org/scheme/Themes",
+                ]
+            ],
         ),
     ],
     vocabulary: Annotated[
@@ -696,7 +694,7 @@ async def cross_tabulate_facets(
         Query(
             description=(
                 "Vocabulary URI scoping concept-scheme axes to their members. "
-                "Required when `row` or `column` is a scheme URI. "
+                "Required when an axis is a concept-scheme URI. "
                 f"Host must be a subdomain of `{settings.vocabulary_host}`."
             ),
             examples=[
@@ -708,8 +706,7 @@ async def cross_tabulate_facets(
     """Cross-tabulate two axes for references matching the query."""
     cells, total = await reference_service.aggregate_cross_facet(
         query,
-        row,
-        column,
+        axes,
         vocabulary_uri=str(vocabulary) if vocabulary else None,
     )
     return anti_corruption_service.cross_facet_to_sdk(cells, total)

--- a/app/domain/references/service.py
+++ b/app/domain/references/service.py
@@ -23,6 +23,7 @@ from app.core.telemetry.attributes import Attributes, trace_attribute
 from app.core.telemetry.logger import get_logger
 from app.core.telemetry.taskiq import queue_task_with_trace
 from app.domain.references.models.models import (
+    CrossFacetCell,
     DuplicateDetermination,
     Enhancement,
     EnhancementRequest,
@@ -72,7 +73,11 @@ from app.domain.service import GenericService
 from app.external.vocabulary.client import get_vocabulary_artifact_client
 from app.persistence.blob.repository import BlobRepository
 from app.persistence.blob.stream import FileStream
-from app.persistence.es.persistence import ESFacetBucket, ESSearchResult
+from app.persistence.es.persistence import (
+    ESFacetBucket,
+    ESSearchResult,
+    ESSearchTotal,
+)
 from app.persistence.es.uow import AsyncESUnitOfWork
 from app.persistence.es.uow import unit_of_work as es_unit_of_work
 from app.persistence.sql.uow import AsyncSqlUnitOfWork
@@ -1291,6 +1296,19 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
         """Count occurrences per facet across references matching the query."""
         return await self._search_service.aggregate_facets(
             query, facets, vocabulary_uri
+        )
+
+    @es_unit_of_work
+    async def aggregate_cross_facet(
+        self,
+        query: SearchQuery,
+        row: str,
+        column: str,
+        vocabulary_uri: str | None = None,
+    ) -> tuple[list[CrossFacetCell], ESSearchTotal]:
+        """Cross-tabulate two axes across references matching the query."""
+        return await self._search_service.aggregate_cross_facet(
+            query, row, column, vocabulary_uri
         )
 
     @tracer.start_as_current_span("Detect and dispatch robot automations")

--- a/app/domain/references/service.py
+++ b/app/domain/references/service.py
@@ -1302,13 +1302,12 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
     async def aggregate_cross_facet(
         self,
         query: SearchQuery,
-        row: str,
-        column: str,
+        axes: tuple[str, str],
         vocabulary_uri: str | None = None,
     ) -> tuple[list[CrossFacetCell], ESSearchTotal]:
         """Cross-tabulate two axes across references matching the query."""
         return await self._search_service.aggregate_cross_facet(
-            query, row, column, vocabulary_uri
+            query, axes, vocabulary_uri
         )
 
     @tracer.start_as_current_span("Detect and dispatch robot automations")

--- a/app/domain/references/services/anti_corruption_service.py
+++ b/app/domain/references/services/anti_corruption_service.py
@@ -461,8 +461,7 @@ class ReferenceAntiCorruptionService(GenericAntiCorruptionService):
                 },
                 cells=[
                     destiny_sdk.references.CrossFacetCell(
-                        row=cell.row,
-                        column=cell.column,
+                        axes=cell.axes,
                         count=cell.count,
                     )
                     for cell in cells

--- a/app/domain/references/services/anti_corruption_service.py
+++ b/app/domain/references/services/anti_corruption_service.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 from app.core.exceptions import DomainToSDKError, SDKToDomainError
 from app.domain.references.models.models import (
     AnnotationFilter,
+    CrossFacetCell,
     Enhancement,
     EnhancementRequest,
     EnhancementType,
@@ -32,7 +33,11 @@ from app.domain.references.services.access_control_service import RedactedRefere
 from app.domain.service import GenericAntiCorruptionService
 from app.persistence.blob.models import BlobSignedUrlType, BlobStorageFile
 from app.persistence.blob.repository import URLSigner
-from app.persistence.es.persistence import ESFacetBucket, ESSearchResult
+from app.persistence.es.persistence import (
+    ESFacetBucket,
+    ESSearchResult,
+    ESSearchTotal,
+)
 
 
 class ReferenceAntiCorruptionService(GenericAntiCorruptionService):
@@ -439,6 +444,30 @@ class ReferenceAntiCorruptionService(GenericAntiCorruptionService):
                 raise NotImplementedError(msg)
         try:
             return destiny_sdk.references.ReferenceFacetResult(**fields)
+        except ValidationError as exception:
+            raise DomainToSDKError(errors=exception.errors()) from exception
+
+    def cross_facet_to_sdk(
+        self,
+        cells: Sequence[CrossFacetCell],
+        total: ESSearchTotal,
+    ) -> destiny_sdk.references.ReferenceCrossFacetResult:
+        """Convert a cross-facet result into the SDK response model."""
+        try:
+            return destiny_sdk.references.ReferenceCrossFacetResult(
+                total={
+                    "count": total.value,
+                    "is_lower_bound": total.relation == "gte",
+                },
+                cells=[
+                    destiny_sdk.references.CrossFacetCell(
+                        row=cell.row,
+                        column=cell.column,
+                        count=cell.count,
+                    )
+                    for cell in cells
+                ],
+            )
         except ValidationError as exception:
             raise DomainToSDKError(errors=exception.errors()) from exception
 

--- a/app/domain/references/services/search_service.py
+++ b/app/domain/references/services/search_service.py
@@ -1,5 +1,6 @@
 """Service for searching references."""
 
+import math
 from collections.abc import Iterable, Sequence
 from typing import ClassVar
 
@@ -126,30 +127,27 @@ class SearchService(GenericService[ReferenceAntiCorruptionService]):
     async def aggregate_cross_facet(
         self,
         query: SearchQuery,
-        row_token: str,
-        column_token: str,
+        axes: tuple[str, str],
         vocabulary_uri: str | None,
     ) -> tuple[list[CrossFacetCell], ESSearchTotal]:
         """
         Cross-tabulate two axes over references matching ``query``.
 
         Each axis is a literal axis or a concept-scheme URI (scoped to its members
-        via ``vocabulary_uri``). Returns the non-zero cells and the exact grand total.
+        via ``vocabulary_uri``). Cells are reported in the given axis order. Returns
+        the non-zero cells and the exact grand total.
         """
         scheme_members: dict[str, frozenset[str]] | None = None
-        if vocabulary_uri and (
-            self._literal_axis_facet(row_token) is None
-            or self._literal_axis_facet(column_token) is None
-        ):
+        if vocabulary_uri and any(self._is_concept_scheme(token) for token in axes):
             scheme_members = await self._vocab_client.get_scheme_members(vocabulary_uri)
-        row = self._resolve_cross_facet_axis(row_token, vocabulary_uri, scheme_members)
-        column = self._resolve_cross_facet_axis(
-            column_token, vocabulary_uri, scheme_members
+        resolved = tuple(
+            self._resolve_cross_facet_axis(token, vocabulary_uri, scheme_members)
+            for token in axes
         )
         self._validate_cross_facet_cell_count(
-            row, column, settings.es_cross_facet_max_cells
+            resolved, settings.es_cross_facet_max_cells
         )
-        return await self.es_uow.references.aggregate_cross_facet(query, row, column)
+        return await self.es_uow.references.aggregate_cross_facet(query, resolved)
 
     @classmethod
     def _literal_axis_facet(cls, token: str) -> FacetType | None:
@@ -159,6 +157,11 @@ class SearchService(GenericService[ReferenceAntiCorruptionService]):
         except ValueError:
             return None
         return facet if facet in cls._LITERAL_AXIS_SIZES else None
+
+    @classmethod
+    def _is_concept_scheme(cls, token: str) -> bool:
+        """Whether an axis token is a concept-scheme URI (i.e. not a literal axis)."""
+        return cls._literal_axis_facet(token) is None
 
     @classmethod
     def _resolve_cross_facet_axis(
@@ -199,15 +202,15 @@ class SearchService(GenericService[ReferenceAntiCorruptionService]):
 
     @staticmethod
     def _validate_cross_facet_cell_count(
-        row: CrossFacetAxis, column: CrossFacetAxis, max_cells: int
+        axes: Sequence[CrossFacetAxis], max_cells: int
     ) -> None:
         """Refuse a matrix whose cell count would exceed ``max_cells``."""
-        cells = row.size * column.size
+        cells = math.prod(axis.size for axis in axes)
         if cells > max_cells:
+            sizes = " x ".join(str(axis.size) for axis in axes)
             msg = (
-                f"Cross-facet matrix would request {cells} cells ({row.size} x "
-                f"{column.size}), exceeding the limit of {max_cells}. Choose axes "
-                "with fewer members."
+                f"Cross-facet matrix would request {cells} cells ({sizes}), "
+                f"exceeding the limit of {max_cells}. Choose axes with fewer members."
             )
             raise ParseError(msg)
 

--- a/app/domain/references/services/search_service.py
+++ b/app/domain/references/services/search_service.py
@@ -1,6 +1,5 @@
 """Service for searching references."""
 
-import math
 from collections.abc import Iterable, Sequence
 from typing import ClassVar
 
@@ -204,13 +203,18 @@ class SearchService(GenericService[ReferenceAntiCorruptionService]):
     def _validate_cross_facet_cell_count(
         axes: Sequence[CrossFacetAxis], max_cells: int
     ) -> None:
-        """Refuse a matrix whose cell count would exceed ``max_cells``."""
-        cells = math.prod(axis.size for axis in axes)
-        if cells > max_cells:
+        """Refuse a matrix that would materialise more than ``max_cells`` ES buckets."""
+        buckets = 0
+        running = 1
+        for axis in axes:
+            running *= axis.size
+            buckets += running
+        if buckets > max_cells:
             sizes = " x ".join(str(axis.size) for axis in axes)
             msg = (
-                f"Cross-facet matrix would request {cells} cells ({sizes}), "
-                f"exceeding the limit of {max_cells}. Choose axes with fewer members."
+                f"Cross-facet matrix would materialise {buckets} aggregation buckets "
+                f"({sizes}), exceeding the limit of {max_cells}. Choose axes with "
+                "fewer members."
             )
             raise ParseError(msg)
 

--- a/app/domain/references/services/search_service.py
+++ b/app/domain/references/services/search_service.py
@@ -5,9 +5,11 @@ from collections.abc import Iterable, Sequence
 from opentelemetry import trace
 
 from app.core.config import get_settings
-from app.core.exceptions import SiblingGroupingError
+from app.core.exceptions import ParseError, SiblingGroupingError
 from app.core.telemetry.logger import get_logger
 from app.domain.references.models.models import (
+    CrossFacetAxis,
+    CrossFacetCell,
     FacetType,
     LinkedDataConceptFilter,
     SearchQuery,
@@ -16,18 +18,39 @@ from app.domain.references.models.models import (
 from app.domain.references.services.anti_corruption_service import (
     ReferenceAntiCorruptionService,
 )
+from app.domain.references.services.world_bank_regions import WORLD_BANK_REGIONS
 from app.domain.service import GenericService
 from app.external.vocabulary.client import (
     VocabularyArtifactClient,
     get_vocabulary_artifact_client,
 )
-from app.persistence.es.persistence import ESFacetBucket, ESSearchResult
+from app.persistence.es.persistence import (
+    ESFacetBucket,
+    ESSearchResult,
+    ESSearchTotal,
+)
 from app.persistence.es.uow import AsyncESUnitOfWork
 from app.persistence.sql.uow import AsyncSqlUnitOfWork
 
 logger = get_logger(__name__)
 settings = get_settings()
 tracer = trace.get_tracer(__name__)
+
+# The terms ``size`` for each literal (non-scheme) axis. A token is a literal axis
+# iff ``FacetType(token)`` is one of these; their code sets are small and bounded.
+_LITERAL_AXIS_SIZES: dict[FacetType, int] = {
+    FacetType.COUNTRIES: 256,  # conservative bound on the ~249 ISO 3166-1 alpha-2 codes
+    FacetType.COUNTRY_WB_REGIONS: len(WORLD_BANK_REGIONS),
+}
+
+
+def _literal_axis_facet(token: str) -> FacetType | None:
+    """Return the FacetType for a literal axis token, or None for a scheme URI."""
+    try:
+        facet = FacetType(token)
+    except ValueError:
+        return None
+    return facet if facet in _LITERAL_AXIS_SIZES else None
 
 
 class SearchService(GenericService[ReferenceAntiCorruptionService]):
@@ -107,6 +130,84 @@ class SearchService(GenericService[ReferenceAntiCorruptionService]):
             sibling_groups_by_facet=sibling_groups_by_facet,
             max_buckets=max_buckets,
         )
+
+    async def aggregate_cross_facet(
+        self,
+        query: SearchQuery,
+        row_token: str,
+        column_token: str,
+        vocabulary_uri: str | None,
+    ) -> tuple[list[CrossFacetCell], ESSearchTotal]:
+        """
+        Cross-tabulate two axes over references matching ``query``.
+
+        Each axis is the literal ``countries`` or ``country_wb_regions``, or a
+        concept-scheme URI (scoped to its members via ``vocabulary_uri``). Returns
+        the non-zero cells and the exact grand total.
+        """
+        scheme_members: dict[str, frozenset[str]] | None = None
+        if vocabulary_uri and (
+            _literal_axis_facet(row_token) is None
+            or _literal_axis_facet(column_token) is None
+        ):
+            scheme_members = await self._vocab_client.get_scheme_members(vocabulary_uri)
+        row = self._resolve_cross_facet_axis(row_token, vocabulary_uri, scheme_members)
+        column = self._resolve_cross_facet_axis(
+            column_token, vocabulary_uri, scheme_members
+        )
+        self._validate_cross_facet_cell_count(row, column)
+        return await self.es_uow.references.aggregate_cross_facet(query, row, column)
+
+    @staticmethod
+    def _resolve_cross_facet_axis(
+        token: str,
+        vocabulary_uri: str | None,
+        scheme_members: dict[str, frozenset[str]] | None,
+    ) -> CrossFacetAxis:
+        """Resolve an axis token into a ``CrossFacetAxis``; raises 400 on bad input."""
+        literal_facet = _literal_axis_facet(token)
+        if literal_facet is not None:
+            return CrossFacetAxis(
+                token=token,
+                facet_type=literal_facet,
+                include=None,
+                size=_LITERAL_AXIS_SIZES[literal_facet],
+            )
+        # Any non-literal token is treated as a concept-scheme URI.
+        if not vocabulary_uri or scheme_members is None:
+            msg = (
+                "`vocabulary=` is required when an axis is a concept scheme: "
+                f"{token!r}."
+            )
+            raise ParseError(msg)
+        members = scheme_members.get(token)
+        if not members:
+            msg = (
+                f"Concept scheme {token!r} has no members in vocabulary "
+                f"{vocabulary_uri!r}."
+            )
+            raise ParseError(msg)
+        return CrossFacetAxis(
+            token=token,
+            facet_type=FacetType.CONCEPTS,
+            include=members,
+            size=len(members),
+        )
+
+    @staticmethod
+    def _validate_cross_facet_cell_count(
+        row: CrossFacetAxis, column: CrossFacetAxis
+    ) -> None:
+        """Refuse a matrix whose cell count would exceed the configured limit."""
+        max_cells = settings.es_cross_facet_max_cells
+        cells = row.size * column.size
+        if cells > max_cells:
+            msg = (
+                f"Cross-facet matrix would request {cells} cells ({row.size} x "
+                f"{column.size}), exceeding the limit of {max_cells}. Choose axes "
+                "with fewer members."
+            )
+            raise ParseError(msg)
 
     @staticmethod
     def _validate_groups_against_max_buckets(

--- a/app/domain/references/services/search_service.py
+++ b/app/domain/references/services/search_service.py
@@ -1,6 +1,7 @@
 """Service for searching references."""
 
 from collections.abc import Iterable, Sequence
+from typing import ClassVar
 
 from opentelemetry import trace
 
@@ -36,22 +37,6 @@ logger = get_logger(__name__)
 settings = get_settings()
 tracer = trace.get_tracer(__name__)
 
-# The terms ``size`` for each literal (non-scheme) axis. A token is a literal axis
-# iff ``FacetType(token)`` is one of these; their code sets are small and bounded.
-_LITERAL_AXIS_SIZES: dict[FacetType, int] = {
-    FacetType.COUNTRIES: 256,  # conservative bound on the ~249 ISO 3166-1 alpha-2 codes
-    FacetType.COUNTRY_WB_REGIONS: len(WORLD_BANK_REGIONS),
-}
-
-
-def _literal_axis_facet(token: str) -> FacetType | None:
-    """Return the FacetType for a literal axis token, or None for a scheme URI."""
-    try:
-        facet = FacetType(token)
-    except ValueError:
-        return None
-    return facet if facet in _LITERAL_AXIS_SIZES else None
-
 
 class SearchService(GenericService[ReferenceAntiCorruptionService]):
     """Service for searching references."""
@@ -60,6 +45,13 @@ class SearchService(GenericService[ReferenceAntiCorruptionService]):
     # produces `relation == "gte"` totals rather than exact counts. Lifting
     # the cap is tracked in destiny-repository#661.
     MAX_RESULT_WINDOW = 10_000
+
+    # The terms `size` for each literal (non-scheme) axis. A token is a literal axis
+    # iff `FacetType(token)` is one of these; their value sets are small and bounded.
+    _LITERAL_AXIS_SIZES: ClassVar[dict[FacetType, int]] = {
+        FacetType.COUNTRIES: 256,  # conservative bound on the ~249 ISO 3166-1 codes
+        FacetType.COUNTRY_WB_REGIONS: len(WORLD_BANK_REGIONS),
+    }
 
     def __init__(
         self,
@@ -141,39 +133,50 @@ class SearchService(GenericService[ReferenceAntiCorruptionService]):
         """
         Cross-tabulate two axes over references matching ``query``.
 
-        Each axis is the literal ``countries`` or ``country_wb_regions``, or a
-        concept-scheme URI (scoped to its members via ``vocabulary_uri``). Returns
-        the non-zero cells and the exact grand total.
+        Each axis is a literal axis or a concept-scheme URI (scoped to its members
+        via ``vocabulary_uri``). Returns the non-zero cells and the exact grand total.
         """
         scheme_members: dict[str, frozenset[str]] | None = None
         if vocabulary_uri and (
-            _literal_axis_facet(row_token) is None
-            or _literal_axis_facet(column_token) is None
+            self._literal_axis_facet(row_token) is None
+            or self._literal_axis_facet(column_token) is None
         ):
             scheme_members = await self._vocab_client.get_scheme_members(vocabulary_uri)
         row = self._resolve_cross_facet_axis(row_token, vocabulary_uri, scheme_members)
         column = self._resolve_cross_facet_axis(
             column_token, vocabulary_uri, scheme_members
         )
-        self._validate_cross_facet_cell_count(row, column)
+        self._validate_cross_facet_cell_count(
+            row, column, settings.es_cross_facet_max_cells
+        )
         return await self.es_uow.references.aggregate_cross_facet(query, row, column)
 
-    @staticmethod
+    @classmethod
+    def _literal_axis_facet(cls, token: str) -> FacetType | None:
+        """Return the FacetType for a literal (non-scheme) axis token, else None."""
+        try:
+            facet = FacetType(token)
+        except ValueError:
+            return None
+        return facet if facet in cls._LITERAL_AXIS_SIZES else None
+
+    @classmethod
     def _resolve_cross_facet_axis(
+        cls,
         token: str,
         vocabulary_uri: str | None,
         scheme_members: dict[str, frozenset[str]] | None,
     ) -> CrossFacetAxis:
-        """Resolve an axis token into a ``CrossFacetAxis``; raises 400 on bad input."""
-        literal_facet = _literal_axis_facet(token)
+        """Resolve an axis token into a ``CrossFacetAxis``, or raise ``ParseError``."""
+        literal_facet = cls._literal_axis_facet(token)
         if literal_facet is not None:
             return CrossFacetAxis(
                 token=token,
                 facet_type=literal_facet,
                 include=None,
-                size=_LITERAL_AXIS_SIZES[literal_facet],
+                size=cls._LITERAL_AXIS_SIZES[literal_facet],
             )
-        # Any non-literal token is treated as a concept-scheme URI.
+        # A non-literal token is treated as a concept-scheme URI.
         if not vocabulary_uri or scheme_members is None:
             msg = (
                 "`vocabulary=` is required when an axis is a concept scheme: "
@@ -196,10 +199,9 @@ class SearchService(GenericService[ReferenceAntiCorruptionService]):
 
     @staticmethod
     def _validate_cross_facet_cell_count(
-        row: CrossFacetAxis, column: CrossFacetAxis
+        row: CrossFacetAxis, column: CrossFacetAxis, max_cells: int
     ) -> None:
-        """Refuse a matrix whose cell count would exceed the configured limit."""
-        max_cells = settings.es_cross_facet_max_cells
+        """Refuse a matrix whose cell count would exceed ``max_cells``."""
         cells = row.size * column.size
         if cells > max_cells:
             msg = (

--- a/app/external/vocabulary/client.py
+++ b/app/external/vocabulary/client.py
@@ -245,13 +245,11 @@ def _build_concept_siblings(graph: Graph) -> dict[str, frozenset[str]]:
 
 def _build_scheme_members(graph: Graph) -> dict[str, frozenset[str]]:
     """
-    Map each concept-scheme URI to the full set of its member concept URIs.
+    Map each concept-scheme URI to the full set of concept URIs that belong to it.
 
-    Membership comes from explicit assertions (``skos:inScheme``,
-    ``skos:topConceptOf``, ``skos:hasTopConcept``); a concept with no assertion of its
-    own inherits its ``skos:broader`` ancestor's scheme(s), so descendants that omit
-    ``inScheme`` are still captured. Concepts that declare their own scheme are never
-    reassigned, so a ``broader`` edge across scheme boundaries does not leak members.
+    A concept belongs to a scheme if it says so directly, via ``skos:inScheme``,
+    ``skos:topConceptOf``, or ``skos:hasTopConcept``. A concept that makes no such
+    declaration falls back to the scheme(s) of its ``skos:broader`` ancestors.
     """
     explicit_schemes: dict[URIRef, set[URIRef]] = {}
 

--- a/app/external/vocabulary/client.py
+++ b/app/external/vocabulary/client.py
@@ -139,6 +139,11 @@ class VocabularyArtifactClient:
         """Concept URI -> sibling set (self-inclusive) for the vocabulary."""
         return _build_concept_siblings(await self.get_vocabulary(uri))
 
+    @alru_cache(maxsize=128)
+    async def get_scheme_members(self, uri: str) -> dict[str, frozenset[str]]:
+        """Concept-scheme URI -> member concept URIs (all depths) for the vocabulary."""
+        return _build_scheme_members(await self.get_vocabulary(uri))
+
     @tenacity.retry(
         retry=tenacity.retry_if_exception_type(httpx.TransportError),
         wait=tenacity.wait_exponential(multiplier=1, max=30),
@@ -236,3 +241,49 @@ def _build_concept_siblings(graph: Graph) -> dict[str, frozenset[str]]:
             peers.update(top_concepts_by_scheme[scheme])
         siblings[str(concept)] = frozenset(str(peer) for peer in peers)
     return siblings
+
+
+def _build_scheme_members(graph: Graph) -> dict[str, frozenset[str]]:
+    """
+    Map each concept-scheme URI to the full set of its member concept URIs.
+
+    Membership comes from explicit assertions (``skos:inScheme``,
+    ``skos:topConceptOf``, ``skos:hasTopConcept``); a concept with no assertion of its
+    own inherits its ``skos:broader`` ancestor's scheme(s), so descendants that omit
+    ``inScheme`` are still captured. Concepts that declare their own scheme are never
+    reassigned, so a ``broader`` edge across scheme boundaries does not leak members.
+    """
+    explicit_schemes: dict[URIRef, set[URIRef]] = {}
+
+    def _assert(concept: object, scheme: object) -> None:
+        if isinstance(concept, URIRef) and isinstance(scheme, URIRef):
+            explicit_schemes.setdefault(concept, set()).add(scheme)
+
+    for concept, _, scheme in graph.triples((None, SKOS.inScheme, None)):
+        _assert(concept, scheme)
+    for concept, _, scheme in graph.triples((None, SKOS.topConceptOf, None)):
+        _assert(concept, scheme)
+    for scheme, _, concept in graph.triples((None, SKOS.hasTopConcept, None)):
+        _assert(concept, scheme)
+
+    parents_by_concept: dict[URIRef, set[URIRef]] = {}
+    for concept, _, parent in graph.triples((None, SKOS.broader, None)):
+        if isinstance(concept, URIRef) and isinstance(parent, URIRef):
+            parents_by_concept.setdefault(concept, set()).add(parent)
+
+    def schemes_for(concept: URIRef, seen: set[URIRef]) -> set[URIRef]:
+        if concept in explicit_schemes:
+            return explicit_schemes[concept]
+        if concept in seen:
+            return set()
+        seen.add(concept)
+        inherited: set[URIRef] = set()
+        for parent in parents_by_concept.get(concept, ()):
+            inherited |= schemes_for(parent, seen)
+        return inherited
+
+    members: dict[str, set[str]] = {}
+    for concept in set(explicit_schemes) | set(parents_by_concept):
+        for scheme in schemes_for(concept, set()):
+            members.setdefault(str(scheme), set()).add(str(concept))
+    return {scheme: frozenset(uris) for scheme, uris in members.items()}

--- a/app/persistence/es/repository.py
+++ b/app/persistence/es/repository.py
@@ -289,7 +289,7 @@ class GenericAsyncESRepository(
         :return: A mapping from each requested field name to its term buckets.
         :rtype: dict[str, list[ESFacetBucket]]
         """
-        search = self._aggregation_search(query, query_fields, filter_clauses)
+        search = self._build_aggregation_search(query, query_fields, filter_clauses)
         for field in aggregate_on:
             search.aggs.bucket(field, "terms", field=field, size=max_buckets)
         response = await self._execute_search(search)
@@ -317,7 +317,7 @@ class GenericAsyncESRepository(
             return main
         return Bool(must=[main], filter=list(filter_clauses))
 
-    def _aggregation_search(
+    def _build_aggregation_search(
         self,
         query_string: str,
         query_fields: Sequence[str] | None,

--- a/app/persistence/es/repository.py
+++ b/app/persistence/es/repository.py
@@ -245,23 +245,17 @@ class GenericAsyncESRepository(
         :return: A list of matching records.
         :rtype: ESSearchResult
         """
-        composed = self._compose_query(query, fields, filter_clauses)
-        trace_attribute(Attributes.DB_QUERY, json.dumps(composed.to_dict()))
         search = (
             AsyncSearch(using=self._client, index=self._persistence_cls.Index.name)
             .extra(size=page_size)
             .extra(from_=(page - 1) * page_size)
-            .query(composed)
+            .query(self._compose_query(query, fields, filter_clauses))
         )
         if sort:
             search = search.sort(*sort)
         if not parse_document:
             search = search.source(includes=[])
-        try:
-            response = await search.execute()
-        except BadRequestError as exc:
-            msg = f"Elasticsearch query string search failed: {exc}."
-            raise ESQueryError(msg) from exc
+        response = await self._execute_search(search)
         return self._parse_search_result(response, page, parse_document=parse_document)
 
     @trace_repository_method(tracer)
@@ -295,21 +289,10 @@ class GenericAsyncESRepository(
         :return: A mapping from each requested field name to its term buckets.
         :rtype: dict[str, list[ESFacetBucket]]
         """
-        composed = self._compose_query(query, query_fields, filter_clauses)
-        trace_attribute(Attributes.DB_QUERY, json.dumps(composed.to_dict()))
-        search = (
-            AsyncSearch(using=self._client, index=self._persistence_cls.Index.name)
-            .extra(size=0)
-            .query(composed)
-            .source(includes=[])
-        )
+        search = self._aggregation_search(query, query_fields, filter_clauses)
         for field in aggregate_on:
             search.aggs.bucket(field, "terms", field=field, size=max_buckets)
-        try:
-            response = await search.execute()
-        except BadRequestError as exc:
-            msg = f"Elasticsearch terms aggregation failed: {exc}."
-            raise ESQueryError(msg) from exc
+        response = await self._execute_search(search)
         return {
             field: [
                 ESFacetBucket(key=str(bucket.key), count=bucket.doc_count)
@@ -333,3 +316,26 @@ class GenericAsyncESRepository(
         if not filter_clauses:
             return main
         return Bool(must=[main], filter=list(filter_clauses))
+
+    def _aggregation_search(
+        self,
+        query_string: str,
+        query_fields: Sequence[str] | None,
+        filter_clauses: Sequence[Query] | None,
+    ) -> AsyncSearch:
+        """Build a ``size=0``, source-stripped search ready for aggregations."""
+        return (
+            AsyncSearch(using=self._client, index=self._persistence_cls.Index.name)
+            .extra(size=0)
+            .query(self._compose_query(query_string, query_fields, filter_clauses))
+            .source(includes=[])
+        )
+
+    async def _execute_search(self, search: AsyncSearch) -> Response:
+        """Trace and execute a search, mapping an ES ``400`` to ``ESQueryError``."""
+        trace_attribute(Attributes.DB_QUERY, json.dumps(search.to_dict()))
+        try:
+            return await search.execute()
+        except BadRequestError as exc:
+            msg = f"Elasticsearch query failed: {exc}."
+            raise ESQueryError(msg) from exc

--- a/docs/procedures/search.rst
+++ b/docs/procedures/search.rst
@@ -254,6 +254,36 @@ Limitations
 
 Each facet returns at most ``ES_AGGREGATION_MAX_BUCKETS`` buckets (default 1000). For concept facets, if a sibling group's vocabulary set exceeds this the request is refused rather than silently truncated.
 
+.. _cross-facets-procedure:
+
+API Cross-Facet Counts
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The cross-facets endpoint at `/v1/references/search/cross-facets/` cross-tabulates two axes over the references matching the search, for evidence maps. It accepts the same filter parameters as `/v1/references/search/` plus a ``row`` and a ``column`` axis.
+
+Each axis is the literal ``countries``, the literal ``country_wb_regions``, or a concept-scheme URI; mixed types are allowed. When an axis is a scheme URI, supply ``vocabulary=`` — its concepts scope that axis (via the SKOS membership of the scheme, at every depth).
+
+.. code-block::
+
+    # WHO region (rows) x thematic focus (columns), across malaria references since 2015:
+    ?q=malaria
+        &row=https://vocab.evidence-repository.org/scheme/WHORegion
+        &column=https://vocab.evidence-repository.org/scheme/Themes
+        &vocabulary=https://vocab.evidence-repository.org/vocabulary/v1
+        &start_year=2015
+
+Counting is simpler than the facets endpoint: each returned cell is a strict intersection - references matching its row value, its column value, all panel filters and the query string. Only non-zero cells are returned.
+
+Returns
+""""""""""
+
+Returns a :class:`ReferenceCrossFacetResult <libs.sdk.src.destiny_sdk.references.ReferenceCrossFacetResult>`: an exact ``total`` plus the non-zero ``{row, column, count}`` cells, sorted by descending count. Cells may sum to more than ``total`` because a reference can carry multiple values on an axis (e.g. several countries), so it contributes to multiple cells.
+
+Restrictions (400 on violation):
+
+1. A scheme axis requires ``vocabulary=`` (whose host must be a subdomain of the configured vocabulary host), and the scheme must resolve to at least one concept in it.
+2. A matrix whose row × column bucket count would exceed ``ES_CROSS_FACET_MAX_CELLS`` (default 50,000) is refused rather than aborting server-side.
+
 .. _lookup-procedure:
 
 API Lookup

--- a/docs/procedures/search.rst
+++ b/docs/procedures/search.rst
@@ -259,30 +259,36 @@ Each facet returns at most ``ES_AGGREGATION_MAX_BUCKETS`` buckets (default 1000)
 API Cross-Facet Counts
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-The cross-facets endpoint at `/v1/references/search/cross-facets/` cross-tabulates two axes over the references matching the search, for evidence maps. It accepts the same filter parameters as `/v1/references/search/` plus a ``row`` and a ``column`` axis.
+The cross-facets endpoint at `/v1/references/search/cross-facets/` cross-tabulates two axes over the references matching the search, for evidence maps. It accepts the same filter parameters as `/v1/references/search/` plus two ``axes``.
 
-Each axis is the literal ``countries``, the literal ``country_wb_regions``, or a concept-scheme URI; mixed types are allowed. When an axis is a scheme URI, supply ``vocabulary=`` — its concepts scope that axis (via the SKOS membership of the scheme, at every depth).
+Each axis is one of:
+
+* a concept-scheme URI
+* the literal ``countries``
+* the literal ``country_wb_regions``
+
+Mixed types are allowed. When an axis is a concept-scheme URI, supply ``vocabulary=`` — its concepts scope that axis (via the SKOS membership of the scheme, at every depth). Cell values are reported in the same order the axes are given.
 
 .. code-block::
 
-    # WHO region (rows) x thematic focus (columns), across malaria references since 2015:
+    # WHO region x thematic focus, across malaria references since 2015:
     ?q=malaria
-        &row=https://vocab.evidence-repository.org/scheme/WHORegion
-        &column=https://vocab.evidence-repository.org/scheme/Themes
+        &axes=https://vocab.evidence-repository.org/scheme/WHORegion
+        &axes=https://vocab.evidence-repository.org/scheme/Themes
         &vocabulary=https://vocab.evidence-repository.org/vocabulary/v1
         &start_year=2015
 
-Counting is simpler than the facets endpoint: each returned cell is a strict intersection - references matching its row value, its column value, all panel filters and the query string. Only non-zero cells are returned.
+Counting is simpler than the facets endpoint: each returned cell is a strict intersection - references matching both its axis values, all panel filters and the query string. Only non-zero cells are returned.
 
 Returns
 """"""""""
 
-Returns a :class:`ReferenceCrossFacetResult <libs.sdk.src.destiny_sdk.references.ReferenceCrossFacetResult>`: an exact ``total`` plus the non-zero ``{row, column, count}`` cells, sorted by descending count. Cells may sum to more than ``total`` because a reference can carry multiple values on an axis (e.g. several countries), so it contributes to multiple cells.
+Returns a :class:`ReferenceCrossFacetResult <libs.sdk.src.destiny_sdk.references.ReferenceCrossFacetResult>`: an exact ``total`` plus the non-zero ``{axes, count}`` cells (``axes`` is a 2-tuple in the requested order), sorted by descending count. Cells may sum to more than ``total`` because a reference can carry multiple values on an axis, and to less because a reference matching the filters need not have a value on either axis.
 
 Restrictions (400 on violation):
 
-1. A scheme axis requires ``vocabulary=`` (whose host must be a subdomain of the configured vocabulary host), and the scheme must resolve to at least one concept in it.
-2. A matrix whose row × column bucket count would exceed ``ES_CROSS_FACET_MAX_CELLS`` (default 50,000) is refused rather than aborting server-side.
+1. A concept-scheme axis requires ``vocabulary=`` (whose host must be a subdomain of the configured vocabulary host), and the scheme must resolve to at least one concept in it.
+2. A matrix whose bucket count would exceed ``ES_CROSS_FACET_MAX_CELLS`` (default 50,000) is refused rather than aborting server-side.
 
 .. _lookup-procedure:
 

--- a/libs/sdk/pyproject.toml
+++ b/libs/sdk/pyproject.toml
@@ -36,7 +36,7 @@ license = "Apache-2.0"
 name = "destiny_sdk"
 readme = "README.md"
 requires-python = ">=3.12, <4"
-version = "0.12.2"
+version = "0.12.3"
 
 [project.optional-dependencies]
 labs = []

--- a/libs/sdk/src/destiny_sdk/references.py
+++ b/libs/sdk/src/destiny_sdk/references.py
@@ -139,21 +139,16 @@ class ReferenceFacetResult(BaseModel):
 class CrossFacetCell(BaseModel):
     """A single non-zero cell of a cross-facet (cross-tabulation) matrix."""
 
-    row: str = Field(
+    axes: tuple[str, str] = Field(
         description=(
-            "The row axis value. "
-            "If the row axis is a concept scheme, this will be its URI."
-        ),
-    )
-    column: str = Field(
-        description=(
-            "The column axis value. "
-            "If the column axis is a concept scheme, this will be its URI."
+            "The cell's value on each axis, in the same order as the requested "
+            "`axes`. Each value is a concept URI (for a concept-scheme axis) or a "
+            "code (for a country/region axis)."
         ),
     )
     count: int = Field(
         description=(
-            "Number of references matching this row and column together, under all "
+            "Number of references matching both axis values together, under all "
             "filters and the query string."
         ),
     )
@@ -163,8 +158,8 @@ class ReferenceCrossFacetResult(BaseModel):
     """
     Cross-tabulation of two axes over the references matching a search.
 
-    Each cell counts references at the strict intersection of its row value, column
-    value, all panel filters, and the query string. Only non-zero cells are returned.
+    Each cell counts references at the strict intersection of its two axis values,
+    all panel filters, and the query string. Only non-zero cells are returned.
 
     Note: cells may sum to more than ``total`` because a reference can carry multiple
     values on a single axis, so it contributes to multiple cells.

--- a/libs/sdk/src/destiny_sdk/references.py
+++ b/libs/sdk/src/destiny_sdk/references.py
@@ -167,8 +167,7 @@ class ReferenceCrossFacetResult(BaseModel):
     value, all panel filters, and the query string. Only non-zero cells are returned.
 
     Note: cells may sum to more than ``total`` because a reference can carry multiple
-    values on an axis (e.g. coded with several countries), so it contributes to
-    multiple cells.
+    values on a single axis, so it contributes to multiple cells.
     """
 
     total: SearchResultTotal = Field(

--- a/libs/sdk/src/destiny_sdk/references.py
+++ b/libs/sdk/src/destiny_sdk/references.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field, HttpUrl, TypeAdapter
 from destiny_sdk.core import UUID, SearchResultMixIn, _JsonlFileInputMixIn
 from destiny_sdk.enhancements import Enhancement, EnhancementFileInput
 from destiny_sdk.identifiers import ExternalIdentifier
+from destiny_sdk.search import SearchResultTotal
 from destiny_sdk.visibility import Visibility
 
 external_identifier_adapter: TypeAdapter[ExternalIdentifier] = TypeAdapter(
@@ -132,6 +133,49 @@ class ReferenceFacetResult(BaseModel):
     country_wb_regions: list[CountryWBRegionFacetCount] | None = Field(
         default=None,
         description="Counts of matching references per World Bank region ID.",
+    )
+
+
+class CrossFacetCell(BaseModel):
+    """A single non-zero cell of a cross-facet (cross-tabulation) matrix."""
+
+    row: str = Field(
+        description=(
+            "The row axis value. "
+            "If the row axis is a concept scheme, this will be its URI."
+        ),
+    )
+    column: str = Field(
+        description=(
+            "The column axis value. "
+            "If the column axis is a concept scheme, this will be its URI."
+        ),
+    )
+    count: int = Field(
+        description=(
+            "Number of references matching this row and column together, under all "
+            "filters and the query string."
+        ),
+    )
+
+
+class ReferenceCrossFacetResult(BaseModel):
+    """
+    Cross-tabulation of two axes over the references matching a search.
+
+    Each cell counts references at the strict intersection of its row value, column
+    value, all panel filters, and the query string. Only non-zero cells are returned.
+
+    Note: cells may sum to more than ``total`` because a reference can carry multiple
+    values on an axis (e.g. coded with several countries), so it contributes to
+    multiple cells.
+    """
+
+    total: SearchResultTotal = Field(
+        description="The total number of references matching the search criteria.",
+    )
+    cells: list[CrossFacetCell] = Field(
+        description="The non-zero cells of the cross-facet matrix.",
     )
 
 

--- a/libs/sdk/uv.lock
+++ b/libs/sdk/uv.lock
@@ -257,7 +257,7 @@ wheels = [
 
 [[package]]
 name = "destiny-sdk"
-version = "0.12.2"
+version = "0.12.3"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },

--- a/tests/integration/test_cross_facets.py
+++ b/tests/integration/test_cross_facets.py
@@ -164,7 +164,7 @@ async def cross_references(es_client: AsyncElasticsearch) -> None:
 
 
 def _cells(body: dict) -> set[tuple[str, str, int]]:
-    return {(c["row"], c["column"], c["count"]) for c in body["cells"]}
+    return {(c["axes"][0], c["axes"][1], c["count"]) for c in body["cells"]}
 
 
 async def test_scheme_by_scheme_cross_tab(
@@ -177,8 +177,7 @@ async def test_scheme_by_scheme_cross_tab(
         "/v1/references/search/cross-facets/",
         params={
             "q": "*",
-            "row": TOPICS_SCHEME,
-            "column": REGION_SCHEME,
+            "axes": [TOPICS_SCHEME, REGION_SCHEME],
             "vocabulary": primed_vocab,
         },
     )
@@ -186,23 +185,19 @@ async def test_scheme_by_scheme_cross_tab(
     body = response.json()
     assert body["total"] == {"count": 5, "is_lower_bound": False}
     assert body["cells"] == [
-        {"row": BOTANY, "column": AFRICA, "count": 3},
-        {"row": MICROBIOLOGY, "column": EUROPE, "count": 1},
-        {"row": ZOOLOGY, "column": AFRICA, "count": 1},
-        {"row": ZOOLOGY, "column": ASIA, "count": 1},
+        {"axes": [BOTANY, AFRICA], "count": 3},
+        {"axes": [MICROBIOLOGY, EUROPE], "count": 1},
+        {"axes": [ZOOLOGY, AFRICA], "count": 1},
+        {"axes": [ZOOLOGY, ASIA], "count": 1},
     ]
 
 
 @pytest.mark.parametrize(
     ("params", "expected"),
     [
-        # concept rows x region-literal columns (include omitted on the column)
+        # concept axis x region-literal axis (include omitted on the literal axis)
         (
-            {
-                "row": TOPICS_SCHEME,
-                "column": "country_wb_regions",
-                "vocabulary": VOCAB_URI,
-            },
+            {"axes": [TOPICS_SCHEME, "country_wb_regions"], "vocabulary": VOCAB_URI},
             {
                 (BOTANY, REGION_SSF, 3),
                 (ZOOLOGY, REGION_NAC, 1),
@@ -212,7 +207,7 @@ async def test_scheme_by_scheme_cross_tab(
         ),
         # two literal axes, no vocabulary needed
         (
-            {"row": "countries", "column": "country_wb_regions"},
+            {"axes": ["countries", "country_wb_regions"]},
             {
                 (COUNTRY_KE, REGION_SSF, 3),
                 (COUNTRY_US, REGION_NAC, 1),
@@ -221,7 +216,7 @@ async def test_scheme_by_scheme_cross_tab(
         ),
         # identical axes -> diagonal co-occurrence matrix
         (
-            {"row": "country_wb_regions", "column": "country_wb_regions"},
+            {"axes": ["country_wb_regions", "country_wb_regions"]},
             {(REGION_SSF, REGION_SSF, 4), (REGION_NAC, REGION_NAC, 1)},
         ),
     ],
@@ -248,7 +243,7 @@ async def test_query_string_and_empty_result(
     """`q` narrows the matrix; a query matching nothing yields an empty matrix."""
     response = await client.get(
         "/v1/references/search/cross-facets/",
-        params={"q": "title:Asia", "row": "countries", "column": "country_wb_regions"},
+        params={"q": "title:Asia", "axes": ["countries", "country_wb_regions"]},
     )
     assert response.status_code == status.HTTP_200_OK, response.text
     assert response.json()["total"] == {"count": 1, "is_lower_bound": False}
@@ -256,11 +251,7 @@ async def test_query_string_and_empty_result(
 
     response = await client.get(
         "/v1/references/search/cross-facets/",
-        params={
-            "q": "title:nope_xyz",
-            "row": "countries",
-            "column": "country_wb_regions",
-        },
+        params={"q": "title:nope_xyz", "axes": ["countries", "country_wb_regions"]},
     )
     assert response.status_code == status.HTTP_200_OK, response.text
     assert response.json() == {
@@ -273,21 +264,24 @@ async def test_query_string_and_empty_result(
     ("params", "expected_status", "detail"),
     [
         # scheme axis with no vocabulary
-        ({"row": TOPICS_SCHEME, "column": "countries"}, 400, "vocabulary"),
+        ({"axes": [TOPICS_SCHEME, "countries"]}, 400, "vocabulary"),
         # matrix too large (256 x 256 countries)
-        ({"row": "countries", "column": "countries"}, 400, "exceeding the limit"),
+        ({"axes": ["countries", "countries"]}, 400, "exceeding the limit"),
         # scheme URI absent from the vocabulary
         (
-            {"row": NOT_A_SCHEME, "column": "countries", "vocabulary": VOCAB_URI},
+            {"axes": [NOT_A_SCHEME, "countries"], "vocabulary": VOCAB_URI},
             400,
             "no members",
         ),
         # vocabulary host outside the allowed domain
         (
-            {"row": TOPICS_SCHEME, "column": "countries", "vocabulary": BAD_HOST_VOCAB},
+            {"axes": [TOPICS_SCHEME, "countries"], "vocabulary": BAD_HOST_VOCAB},
             422,
             None,
         ),
+        # not exactly two axes (tuple length enforced by the schema)
+        ({"axes": ["countries"]}, 422, None),
+        ({"axes": ["countries", "countries", "countries"]}, 422, None),
     ],
 )
 async def test_cross_facet_request_rejected(
@@ -325,8 +319,7 @@ async def test_unfetchable_vocabulary_returns_400(
         "/v1/references/search/cross-facets/",
         params={
             "q": "*",
-            "row": TOPICS_SCHEME,
-            "column": "countries",
+            "axes": [TOPICS_SCHEME, "countries"],
             "vocabulary": "https://vocab.evidence-repository.org/test/missing",
         },
     )

--- a/tests/integration/test_cross_facets.py
+++ b/tests/integration/test_cross_facets.py
@@ -269,6 +269,71 @@ async def test_query_string_and_empty_result(
     }
 
 
+async def test_panel_filter_narrows_whole_matrix(
+    client: AsyncClient,
+    cross_references: None,  # noqa: ARG001
+) -> None:
+    """A panel filter narrows every cell, even where it overlaps an axis."""
+    response = await client.get(
+        "/v1/references/search/cross-facets/",
+        params={
+            "q": "*",
+            "axes": ["countries", "country_wb_regions"],
+            "country": COUNTRY_KE,
+        },
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+    # Only KE docs (1, 2, 5, 6) survive, all SSF — the country filter overlaps the
+    # country axis and still applies, leaving KE as the only row.
+    assert response.json()["total"] == {"count": 4, "is_lower_bound": False}
+    assert _cells(response.json()) == {(COUNTRY_KE, REGION_SSF, 4)}
+
+
+async def test_multiple_andd_filters_narrow(
+    client: AsyncClient,
+    cross_references: None,  # noqa: ARG001
+) -> None:
+    """Multiple filters AND (no OR-grouping): KE and US together match nothing."""
+    response = await client.get(
+        "/v1/references/search/cross-facets/",
+        params={
+            "q": "*",
+            "axes": ["countries", "country_wb_regions"],
+            "country": [COUNTRY_KE, COUNTRY_US],
+        },
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert response.json() == {
+        "total": {"count": 0, "is_lower_bound": False},
+        "cells": [],
+    }
+
+
+async def test_filter_overlapping_a_scheme_axis_still_applies(
+    client: AsyncClient,
+    cross_references: None,  # noqa: ARG001
+    primed_vocab: str,
+) -> None:
+    """A concept filter on the row scheme narrows docs but doesn't restrict the axis."""
+    response = await client.get(
+        "/v1/references/search/cross-facets/",
+        params={
+            "q": "*",
+            "axes": [TOPICS_SCHEME, "country_wb_regions"],
+            "concept": BOTANY,
+            "vocabulary": primed_vocab,
+        },
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+    # Restricted to Botany docs (1, 2, 5, 6); Zoology still surfaces because docs 5/6
+    # carry it too — the overlapping filter narrows the matrix, not the axis.
+    assert response.json()["total"] == {"count": 4, "is_lower_bound": False}
+    assert _cells(response.json()) == {
+        (BOTANY, REGION_SSF, 4),
+        (ZOOLOGY, REGION_SSF, 2),
+    }
+
+
 @pytest.mark.parametrize(
     ("params", "expected_status", "detail"),
     [
@@ -313,12 +378,12 @@ async def test_cross_facet_request_rejected(
         assert detail in response.text
 
 
-async def test_unfetchable_vocabulary_returns_400(
+async def test_unfetchable_vocabulary_returns_502(
     client: AsyncClient,
     cross_references: None,  # noqa: ARG001
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A host-valid but unfetchable vocabulary surfaces as a 400, not a 500."""
+    """An unfetchable (but host-valid) vocabulary is an upstream failure: 502."""
     monkeypatch.setattr(
         get_vocabulary_artifact_client(),
         "get_scheme_members",
@@ -332,4 +397,4 @@ async def test_unfetchable_vocabulary_returns_400(
             "vocabulary": "https://vocab.evidence-repository.org/test/missing",
         },
     )
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.status_code == status.HTTP_502_BAD_GATEWAY

--- a/tests/integration/test_cross_facets.py
+++ b/tests/integration/test_cross_facets.py
@@ -1,0 +1,333 @@
+"""Integration tests for the `/references/search/cross-facets/` endpoint."""
+
+from collections.abc import AsyncGenerator, Iterator
+from unittest.mock import AsyncMock
+from uuid import uuid7
+
+import pytest
+from elasticsearch import AsyncElasticsearch
+from fastapi import FastAPI, status
+from httpx import ASGITransport, AsyncClient
+from rdflib import Graph
+
+from app.api.exception_handlers import (
+    es_exception_handler,
+    parse_error_exception_handler,
+    vocabulary_fetch_exception_handler,
+)
+from app.core.exceptions import ESQueryError, ParseError, VocabularyFetchError
+from app.domain.references import routes as references
+from app.domain.references.models.es import ReferenceDocument
+from app.domain.references.models.models import Visibility
+from app.external.vocabulary.client import get_vocabulary_artifact_client
+
+pytestmark = pytest.mark.usefixtures("session")
+
+
+# ---- Vocabulary fixture: two schemes (Topics, Region) ----------------------------
+
+VOCAB_URI = "https://vocab.evidence-repository.org/test/v1"
+TOPICS_SCHEME = "https://vocab.example.org/test/Topics"
+REGION_SCHEME = "https://vocab.example.org/test/Region"
+
+VOCAB_TURTLE = """\
+@prefix ex:   <https://vocab.example.org/test/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+ex:Topics a skos:ConceptScheme .
+ex:Botany       a skos:Concept ; skos:inScheme ex:Topics ; skos:prefLabel "Botany" .
+ex:Zoology      a skos:Concept ; skos:inScheme ex:Topics ; skos:prefLabel "Zoology" .
+ex:Microbiology a skos:Concept ; skos:inScheme ex:Topics ;
+                skos:prefLabel "Microbiology" .
+
+ex:Region a skos:ConceptScheme .
+ex:Africa a skos:Concept ; skos:inScheme ex:Region ; skos:prefLabel "Africa" .
+ex:Asia   a skos:Concept ; skos:inScheme ex:Region ; skos:prefLabel "Asia" .
+ex:Europe a skos:Concept ; skos:inScheme ex:Region ; skos:prefLabel "Europe" .
+"""
+
+BOTANY = "https://vocab.example.org/test/Botany"
+ZOOLOGY = "https://vocab.example.org/test/Zoology"
+MICROBIOLOGY = "https://vocab.example.org/test/Microbiology"
+AFRICA = "https://vocab.example.org/test/Africa"
+ASIA = "https://vocab.example.org/test/Asia"
+EUROPE = "https://vocab.example.org/test/Europe"
+
+# ISO 3166-1 alpha-2 codes and their World Bank region IDs (KE/UG -> SSF, US -> NAC).
+COUNTRY_KE = "KE"
+COUNTRY_UG = "UG"
+COUNTRY_US = "US"
+REGION_SSF = "SSF"
+REGION_NAC = "NAC"
+
+NOT_A_SCHEME = "https://vocab.example.org/test/NotAScheme"
+BAD_HOST_VOCAB = "https://vocab.evil.example.org/v.ttl"
+
+
+@pytest.fixture
+def primed_vocab() -> Iterator[str]:
+    """Pre-populate the vocab client's graph cache with the two-scheme fixture."""
+    graph = Graph()
+    graph.parse(data=VOCAB_TURTLE, format="turtle")
+    client = get_vocabulary_artifact_client()
+    client._vocabulary_cache[VOCAB_URI] = graph  # noqa: SLF001
+    try:
+        yield VOCAB_URI
+    finally:
+        client._vocabulary_cache.pop(VOCAB_URI, None)  # noqa: SLF001
+        client.get_scheme_members.cache_clear()
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    """Create a FastAPI application instance for testing."""
+    app = FastAPI(
+        exception_handlers={
+            ESQueryError: es_exception_handler,
+            ParseError: parse_error_exception_handler,
+            VocabularyFetchError: vocabulary_fetch_exception_handler,
+        }
+    )
+    app.include_router(references.reference_router, prefix="/v1")
+    return app
+
+
+@pytest.fixture
+async def client(
+    app: FastAPI,
+    es_client: AsyncElasticsearch,  # noqa: ARG001
+) -> AsyncGenerator[AsyncClient, None]:
+    """Create a test client for the FastAPI application."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        yield client
+
+
+@pytest.fixture
+async def cross_references(es_client: AsyncElasticsearch) -> None:
+    """
+    Index references with Topics/Region concepts plus countries and wb regions.
+
+    - doc 1: Botany, Africa;          KE; SSF
+    - doc 2: Botany, Africa;          KE; SSF
+    - doc 3: Zoology, Asia;           US; NAC
+    - doc 4: Microbiology, Europe;    UG; SSF
+    - doc 5: Botany, Zoology, Africa; KE; SSF   (multi-valued on Topics)
+    """
+    docs = [
+        ReferenceDocument(
+            meta={"id": uuid7()},
+            visibility=Visibility.PUBLIC,
+            title="Botany in Africa one",
+            linked_data_concepts=[BOTANY, AFRICA],
+            linked_data_countries=[COUNTRY_KE],
+            linked_data_country_wb_regions=[REGION_SSF],
+        ),
+        ReferenceDocument(
+            meta={"id": uuid7()},
+            visibility=Visibility.PUBLIC,
+            title="Botany in Africa two",
+            linked_data_concepts=[BOTANY, AFRICA],
+            linked_data_countries=[COUNTRY_KE],
+            linked_data_country_wb_regions=[REGION_SSF],
+        ),
+        ReferenceDocument(
+            meta={"id": uuid7()},
+            visibility=Visibility.PUBLIC,
+            title="Zoology in Asia",
+            linked_data_concepts=[ZOOLOGY, ASIA],
+            linked_data_countries=[COUNTRY_US],
+            linked_data_country_wb_regions=[REGION_NAC],
+        ),
+        ReferenceDocument(
+            meta={"id": uuid7()},
+            visibility=Visibility.PUBLIC,
+            title="Microbiology in Europe",
+            linked_data_concepts=[MICROBIOLOGY, EUROPE],
+            linked_data_countries=[COUNTRY_UG],
+            linked_data_country_wb_regions=[REGION_SSF],
+        ),
+        ReferenceDocument(
+            meta={"id": uuid7()},
+            visibility=Visibility.PUBLIC,
+            title="Botany and Zoology in Africa",
+            linked_data_concepts=[BOTANY, ZOOLOGY, AFRICA],
+            linked_data_countries=[COUNTRY_KE],
+            linked_data_country_wb_regions=[REGION_SSF],
+        ),
+    ]
+    for doc in docs:
+        await doc.save(using=es_client)
+    await es_client.indices.refresh(index=ReferenceDocument.Index.name)
+
+
+def _cells(body: dict) -> set[tuple[str, str, int]]:
+    return {(c["row"], c["column"], c["count"]) for c in body["cells"]}
+
+
+async def test_scheme_by_scheme_cross_tab(
+    client: AsyncClient,
+    cross_references: None,  # noqa: ARG001
+    primed_vocab: str,
+) -> None:
+    """Cells are ordered by count desc; doc 5 puts two cells over the total of 5."""
+    response = await client.get(
+        "/v1/references/search/cross-facets/",
+        params={
+            "q": "*",
+            "row": TOPICS_SCHEME,
+            "column": REGION_SCHEME,
+            "vocabulary": primed_vocab,
+        },
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+    body = response.json()
+    assert body["total"] == {"count": 5, "is_lower_bound": False}
+    assert body["cells"] == [
+        {"row": BOTANY, "column": AFRICA, "count": 3},
+        {"row": MICROBIOLOGY, "column": EUROPE, "count": 1},
+        {"row": ZOOLOGY, "column": AFRICA, "count": 1},
+        {"row": ZOOLOGY, "column": ASIA, "count": 1},
+    ]
+
+
+@pytest.mark.parametrize(
+    ("params", "expected"),
+    [
+        # concept rows x region-literal columns (include omitted on the column)
+        (
+            {
+                "row": TOPICS_SCHEME,
+                "column": "country_wb_regions",
+                "vocabulary": VOCAB_URI,
+            },
+            {
+                (BOTANY, REGION_SSF, 3),
+                (ZOOLOGY, REGION_NAC, 1),
+                (ZOOLOGY, REGION_SSF, 1),
+                (MICROBIOLOGY, REGION_SSF, 1),
+            },
+        ),
+        # two literal axes, no vocabulary needed
+        (
+            {"row": "countries", "column": "country_wb_regions"},
+            {
+                (COUNTRY_KE, REGION_SSF, 3),
+                (COUNTRY_US, REGION_NAC, 1),
+                (COUNTRY_UG, REGION_SSF, 1),
+            },
+        ),
+        # identical axes -> diagonal co-occurrence matrix
+        (
+            {"row": "country_wb_regions", "column": "country_wb_regions"},
+            {(REGION_SSF, REGION_SSF, 4), (REGION_NAC, REGION_NAC, 1)},
+        ),
+    ],
+)
+async def test_cross_facet_cells(
+    client: AsyncClient,
+    cross_references: None,  # noqa: ARG001
+    primed_vocab: str,  # noqa: ARG001
+    params: dict,
+    expected: set,
+) -> None:
+    """Mixed, literal-only, and identical axes each return the expected cells."""
+    response = await client.get(
+        "/v1/references/search/cross-facets/", params={"q": "*", **params}
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert _cells(response.json()) == expected
+
+
+async def test_query_string_and_empty_result(
+    client: AsyncClient,
+    cross_references: None,  # noqa: ARG001
+) -> None:
+    """`q` narrows the matrix; a query matching nothing yields an empty matrix."""
+    response = await client.get(
+        "/v1/references/search/cross-facets/",
+        params={"q": "title:Asia", "row": "countries", "column": "country_wb_regions"},
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert response.json()["total"] == {"count": 1, "is_lower_bound": False}
+    assert _cells(response.json()) == {(COUNTRY_US, REGION_NAC, 1)}
+
+    response = await client.get(
+        "/v1/references/search/cross-facets/",
+        params={
+            "q": "title:nope_xyz",
+            "row": "countries",
+            "column": "country_wb_regions",
+        },
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert response.json() == {
+        "total": {"count": 0, "is_lower_bound": False},
+        "cells": [],
+    }
+
+
+@pytest.mark.parametrize(
+    ("params", "expected_status", "detail"),
+    [
+        # scheme axis with no vocabulary
+        ({"row": TOPICS_SCHEME, "column": "countries"}, 400, "vocabulary"),
+        # matrix too large (256 x 256 countries)
+        ({"row": "countries", "column": "countries"}, 400, "exceeding the limit"),
+        # scheme URI absent from the vocabulary
+        (
+            {"row": NOT_A_SCHEME, "column": "countries", "vocabulary": VOCAB_URI},
+            400,
+            "no members",
+        ),
+        # vocabulary host outside the allowed domain
+        (
+            {"row": TOPICS_SCHEME, "column": "countries", "vocabulary": BAD_HOST_VOCAB},
+            422,
+            None,
+        ),
+    ],
+)
+async def test_cross_facet_request_rejected(
+    client: AsyncClient,
+    primed_vocab: str,  # noqa: ARG001
+    params: dict,
+    expected_status: int,
+    detail: str | None,
+) -> None:
+    """
+    Bad axes, oversized matrices, and bad vocabularies are rejected (4xx).
+
+    These all fail validation before any ES query, so no indexed docs are needed.
+    """
+    response = await client.get(
+        "/v1/references/search/cross-facets/", params={"q": "*", **params}
+    )
+    assert response.status_code == expected_status, response.text
+    if detail:
+        assert detail in response.text
+
+
+async def test_unfetchable_vocabulary_returns_400(
+    client: AsyncClient,
+    cross_references: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A host-valid but unfetchable vocabulary surfaces as a 400, not a 500."""
+    monkeypatch.setattr(
+        get_vocabulary_artifact_client(),
+        "get_scheme_members",
+        AsyncMock(side_effect=VocabularyFetchError("bad", "boom")),
+    )
+    response = await client.get(
+        "/v1/references/search/cross-facets/",
+        params={
+            "q": "*",
+            "row": TOPICS_SCHEME,
+            "column": "countries",
+            "vocabulary": "https://vocab.evidence-repository.org/test/missing",
+        },
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/tests/integration/test_cross_facets.py
+++ b/tests/integration/test_cross_facets.py
@@ -115,6 +115,7 @@ async def cross_references(es_client: AsyncElasticsearch) -> None:
     - doc 3: Zoology, Asia;           US; NAC
     - doc 4: Microbiology, Europe;    UG; SSF
     - doc 5: Botany, Zoology, Africa; KE; SSF   (multi-valued on Topics)
+    - doc 6: Botany, Zoology, Africa; KE; SSF   (multi-valued on Topics)
     """
     docs = [
         ReferenceDocument(
@@ -157,6 +158,14 @@ async def cross_references(es_client: AsyncElasticsearch) -> None:
             linked_data_countries=[COUNTRY_KE],
             linked_data_country_wb_regions=[REGION_SSF],
         ),
+        ReferenceDocument(
+            meta={"id": uuid7()},
+            visibility=Visibility.PUBLIC,
+            title="More botany and zoology in Africa",
+            linked_data_concepts=[BOTANY, ZOOLOGY, AFRICA],
+            linked_data_countries=[COUNTRY_KE],
+            linked_data_country_wb_regions=[REGION_SSF],
+        ),
     ]
     for doc in docs:
         await doc.save(using=es_client)
@@ -172,7 +181,7 @@ async def test_scheme_by_scheme_cross_tab(
     cross_references: None,  # noqa: ARG001
     primed_vocab: str,
 ) -> None:
-    """Cells are ordered by count desc; doc 5 puts two cells over the total of 5."""
+    """Cells are sorted by descending count, interleaving axis values."""
     response = await client.get(
         "/v1/references/search/cross-facets/",
         params={
@@ -183,11 +192,11 @@ async def test_scheme_by_scheme_cross_tab(
     )
     assert response.status_code == status.HTTP_200_OK, response.text
     body = response.json()
-    assert body["total"] == {"count": 5, "is_lower_bound": False}
+    assert body["total"] == {"count": 6, "is_lower_bound": False}
     assert body["cells"] == [
-        {"axes": [BOTANY, AFRICA], "count": 3},
+        {"axes": [BOTANY, AFRICA], "count": 4},
+        {"axes": [ZOOLOGY, AFRICA], "count": 2},
         {"axes": [MICROBIOLOGY, EUROPE], "count": 1},
-        {"axes": [ZOOLOGY, AFRICA], "count": 1},
         {"axes": [ZOOLOGY, ASIA], "count": 1},
     ]
 
@@ -199,9 +208,9 @@ async def test_scheme_by_scheme_cross_tab(
         (
             {"axes": [TOPICS_SCHEME, "country_wb_regions"], "vocabulary": VOCAB_URI},
             {
-                (BOTANY, REGION_SSF, 3),
+                (BOTANY, REGION_SSF, 4),
                 (ZOOLOGY, REGION_NAC, 1),
-                (ZOOLOGY, REGION_SSF, 1),
+                (ZOOLOGY, REGION_SSF, 2),
                 (MICROBIOLOGY, REGION_SSF, 1),
             },
         ),
@@ -209,7 +218,7 @@ async def test_scheme_by_scheme_cross_tab(
         (
             {"axes": ["countries", "country_wb_regions"]},
             {
-                (COUNTRY_KE, REGION_SSF, 3),
+                (COUNTRY_KE, REGION_SSF, 4),
                 (COUNTRY_US, REGION_NAC, 1),
                 (COUNTRY_UG, REGION_SSF, 1),
             },
@@ -217,7 +226,7 @@ async def test_scheme_by_scheme_cross_tab(
         # identical axes -> diagonal co-occurrence matrix
         (
             {"axes": ["country_wb_regions", "country_wb_regions"]},
-            {(REGION_SSF, REGION_SSF, 4), (REGION_NAC, REGION_NAC, 1)},
+            {(REGION_SSF, REGION_SSF, 5), (REGION_NAC, REGION_NAC, 1)},
         ),
     ],
 )

--- a/tests/unit/domain/references/services/test_search_service.py
+++ b/tests/unit/domain/references/services/test_search_service.py
@@ -518,22 +518,19 @@ def test_resolve_cross_facet_axis():
     ],
 )
 def test_resolve_cross_facet_axis_rejects(token, vocab, members, match):
-    """A scheme axis without a vocabulary, or absent from it, is a 400-level error."""
+    """A scheme axis without a vocabulary, or absent from it, raises ParseError."""
     with pytest.raises(ParseError, match=match):
         SearchService._resolve_cross_facet_axis(token, vocab, members)  # noqa: SLF001
 
 
 def test_validate_cross_facet_cell_count():
-    """A matrix within the cell limit passes; over it raises ParseError."""
-    small = CrossFacetAxis(
+    """A matrix within ``max_cells`` passes; over it raises ParseError."""
+    axis = CrossFacetAxis(
         token="countries", facet_type=FacetType.COUNTRIES, include=None, size=100
     )
-    SearchService._validate_cross_facet_cell_count(small, small)  # noqa: SLF001
-    big = CrossFacetAxis(
-        token="x", facet_type=FacetType.CONCEPTS, include=None, size=300
-    )
+    SearchService._validate_cross_facet_cell_count(axis, axis, max_cells=10_000)  # noqa: SLF001
     with pytest.raises(ParseError, match="exceeding the limit"):
-        SearchService._validate_cross_facet_cell_count(big, big)  # noqa: SLF001
+        SearchService._validate_cross_facet_cell_count(axis, axis, max_cells=9_999)  # noqa: SLF001
 
 
 async def test_aggregate_cross_facet_literal_axes_skip_vocab_fetch(

--- a/tests/unit/domain/references/services/test_search_service.py
+++ b/tests/unit/domain/references/services/test_search_service.py
@@ -524,13 +524,13 @@ def test_resolve_cross_facet_axis_rejects(token, vocab, members, match):
 
 
 def test_validate_cross_facet_cell_count():
-    """A matrix within ``max_cells`` passes; over it raises ParseError."""
+    """The guard counts parent buckets too: axes (100, 100) -> 100 + 100*100 buckets."""
     axis = CrossFacetAxis(
         token="countries", facet_type=FacetType.COUNTRIES, include=None, size=100
     )
-    SearchService._validate_cross_facet_cell_count((axis, axis), max_cells=10_000)  # noqa: SLF001
+    SearchService._validate_cross_facet_cell_count((axis, axis), max_cells=10_100)  # noqa: SLF001
     with pytest.raises(ParseError, match="exceeding the limit"):
-        SearchService._validate_cross_facet_cell_count((axis, axis), max_cells=9_999)  # noqa: SLF001
+        SearchService._validate_cross_facet_cell_count((axis, axis), max_cells=10_099)  # noqa: SLF001
 
 
 async def test_aggregate_cross_facet_literal_axes_skip_vocab_fetch(

--- a/tests/unit/domain/references/services/test_search_service.py
+++ b/tests/unit/domain/references/services/test_search_service.py
@@ -6,9 +6,10 @@ import pytest
 from elasticsearch import AsyncElasticsearch
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.exceptions import SiblingGroupingError
+from app.core.exceptions import ParseError, SiblingGroupingError
 from app.domain.references.models.models import (
     AnnotationFilter,
+    CrossFacetAxis,
     FacetType,
     LinkedDataConceptFilter,
     LinkedDataCountryFilter,
@@ -21,6 +22,7 @@ from app.domain.references.services.anti_corruption_service import (
     ReferenceAntiCorruptionService,
 )
 from app.domain.references.services.search_service import SearchService
+from app.domain.references.services.world_bank_regions import WORLD_BANK_REGIONS
 from app.external.vocabulary.client import VocabularyArtifactClient
 from app.persistence.blob.repository import BlobRepository
 from app.persistence.es.uow import AsyncESUnitOfWork
@@ -469,3 +471,98 @@ async def test_aggregate_facets_rejects_multiple_country_filters_with_facet(
             facets=(FacetType.COUNTRIES,),
             vocabulary_uri=None,
         )
+
+
+# ---- aggregate_cross_facet ------------------------------------------------------
+
+TOPICS_SCHEME = "https://vocab.example.org/Topics"
+REGION_SCHEME = "https://vocab.example.org/Region"
+MEMBERS_FIXTURE: dict[str, frozenset[str]] = {
+    TOPICS_SCHEME: _TOPICS,
+    REGION_SCHEME: _REGIONS,
+}
+
+
+@pytest.fixture
+def vocab_client_with_members() -> MagicMock:
+    client = MagicMock(spec=VocabularyArtifactClient)
+    client.get_scheme_members = AsyncMock(return_value=MEMBERS_FIXTURE)
+    return client
+
+
+def test_resolve_cross_facet_axis():
+    """Literal axes carry a fixed size; a scheme axis is scoped to its members."""
+    countries = SearchService._resolve_cross_facet_axis("countries", None, None)  # noqa: SLF001
+    regions = SearchService._resolve_cross_facet_axis("country_wb_regions", None, None)  # noqa: SLF001
+    scheme = SearchService._resolve_cross_facet_axis(  # noqa: SLF001
+        TOPICS_SCHEME, VOCAB_URI, MEMBERS_FIXTURE
+    )
+    assert (countries.facet_type, countries.include, countries.size) == (
+        FacetType.COUNTRIES,
+        None,
+        256,
+    )
+    assert regions.size == len(WORLD_BANK_REGIONS)
+    assert (scheme.facet_type, scheme.include, scheme.size) == (
+        FacetType.CONCEPTS,
+        _TOPICS,
+        len(_TOPICS),
+    )
+
+
+@pytest.mark.parametrize(
+    ("token", "vocab", "members", "match"),
+    [
+        (TOPICS_SCHEME, None, None, "`vocabulary=` is required"),
+        ("https://vocab.example.org/Missing", VOCAB_URI, MEMBERS_FIXTURE, "no members"),
+    ],
+)
+def test_resolve_cross_facet_axis_rejects(token, vocab, members, match):
+    """A scheme axis without a vocabulary, or absent from it, is a 400-level error."""
+    with pytest.raises(ParseError, match=match):
+        SearchService._resolve_cross_facet_axis(token, vocab, members)  # noqa: SLF001
+
+
+def test_validate_cross_facet_cell_count():
+    """A matrix within the cell limit passes; over it raises ParseError."""
+    small = CrossFacetAxis(
+        token="countries", facet_type=FacetType.COUNTRIES, include=None, size=100
+    )
+    SearchService._validate_cross_facet_cell_count(small, small)  # noqa: SLF001
+    big = CrossFacetAxis(
+        token="x", facet_type=FacetType.CONCEPTS, include=None, size=300
+    )
+    with pytest.raises(ParseError, match="exceeding the limit"):
+        SearchService._validate_cross_facet_cell_count(big, big)  # noqa: SLF001
+
+
+async def test_aggregate_cross_facet_literal_axes_skip_vocab_fetch(
+    vocab_client_with_members: MagicMock,
+):
+    """Two literal axes need no vocabulary lookup and pass resolved axes to the repo."""
+    service = _service(vocab_client_with_members)
+    service.es_uow.references = MagicMock()  # type: ignore[union-attr]
+    service.es_uow.references.aggregate_cross_facet = AsyncMock(return_value=([], None))  # type: ignore[union-attr]
+    await service.aggregate_cross_facet(
+        SearchQuery(query_string="*"), "countries", "country_wb_regions", None
+    )
+    vocab_client_with_members.get_scheme_members.assert_not_called()
+    (_query, row, column), _ = service.es_uow.references.aggregate_cross_facet.call_args  # type: ignore[union-attr]
+    assert row.facet_type is FacetType.COUNTRIES
+    assert column.facet_type is FacetType.COUNTRY_WB_REGIONS
+
+
+async def test_aggregate_cross_facet_scheme_axis_fetches_members_once(
+    vocab_client_with_members: MagicMock,
+):
+    """A scheme axis triggers a single vocabulary fetch shared across both axes."""
+    service = _service(vocab_client_with_members)
+    service.es_uow.references = MagicMock()  # type: ignore[union-attr]
+    service.es_uow.references.aggregate_cross_facet = AsyncMock(return_value=([], None))  # type: ignore[union-attr]
+    await service.aggregate_cross_facet(
+        SearchQuery(query_string="*"), TOPICS_SCHEME, REGION_SCHEME, VOCAB_URI
+    )
+    vocab_client_with_members.get_scheme_members.assert_awaited_once_with(VOCAB_URI)
+    (_query, row, column), _ = service.es_uow.references.aggregate_cross_facet.call_args  # type: ignore[union-attr]
+    assert row.include == _TOPICS
+    assert column.include == _REGIONS

--- a/tests/unit/domain/references/services/test_search_service.py
+++ b/tests/unit/domain/references/services/test_search_service.py
@@ -528,9 +528,9 @@ def test_validate_cross_facet_cell_count():
     axis = CrossFacetAxis(
         token="countries", facet_type=FacetType.COUNTRIES, include=None, size=100
     )
-    SearchService._validate_cross_facet_cell_count(axis, axis, max_cells=10_000)  # noqa: SLF001
+    SearchService._validate_cross_facet_cell_count((axis, axis), max_cells=10_000)  # noqa: SLF001
     with pytest.raises(ParseError, match="exceeding the limit"):
-        SearchService._validate_cross_facet_cell_count(axis, axis, max_cells=9_999)  # noqa: SLF001
+        SearchService._validate_cross_facet_cell_count((axis, axis), max_cells=9_999)  # noqa: SLF001
 
 
 async def test_aggregate_cross_facet_literal_axes_skip_vocab_fetch(
@@ -541,12 +541,12 @@ async def test_aggregate_cross_facet_literal_axes_skip_vocab_fetch(
     service.es_uow.references = MagicMock()  # type: ignore[union-attr]
     service.es_uow.references.aggregate_cross_facet = AsyncMock(return_value=([], None))  # type: ignore[union-attr]
     await service.aggregate_cross_facet(
-        SearchQuery(query_string="*"), "countries", "country_wb_regions", None
+        SearchQuery(query_string="*"), ("countries", "country_wb_regions"), None
     )
     vocab_client_with_members.get_scheme_members.assert_not_called()
-    (_query, row, column), _ = service.es_uow.references.aggregate_cross_facet.call_args  # type: ignore[union-attr]
-    assert row.facet_type is FacetType.COUNTRIES
-    assert column.facet_type is FacetType.COUNTRY_WB_REGIONS
+    (_query, axes), _ = service.es_uow.references.aggregate_cross_facet.call_args  # type: ignore[union-attr]
+    assert axes[0].facet_type is FacetType.COUNTRIES
+    assert axes[1].facet_type is FacetType.COUNTRY_WB_REGIONS
 
 
 async def test_aggregate_cross_facet_scheme_axis_fetches_members_once(
@@ -557,9 +557,9 @@ async def test_aggregate_cross_facet_scheme_axis_fetches_members_once(
     service.es_uow.references = MagicMock()  # type: ignore[union-attr]
     service.es_uow.references.aggregate_cross_facet = AsyncMock(return_value=([], None))  # type: ignore[union-attr]
     await service.aggregate_cross_facet(
-        SearchQuery(query_string="*"), TOPICS_SCHEME, REGION_SCHEME, VOCAB_URI
+        SearchQuery(query_string="*"), (TOPICS_SCHEME, REGION_SCHEME), VOCAB_URI
     )
     vocab_client_with_members.get_scheme_members.assert_awaited_once_with(VOCAB_URI)
-    (_query, row, column), _ = service.es_uow.references.aggregate_cross_facet.call_args  # type: ignore[union-attr]
-    assert row.include == _TOPICS
-    assert column.include == _REGIONS
+    (_query, axes), _ = service.es_uow.references.aggregate_cross_facet.call_args  # type: ignore[union-attr]
+    assert axes[0].include == _TOPICS
+    assert axes[1].include == _REGIONS

--- a/tests/unit/external/vocabulary/test_client.py
+++ b/tests/unit/external/vocabulary/test_client.py
@@ -4,11 +4,13 @@ import httpx
 import pytest
 import pytest_asyncio
 from pytest_httpx import HTTPXMock
+from rdflib import Graph
 
 from app.core.exceptions import VocabularyFetchError
 from app.external.vocabulary.client import (
     ContextNotPreFetchedError,
     VocabularyArtifactClient,
+    _build_scheme_members,
 )
 
 SAMPLE_TURTLE = """\
@@ -352,3 +354,94 @@ class TestSkosDerivedLookups:
         # Multi-parented: union of co-children across both parents.
         # Quantum is the only child of both Physics and Mathematics.
         assert siblings[_concept("Quantum")] == frozenset({_concept("Quantum")})
+
+    @pytest.mark.asyncio
+    async def test_scheme_members_covers_every_membership_shape(
+        self, skos_client: VocabularyArtifactClient
+    ):
+        members = await skos_client.get_scheme_members(VOCAB_URI)
+
+        # Hierarchical scheme: top concepts and their broader-children alike.
+        assert members[_concept("Topics")] == frozenset(
+            {
+                _concept("Biology"),
+                _concept("Chemistry"),
+                _concept("Botany"),
+                _concept("Zoology"),
+                _concept("Microbiology"),
+            }
+        )
+        # Flat scheme via skos:topConceptOf.
+        assert members[_concept("Regions")] == frozenset(
+            {_concept("Africa"), _concept("Asia")}
+        )
+        # Flat scheme via skos:hasTopConcept.
+        assert members[_concept("Fruits")] == frozenset(
+            {_concept("Apple"), _concept("Pear")}
+        )
+        # Flat scheme via skos:inScheme only.
+        assert members[_concept("Languages")] == frozenset(
+            {_concept("English"), _concept("Spanish")}
+        )
+        # Unknown scheme URIs are simply absent.
+        assert _concept("DoesNotExist") not in members
+
+
+class TestBuildSchemeMembers:
+    """Edge cases for scheme membership that the shared fixture can't express."""
+
+    def test_descendant_without_inscheme_inherits_via_broader(self):
+        """A leaf with only skos:broader is still a member of its ancestor's scheme."""
+        graph = Graph()
+        graph.parse(
+            data="""\
+@prefix ex:   <http://example.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+ex:Topics a skos:ConceptScheme .
+ex:Bio    a skos:Concept ; skos:inScheme ex:Topics ; skos:topConceptOf ex:Topics .
+ex:Botany a skos:Concept ; skos:inScheme ex:Topics ; skos:broader ex:Bio .
+ex:Leaf   a skos:Concept ; skos:broader ex:Botany .
+""",
+            format="turtle",
+        )
+        members = _build_scheme_members(graph)
+        # Leaf carries no inScheme, but is reachable up the broader chain to Topics.
+        assert members[_concept("Topics")] == frozenset(
+            {_concept("Bio"), _concept("Botany"), _concept("Leaf")}
+        )
+
+    def test_explicit_scheme_is_not_reassigned_via_broader(self):
+        """A broader edge crossing scheme boundaries does not leak members."""
+        graph = Graph()
+        graph.parse(
+            data="""\
+@prefix ex:   <http://example.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+ex:SchemeA a skos:ConceptScheme .
+ex:SchemeB a skos:ConceptScheme .
+ex:Parent a skos:Concept ; skos:inScheme ex:SchemeA .
+ex:Child  a skos:Concept ; skos:inScheme ex:SchemeB ; skos:broader ex:Parent .
+""",
+            format="turtle",
+        )
+        members = _build_scheme_members(graph)
+        # Child declares SchemeB, so it is not pulled into SchemeA via its parent.
+        assert members[_concept("SchemeA")] == frozenset({_concept("Parent")})
+        assert members[_concept("SchemeB")] == frozenset({_concept("Child")})
+
+    def test_concept_in_multiple_schemes_appears_in_each(self):
+        """A concept asserted in two schemes is a member of both."""
+        graph = Graph()
+        graph.parse(
+            data="""\
+@prefix ex:   <http://example.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+ex:SchemeA a skos:ConceptScheme .
+ex:SchemeB a skos:ConceptScheme .
+ex:Shared a skos:Concept ; skos:inScheme ex:SchemeA , ex:SchemeB .
+""",
+            format="turtle",
+        )
+        members = _build_scheme_members(graph)
+        assert members[_concept("SchemeA")] == frozenset({_concept("Shared")})
+        assert members[_concept("SchemeB")] == frozenset({_concept("Shared")})

--- a/uv.lock
+++ b/uv.lock
@@ -701,7 +701,7 @@ test = [
 
 [[package]]
 name = "destiny-sdk"
-version = "0.12.2"
+version = "0.12.3"
 source = { editable = "libs/sdk" }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
Closes #722 

- Adds endpoint to provide cross-facets for a given `row` and `column`, which can be countries, regions or concept scheme IDs
- Treats every concept in a scheme as a sibling - each will get its own entry in the axis regardless of hierarchical depth
  - NB there will be facet searching follow-ups to mirror this behaviour over searching/counting - see also https://github.com/destiny-evidence/evidence-repo-ui/pull/98#discussion_r3323286633
- Returns a model with every non-zero cell, keyed by row and column, and overall total