### PR TITLE
Add role assignments for ai evidence summariser

### DIFF
--- a/infra/app/auth.tf
+++ b/infra/app/auth.tf
@@ -327,3 +327,24 @@ resource "azuread_app_role_assignment" "destiny_demonstrator_ui_to_reference_rea
   principal_object_id = data.azurerm_user_assigned_identity.destiny_demonstrator_ui[0].principal_id
   resource_object_id  = azuread_service_principal.destiny_repository.object_id
 }
+
+# AI Evidence Summariser role assignments
+data "azurerm_user_assigned_identity" "ai_evidence_summariser" {
+  count               = var.environment != "development" && var.ai_evidence_summariser_app_name != null ? 1 : 0
+  name                = var.ai_evidence_summariser_app_name
+  resource_group_name = "rg-${var.ai_evidence_summariser_app_name}-${var.environment}"
+}
+
+resource "azuread_app_role_assignment" "ai_evidence_summariser_to_reference_reader" {
+  count               = length(data.azurerm_user_assigned_identity.ai_evidence_summariser)
+  app_role_id         = azuread_application_app_role.reference_reader.role_id
+  principal_object_id = data.azurerm_user_assigned_identity.ai_evidence_summariser[0].principal_id
+  resource_object_id  = azuread_service_principal.destiny_repository.object_id
+}
+
+resource "azuread_app_role_assignment" "ai_evidence_summariser_to_reference_full_text_reader" {
+  count               = length(data.azurerm_user_assigned_identity.ai_evidence_summariser)
+  app_role_id         = azuread_application_app_role.reference_full_text_reader.role_id
+  principal_object_id = data.azurerm_user_assigned_identity.ai_evidence_summariser[0].principal_id
+  resource_object_id  = azuread_service_principal.destiny_repository.object_id
+}

--- a/infra/app/variables.tf
+++ b/infra/app/variables.tf
@@ -239,6 +239,12 @@ variable "destiny_demonstrator_ui_app_name" {
   default     = "demonstrator-ui"
 }
 
+variable "ai_evidence_summariser_app_name" {
+  description = "The name of the AI evidence summariser application. Set to null to disable its role assignments."
+  type        = string
+  default     = null
+}
+
 # elasticsearch is not available in all regions, see https://www.elastic.co/cloud/regions
 variable "elasticsearch_region" {
   description = "Region for the Elasticsearch cluster"


### PR DESCRIPTION
Pairs nicely with https://github.com/futureevidence/ai-evidence-summariser/issues/1

Can be deployed now, won't take effect until the application details are provided in the tfvars.