### PR TITLE
Extend README for easier reproducibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 ### DB ###
+POSTGRES_PORT=5432
+
 # Locally (option 1):
-DB_CONFIG='{"DB_FQDN": "localhost", "DB_NAME": "destiny_dev", "DB_USER": "localuser", "DB_PASS": "localpass"}'
+DB_CONFIG='{"DB_FQDN": "localhost", "DB_NAME": "destiny_dev", "DB_USER": "localuser", "DB_PASS": "localpass", "DB_PORT": 5432}'
 
 # Locally (option 2):
 # DB_CONFIG='{"DB_URL": "postgresql+asyncpg://localuser:localpass@localhost:5432/destiny_dev"}'

--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,5 @@ libs/fake_data/*.jsonl
 .idea/
 
 .test.tmp
+
+docker-compose.override.yml

--- a/README.md
+++ b/README.md
@@ -35,21 +35,46 @@ modification to run the application), copy the example file:
 
 ```shell
 cp .env.example .env
+
+# To run any of the following commands, environment variables need to be set by
+source .env
 ```
+If you want to run locally and have no tenant-id, you at least need to replace the 
+`<` and `>` in the `.env` file.
 
 ### Starting the development server
 
 First you will need to start the auxiliary servers:
 
 ```sh
+source .env  # set environment variables
 docker compose up -d
 ```
+
+Make sure there is enough space where the docker volumes are located (typically 
+`/var/lib/docker/`); elasticsearch will cause issues if the partition is >90%. 
+Plan for 2–3GB for images and volumes.
+
+If you want to locate the volumes in a specific location, you can create 
+`docker-compose.override.yml`:
+```
+volumes:
+  certs:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: /path/to/volumes/certs
+  ...
+```
+Remember to create the directory before starting.
 
 #### Database
 
 Once the database server is running, run the migrations to setup the database.
 
 ```sh
+source .env  # set environment variables
 uv run alembic upgrade head
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,13 +33,14 @@ accidental exposure of secrets, this file is ignored using the `.gitignore`
 file. To set up a copy of the configuration (which should not require
 modification to run the application), copy the example file:
 
-```shell
+```sh
 cp .env.example .env
 
 # To run any of the following commands, environment variables need to be set by
 source .env
 ```
-If you want to run locally and have no tenant-id, you at least need to replace the 
+
+If you want to run locally and have no tenant-id, you at least need to replace the
 `<` and `>` in the `.env` file.
 
 ### Starting the development server
@@ -51,13 +52,14 @@ source .env  # set environment variables
 docker compose up -d
 ```
 
-Make sure there is enough space where the docker volumes are located (typically 
-`/var/lib/docker/`); elasticsearch will cause issues if the partition is >90%. 
+Make sure there is enough space where the docker volumes are located (typically
+`/var/lib/docker/`); elasticsearch will cause issues if the partition is >90%.
 Plan for 2–3GB for images and volumes.
 
-If you want to locate the volumes in a specific location, you can create 
+If you want to locate the volumes in a specific location, you can create
 `docker-compose.override.yml`:
-```
+
+```yaml
 volumes:
   certs:
     driver: local
@@ -67,6 +69,7 @@ volumes:
       device: /path/to/volumes/certs
   ...
 ```
+
 Remember to create the directory before starting.
 
 #### Database

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -33,6 +33,7 @@ class DatabaseConfig(BaseModel):
     db_user: str | None = None
     db_pass: str | None = None
     db_name: str | None = None
+    db_port: int | None = None
     azure_db_resource_url: HttpUrl | None = None
     db_url: PostgresDsn | None = None
     ssl_mode: str = "prefer"
@@ -48,9 +49,19 @@ class DatabaseConfig(BaseModel):
         if self.db_url:
             url = str(self.db_url)
         elif self.passwordless:
-            url = f"postgresql+asyncpg://{self.db_user}@{self.db_fqdn}/{self.db_name}"
+            url = (
+                f"postgresql+asyncpg://"
+                f"{self.db_user}"
+                f"@{self.db_fqdn}:{self.db_port}"
+                f"/{self.db_name}"
+            )
         else:
-            url = f"postgresql+asyncpg://{self.db_user}:{self.db_pass}@{self.db_fqdn}/{self.db_name}"
+            url = (
+                f"postgresql+asyncpg://"
+                f"{self.db_user}:{self.db_pass}"
+                f"@{self.db_fqdn}:{self.db_port}"
+                f"/{self.db_name}"
+            )
 
         # ssl prefer allows us to connect locally without SSL, overwritable if needed
         return f"{url}?ssl={self.ssl_mode}"
@@ -66,6 +77,7 @@ class DatabaseConfig(BaseModel):
                     self.db_user,
                     self.db_pass,
                     self.db_name,
+                    self.db_port,
                     self.azure_db_resource_url,
                 )
             ):
@@ -73,7 +85,7 @@ class DatabaseConfig(BaseModel):
                 raise ValueError(msg)
         else:
             # DB URL not provided
-            if not all((self.db_fqdn, self.db_user, self.db_name)):
+            if not all((self.db_fqdn, self.db_user, self.db_name, self.db_port)):
                 msg = """
 If db_url is not provided, db_fqdn, db_user and db_name must be provided."""
                 raise ValueError(msg)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,9 @@ services:
       POSTGRES_USER: localuser
       POSTGRES_PASSWORD: localpass
       POSTGRES_DB: destiny_dev
+      POSTGRES_PORT: 5432
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - db_data:/var/lib/postgresql/data
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -246,6 +246,9 @@ services:
         find . -type f -exec chmod 640 \{\} \;;
         echo "Copying CA to local certs directory";
         cp config/certs/ca/ca.crt /certs-local/ca.crt;
+        # CA is public; make the host copy readable so local (non-docker)
+        # uv run fastapi/taskiq can load it without sudo
+        chmod 644 /certs-local/ca.crt;
         echo "Waiting for Elasticsearch availability";
         until curl -s --cacert config/certs/ca/ca.crt https://elasticsearch:9200 | grep -q "missing authentication credentials"; do sleep 30; done;
         echo "Setting kibana_system password";

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
       POSTGRES_USER: localuser
       POSTGRES_PASSWORD: localpass
       POSTGRES_DB: destiny_dev
-      POSTGRES_PORT: 5432
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
     volumes:


### PR DESCRIPTION
I tried to get the repository running locally and kept a log of issues I encountered. In hindsight, not too much, but recovering from not setting environment variables for example took a lot of time, hence the README should be more explicit about that.

I also added an option to configure the postgres port because I have multiple instances running.

Unresolved is the "issue" that I need sudo for `uv run fastapi` and `uv run taskiq`, otherwise I get permission errors (apparently the certs are placed in the docker volume directory and some of the volumes are owned by root (not running `docker-compose up` as root)

```
17:10 start
17:18 docker compose done but not starting; >2.5GB storage gone
17:24: needs to `sudo pacman -S docker-buildx`
17:26: error: port 5432 already used
17:34: fixed with added config
17:43: .env template can't be sourced because of tenant ID (replace first)
17:47: need to use DB_conf option with connection string in .env to run alembic migrate
17:49: uv run fastapi seems to work, but not reachable
17:51: taskiq worker fails to run, ES permission denied
17:57: run docker compose down -v --rmi all to clear everything 
17:58: docker compose again with source .env before (eats another 2GB of storage)
17:59: problem persists
18:40: deleted volumes several time to try and flush (possibly) stuck config and wrong password; added override to have volumes in different location
18:44: can now log in via browser, but fastapi now fails with permission denied and taskiq still has permission errors
18:55: some volume directories were now owned by root; changing ownerships, now fastapi runs again (still no opening in browser though)
18:58: changing permissions of volume dir is no good for container apparently and resets are down+up; running fastapi as root works and now also access in browser
18:59: taskiq as root also fixes issues and things work



root causes:
* not enough disk space for volumes causes odd ES behaviour
* not sourcing .env before first run causes stubbornly persistent configs in docker
* file permissions; shouldn't need to run uv as root for fastapi and taskiq

docker system prune -a --volumes helps to clean things up
```