### PR TITLE
Handle large file streaming

### DIFF
--- a/app/persistence/blob/client.py
+++ b/app/persistence/blob/client.py
@@ -1,5 +1,6 @@
 """Generic class for a blob storage client."""
 
+import codecs
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator, AsyncIterator
 from io import BytesIO
@@ -78,12 +79,14 @@ class GenericBlobStorageClient(ABC):
         :return: An async generator that yields lines from the file.
         :rtype: AsyncGenerator[str, None]
         """
+        decoder = codecs.getincrementaldecoder("utf-8")()
         buffer = ""
         async for chunk in self.stream_chunks(file):
-            buffer += chunk.decode("utf-8")
+            buffer += decoder.decode(chunk)  # carries partial char across chunks
             while "\n" in buffer:
                 line, buffer = buffer.split("\n", 1)
                 yield line
+        buffer += decoder.decode(b"", final=True)
         if buffer:
             yield buffer
 

--- a/tests/unit/persistence/blob/test_blob.py
+++ b/tests/unit/persistence/blob/test_blob.py
@@ -352,6 +352,31 @@ async def test_copy_rejects_destination_on_other_backend():
         await repo.copy(source, destination)
 
 
+_STREAM_FILE = BlobStorageFile(
+    location=BlobStorageLocation.MINIO,
+    container="c",
+    path="p",
+    filename="f.txt",
+)
+
+
+@pytest.mark.asyncio
+async def test_stream_file_reassembles_multibyte_char_split_across_chunks():
+    """A UTF-8 char split across chunk boundaries must not raise or corrupt."""
+    # "café" -> b"caf\xc3\xa9"; split mid-way through the two-byte é.
+    client = _RecordingClient(chunks=[b"caf\xc3", b"\xa9\n"])
+    lines = [line async for line in client.stream_file(_STREAM_FILE)]
+    assert lines == ["café"]
+
+
+@pytest.mark.asyncio
+async def test_stream_file_splits_lines_across_chunks():
+    """Lines spanning chunk boundaries are reassembled; trailing line emitted."""
+    client = _RecordingClient(chunks=[b"one\ntw", b"o\nthree"])
+    lines = [line async for line in client.stream_file(_STREAM_FILE)]
+    assert lines == ["one", "two", "three"]
+
+
 class DummyClient(GenericBlobStorageClient):
     async def upload_file(self, content, file, content_type=None):
         self.uploaded = (content, file, content_type)


### PR DESCRIPTION
Streaming over chunk boundaries could cause an issue where a multi-byte character is undecodable - eg https://ui.honeycomb.io/destiny-evidence/environments/production/result/reZXzLiksw6/trace/GM3YuSHu5Z3?fields[]=s_name&fields[]=s_serviceName&span=ae5fb029d3eaa1b6