### PR TITLE
Add search endpoint that returns ids

### DIFF
--- a/app/api/decorators.py
+++ b/app/api/decorators.py
@@ -2,26 +2,22 @@
 
 from fastapi.types import DecoratedCallable
 
-
-def experimental(func: DecoratedCallable) -> DecoratedCallable:
-    """Mark an API endpoint as experimental in its documentation."""
-    _note = """
+EXPERIMENTAL_NOTE = """\
 > ⚠️ **Experimental**
 >
 > This endpoint is experimental and may change without notice.
 
 
 """
-    (
-        "⚠️ **Experimental** <br/>"
-        "This endpoint is experimental and may change without notice."
-        "<br/><br/>"
-    )
 
-    # Update the docstring
-    if func.__doc__:
-        func.__doc__ = _note + func.__doc__
-    else:
-        func.__doc__ = _note
 
+def experimental(func: DecoratedCallable) -> DecoratedCallable:
+    """
+    Mark an API endpoint as experimental in its documentation.
+
+    Mutates the handler's docstring, so it must be applied *below* the route
+    decorator (it runs first, before registration) and only works for routes
+    that derive their OpenAPI description from the docstring.
+    """
+    func.__doc__ = EXPERIMENTAL_NOTE + (func.__doc__ or "")
     return func

--- a/app/domain/references/routes.py
+++ b/app/domain/references/routes.py
@@ -576,7 +576,6 @@ async def search_references(
     )
 
 
-@experimental
 @search_router.get(
     "/ids/",
     status_code=status.HTTP_200_OK,
@@ -586,12 +585,8 @@ async def search_references(
             "model": APIExceptionContent,
         }
     },
-    description="Search for references and return only the matching reference IDs, "
-    "without the reference data. Accepts the same query and filter parameters as "
-    "`/references/search/` without pagination. Returns the IDs in result order, "
-    f"capped at the first {SearchService.MAX_RESULT_WINDOW:,} matches. When more "
-    "references match than are returned, `total.is_lower_bound` is true.",
 )
+@experimental
 async def search_reference_ids(
     reference_service: Annotated[ReferenceService, Depends(reference_service)],
     anti_corruption_service: Annotated[
@@ -600,7 +595,15 @@ async def search_reference_ids(
     query: Annotated[SearchQuery, Depends(parse_search_query)],
     sort: SortParam = None,
 ) -> destiny_sdk.references.ReferenceIDSearchResult:
-    """Search for references and return the matching reference IDs."""
+    """
+    Search for references and return only the matching reference IDs.
+
+    Returns the matching reference IDs without the reference data. Accepts the
+    same query and filter parameters as `/references/search/` without
+    pagination. Returns the IDs in result order, capped at the first 10,000
+    matches. When more references match than are returned,
+    `total.is_lower_bound` is true.
+    """
     search_result = await reference_service.search_references(
         query,
         page=1,

--- a/app/domain/references/routes.py
+++ b/app/domain/references/routes.py
@@ -576,6 +576,40 @@ async def search_references(
     )
 
 
+@experimental
+@search_router.get(
+    "/ids/",
+    status_code=status.HTTP_200_OK,
+    responses={
+        status.HTTP_400_BAD_REQUEST: {
+            "description": "Bad Query String",
+            "model": APIExceptionContent,
+        }
+    },
+    description="Search for references and return only the matching reference IDs, "
+    "without the reference data. Accepts the same query and filter parameters as "
+    "`/references/search/` without pagination. Returns the IDs in result order, "
+    f"capped at the first {SearchService.MAX_RESULT_WINDOW:,} matches. When more "
+    "references match than are returned, `total.is_lower_bound` is true.",
+)
+async def search_reference_ids(
+    reference_service: Annotated[ReferenceService, Depends(reference_service)],
+    anti_corruption_service: Annotated[
+        ReferenceAntiCorruptionService, Depends(reference_anti_corruption_service)
+    ],
+    query: Annotated[SearchQuery, Depends(parse_search_query)],
+    sort: SortParam = None,
+) -> destiny_sdk.references.ReferenceIDSearchResult:
+    """Search for references and return the matching reference IDs."""
+    search_result = await reference_service.search_references(
+        query,
+        page=1,
+        page_size=SearchService.MAX_RESULT_WINDOW,
+        sort=sort,
+    )
+    return anti_corruption_service.reference_id_search_result_to_sdk(search_result)
+
+
 @search_router.get(
     "/facets/",
     status_code=status.HTTP_200_OK,

--- a/app/domain/references/service.py
+++ b/app/domain/references/service.py
@@ -1277,12 +1277,14 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
         self,
         query: SearchQuery,
         page: int = 1,
+        page_size: int = 20,
         sort: list[str] | None = None,
     ) -> ESSearchResult:
         """Search for references matching the given query specification."""
         return await self._search_service.search(
             query,
             page=page,
+            page_size=page_size,
             sort=sort,
         )
 

--- a/app/domain/references/services/anti_corruption_service.py
+++ b/app/domain/references/services/anti_corruption_service.py
@@ -497,6 +497,22 @@ class ReferenceAntiCorruptionService(GenericAntiCorruptionService):
         except ValidationError as exception:
             raise DomainToSDKError(errors=exception.errors()) from exception
 
+    def reference_id_search_result_to_sdk(
+        self,
+        search_result: ESSearchResult,
+    ) -> destiny_sdk.references.ReferenceIDSearchResult:
+        """Convert a search result to the SDK ID-only search result model."""
+        try:
+            return destiny_sdk.references.ReferenceIDSearchResult(
+                total={
+                    "count": search_result.total.value,
+                    "is_lower_bound": search_result.total.relation == "gte",
+                },
+                reference_ids=[hit.id for hit in search_result.hits],
+            )
+        except ValidationError as exception:
+            raise DomainToSDKError(errors=exception.errors()) from exception
+
     def publication_year_range_from_query_parameter(
         self,
         start_year: int | None,

--- a/libs/sdk/pyproject.toml
+++ b/libs/sdk/pyproject.toml
@@ -36,7 +36,7 @@ license = "Apache-2.0"
 name = "destiny_sdk"
 readme = "README.md"
 requires-python = ">=3.12, <4"
-version = "0.12.4"
+version = "0.12.5"
 
 [project.optional-dependencies]
 labs = []

--- a/libs/sdk/src/destiny_sdk/references.py
+++ b/libs/sdk/src/destiny_sdk/references.py
@@ -79,6 +79,17 @@ class ReferenceSearchResult(SearchResultMixIn, BaseModel):
     )
 
 
+class ReferenceIDSearchResult(BaseModel):
+    """The matching reference IDs for a search, without the reference data."""
+
+    total: SearchResultTotal = Field(
+        description="The total number of references matching the search criteria."
+    )
+    reference_ids: list[UUID] = Field(
+        description="The IDs of the references matching the search, in result order."
+    )
+
+
 class FacetType(StrEnum):
     """Search facets of references."""
 

--- a/libs/sdk/uv.lock
+++ b/libs/sdk/uv.lock
@@ -257,7 +257,7 @@ wheels = [
 
 [[package]]
 name = "destiny-sdk"
-version = "0.12.4"
+version = "0.12.5"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },

--- a/tests/routers/test_references.py
+++ b/tests/routers/test_references.py
@@ -58,6 +58,7 @@ from app.domain.references.models.sql import (
 )
 from app.domain.references.service import ReferenceService
 from app.domain.references.services.export_service import SearchExportService
+from app.domain.references.services.search_service import SearchService
 from app.domain.robots.models.sql import Robot as SQLRobot
 from app.persistence.blob.models import BlobSignedUrlType, BlobStorageFile
 from app.persistence.blob.repository import BlobRepository
@@ -874,6 +875,63 @@ async def test_search_references_preserves_es_order(
 
     # Order should match ES order (A, B, C), not SQL order (C, A, B)
     assert returned_ids == [str(ref_a.id), str(ref_b.id), str(ref_c.id)]
+
+
+async def test_search_reference_ids_returns_ids_only(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ids endpoint returns matching IDs in order without fetching references."""
+    ref_a = ReferenceFactory.build()
+    ref_b = ReferenceFactory.build()
+
+    mock_search_result = ESSearchResult(
+        hits=[
+            ESHit(id=ref_a.id, score=2.0),
+            ESHit(id=ref_b.id, score=1.0),
+        ],
+        total=ESSearchTotal(value=2, relation="eq"),
+        page=1,
+    )
+    mock_search = AsyncMock(return_value=mock_search_result)
+    monkeypatch.setattr(ReferenceService, "search_references", mock_search)
+    mock_get_dedup = AsyncMock()
+    monkeypatch.setattr(ReferenceService, "get_deduplicated_references", mock_get_dedup)
+
+    response = await client.get("/v1/references/search/ids/", params={"q": "test"})
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["reference_ids"] == [str(ref_a.id), str(ref_b.id)]
+    assert data["total"] == {"count": 2, "is_lower_bound": False}
+
+    # IDs are read straight off the search hits — references are never fetched.
+    mock_get_dedup.assert_not_awaited()
+    mock_search.assert_awaited_once()
+    assert mock_search.call_args.kwargs["page_size"] == SearchService.MAX_RESULT_WINDOW
+
+
+async def test_search_reference_ids_reports_lower_bound_when_truncated(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A `gte` total surfaces as `is_lower_bound: true`."""
+    reference = ReferenceFactory.build()
+    mock_search_result = ESSearchResult(
+        hits=[ESHit(id=reference.id, score=1.0)],
+        total=ESSearchTotal(value=10000, relation="gte"),
+        page=1,
+    )
+    monkeypatch.setattr(
+        ReferenceService,
+        "search_references",
+        AsyncMock(return_value=mock_search_result),
+    )
+
+    response = await client.get("/v1/references/search/ids/", params={"q": "test"})
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["total"] == {"count": 10000, "is_lower_bound": True}
 
 
 async def test_search_references_with_annotation_filters(

--- a/uv.lock
+++ b/uv.lock
@@ -701,7 +701,7 @@ test = [
 
 [[package]]
 name = "destiny-sdk"
-version = "0.12.4"
+version = "0.12.5"
 source = { editable = "libs/sdk" }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
Adds a search endpoint to return all IDs, without pagination.

See https://github.com/futureevidence/ai-evidence-summariser/issues/1 for context. Endpoint flagged as experimental for now in case we land on a different approach long-term.

Virtually entirely made of existing work which is beautiful!