### PR TITLE
Fix worker/scheduler local-dev compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,7 +134,7 @@ services:
       APP_NAME: destiny-worker
     networks:
       - default
-    entrypoint: taskiq worker app.tasks:broker --tasks-pattern app/**/tasks.py --fs-discover --reload
+    entrypoint: watchmedo auto-restart --directory=./app --pattern=*.py --recursive -- taskiq worker app.tasks:broker --tasks-pattern app/**/tasks.py --fs-discover
 
   scheduler:
     profiles: ["scheduler"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,7 +129,7 @@ services:
     environment:
       MESSAGE_BROKER_URL: amqp://guest:guest@rabbitmq:5672
       DB_CONFIG: '{"DB_URL":"postgresql+asyncpg://localuser:localpass@db:5432/destiny_dev"}'
-      MINIO_CONFIG: '{"HOST":"fs:9000","ACCESS_KEY":"localuser","SECRET_KEY":"localpass"}'
+      MINIO_CONFIG: '{"HOST":"fs:9000","ACCESS_KEY":"localuser","SECRET_KEY":"localpass", "CONTAINERS": {"operations": "destiny-repository", "full_texts": "destiny-repository"}}'
       ES_CONFIG: '{"ES_URL": "https://elasticsearch:9200", "ES_USER": "elastic", "ES_PASS": "destiny", "ES_CA_PATH": "/app/certs/ca/ca.crt"}'
       APP_NAME: destiny-worker
     networks:
@@ -160,7 +160,7 @@ services:
     environment:
       MESSAGE_BROKER_URL: amqp://guest:guest@rabbitmq:5672
       DB_CONFIG: '{"DB_URL":"postgresql+asyncpg://localuser:localpass@db:5432/destiny_dev"}'
-      MINIO_CONFIG: '{"HOST":"fs:9000","ACCESS_KEY":"localuser","SECRET_KEY":"localpass"}'
+      MINIO_CONFIG: '{"HOST":"fs:9000","ACCESS_KEY":"localuser","SECRET_KEY":"localpass", "CONTAINERS": {"operations": "destiny-repository", "full_texts": "destiny-repository"}}'
       ES_CONFIG: '{"ES_URL": "https://elasticsearch:9200", "ES_USER": "elastic", "ES_PASS": "destiny", "ES_CA_PATH": "/app/certs/ca/ca.crt"}'
       APP_NAME: destiny-scheduler
     networks:


### PR DESCRIPTION
- Adds missing \`CONTAINERS\` to \`MINIO_CONFIG\` for worker and scheduler — \`Settings()\` now requires it ([config.py:165](app/core/config.py#L165)).
- Replaces \`taskiq --reload\` with \`watchmedo auto-restart\` for the worker — taskiq's reloader spins in a tight loop on Docker Desktop macOS bind mounts.
e.g.
```
worker-1          | [2026-06-04 06:48:53,071][taskiq.process-manager][INFO   ][MainProcess] Scheduled workers reload.
worker-1          | [2026-06-04 06:48:53,071][taskiq.process-manager][INFO   ][MainProcess] Scheduled workers reload.
worker-1          | [2026-06-04 06:48:53,072][taskiq.process-manager][INFO   ][MainProcess] Scheduled workers reload.
worker-1          | [2026-06-04 06:48:53,073][taskiq.process-manager][INFO   ][MainProcess] Scheduled workers reload.
worker-1          | [2026-06-04 06:48:53,073][taskiq.process-manager][INFO   ][MainProcess] Scheduled workers reload.
worker-1          | [2026-06-04 06:48:53,073][taskiq.process-manager][INFO   ][MainProcess] Scheduled workers reload.
worker-1          | [2026-06-04 06:48:53,073][taskiq.process-manager][INFO   ][MainProcess] Scheduled workers reload.
worker-1          | [2026-06-04 06:48:53,073][taskiq.process-manager][INFO   ][MainProcess] Scheduled workers reload.
worker-1          | [2026-06-04 06:48:53,073][taskiq.process-manager][INFO   ][MainProcess] Scheduled workers reload.
```