### PR TITLE
Fix token refresh flow in oauthclient

### DIFF
--- a/libs/sdk/pyproject.toml
+++ b/libs/sdk/pyproject.toml
@@ -36,7 +36,7 @@ license = "Apache-2.0"
 name = "destiny_sdk"
 readme = "README.md"
 requires-python = ">=3.12, <4"
-version = "0.12.5"
+version = "0.12.6"
 
 [project.optional-dependencies]
 labs = []

--- a/libs/sdk/src/destiny_sdk/client.py
+++ b/libs/sdk/src/destiny_sdk/client.py
@@ -255,10 +255,6 @@ class OAuthMiddleware(httpx.Auth):
 
     """
 
-    # auth_flow inspects the response body to detect token expiry, so httpx
-    # must read the body before resuming the generator.
-    requires_response_body = True
-
     def __init__(
         self,
         azure_client_id: str,
@@ -444,6 +440,7 @@ class OAuthMiddleware(httpx.Auth):
 
         # Check if token expired and retry once with fresh token
         if response.status_code == httpx.codes.UNAUTHORIZED:
+            response.read()
             try:
                 json_response: dict = response.json()
                 error_detail: str = json_response.get("detail", {})
@@ -492,10 +489,6 @@ class KeycloakOAuthMiddleware(httpx.Auth):
         )
 
     """
-
-    # auth_flow inspects the response body to detect token expiry, so httpx
-    # must read the body before resuming the generator.
-    requires_response_body = True
 
     def __init__(  # noqa: PLR0913
         self,
@@ -612,6 +605,7 @@ class KeycloakOAuthMiddleware(httpx.Auth):
 
         # Check if token expired and retry once with fresh token
         if response.status_code == httpx.codes.UNAUTHORIZED:
+            response.read()
             try:
                 json_response: dict = response.json()
                 error_detail: str = json_response.get("detail", {})

--- a/libs/sdk/src/destiny_sdk/client.py
+++ b/libs/sdk/src/destiny_sdk/client.py
@@ -255,6 +255,10 @@ class OAuthMiddleware(httpx.Auth):
 
     """
 
+    # auth_flow inspects the response body to detect token expiry, so httpx
+    # must read the body before resuming the generator.
+    requires_response_body = True
+
     def __init__(
         self,
         azure_client_id: str,
@@ -488,6 +492,10 @@ class KeycloakOAuthMiddleware(httpx.Auth):
         )
 
     """
+
+    # auth_flow inspects the response body to detect token expiry, so httpx
+    # must read the body before resuming the generator.
+    requires_response_body = True
 
     def __init__(  # noqa: PLR0913
         self,

--- a/libs/sdk/tests/unit/test_client.py
+++ b/libs/sdk/tests/unit/test_client.py
@@ -1,5 +1,6 @@
 """Tests client authentication"""
 
+import json
 import time
 from uuid import UUID, uuid7
 
@@ -551,3 +552,87 @@ class TestKeycloakOAuthMiddleware:
 
         assert retry_request.headers["Authorization"] == f"Bearer {refreshed_token}"
         assert call_count["count"] == 2
+
+
+def _build_keycloak_middleware(_monkeypatch) -> KeycloakOAuthMiddleware:
+    return KeycloakOAuthMiddleware(
+        keycloak_url="http://localhost:8080",
+        realm="destiny",
+        client_id="test-service-client",
+        client_secret=SecretStr("test-secret"),
+    )
+
+
+def _build_azure_middleware(monkeypatch) -> OAuthMiddleware:
+    class _NoOpPublicClientApp(PublicClientApplication):
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+    monkeypatch.setattr(
+        "destiny_sdk.client.PublicClientApplication", _NoOpPublicClientApp
+    )
+    return OAuthMiddleware(
+        azure_login_url="test-url",
+        azure_client_id="test-client",
+        azure_application_id="test-app",
+    )
+
+
+@pytest.mark.parametrize(
+    "build_middleware",
+    [_build_keycloak_middleware, _build_azure_middleware],
+    ids=["keycloak", "azure"],
+)
+def test_token_refresh_through_real_client(monkeypatch, build_middleware) -> None:
+    """
+    Renewal must work through httpx's full auth flow on a streamed response.
+
+    This drives a real ``httpx.Client`` with an unread, streamed response to
+    catch that regression, across both OAuth middlewares.
+    """
+
+    class _Stream(httpx.SyncByteStream):
+        def __init__(self, data: bytes) -> None:
+            self._data = data
+
+        def __iter__(self):
+            yield self._data
+
+        def close(self) -> None:
+            pass
+
+    def streamed(status_code: int, payload: dict) -> httpx.Response:
+        return httpx.Response(
+            status_code,
+            headers={"Content-Type": "application/json"},
+            stream=_Stream(json.dumps(payload).encode()),
+        )
+
+    server_requests = {"count": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        server_requests["count"] += 1
+        if server_requests["count"] == 1:
+            return streamed(401, {"detail": TOKEN_EXPIRED_MESSAGE})
+        return streamed(200, {"ok": True})
+
+    middleware = build_middleware(monkeypatch)
+
+    token_calls = {"count": 0, "force_refresh": 0}
+
+    def fake_get_token(*, force_refresh: bool = False) -> str:
+        token_calls["count"] += 1
+        if force_refresh:
+            token_calls["force_refresh"] += 1
+            return "refreshed-token"
+        return "initial-token"
+
+    # Bypass real token acquisition; only the auth_flow retry logic is under test.
+    middleware._get_token = fake_get_token  # noqa: SLF001
+
+    client = httpx.Client(transport=httpx.MockTransport(handler), auth=middleware)
+    response = client.get("https://api.example.com/test")
+
+    assert response.status_code == 200
+    assert server_requests["count"] == 2
+    assert token_calls["force_refresh"] == 1

--- a/libs/sdk/uv.lock
+++ b/libs/sdk/uv.lock
@@ -257,7 +257,7 @@ wheels = [
 
 [[package]]
 name = "destiny-sdk"
-version = "0.12.5"
+version = "0.12.6"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },

--- a/uv.lock
+++ b/uv.lock
@@ -701,7 +701,7 @@ test = [
 
 [[package]]
 name = "destiny-sdk"
-version = "0.12.5"
+version = "0.12.6"
 source = { editable = "libs/sdk" }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
Required to unblock DESTINY abstract loadings (and possibly will also be needed for the full text robot script!)