### PR TITLE
Deterministic sort in Elasticsearch

### DIFF
--- a/app/domain/references/models/es.py
+++ b/app/domain/references/models/es.py
@@ -406,6 +406,7 @@ class ReferenceDocument(
 
         name = "reference"
 
+    id: UUID = mapped_field(Keyword(required=True))
     visibility: Visibility = mapped_field(Keyword(required=True))
     duplicate_determination: DuplicateDetermination | None = mapped_field(
         Keyword(required=False),
@@ -417,6 +418,7 @@ class ReferenceDocument(
         return cls(
             # Parent's parent does accept meta, but mypy doesn't like it here.
             meta={"id": domain_obj.id},  # type: ignore[call-arg]
+            id=domain_obj.id,
             visibility=domain_obj.visibility,
             duplicate_determination=domain_obj.duplicate_determination,
             **ReferenceSearchFieldsMixin.from_projections(

--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -379,7 +379,7 @@ class ReferenceESRepository(
         """Search references matching ``query``; structured filters AND with q."""
         # Append the unique doc id as a final tie-breaker so equal-sort-value hits
         # have a deterministic order
-        sort = [*sort, "id"] if sort else ["_score", "id"]
+        sort = [*sort, "-id"] if sort else ["_score", "-id"]
         return await self.search_with_query_string(
             query.query_string,
             fields=self.default_search_fields,

--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -3,7 +3,7 @@
 import datetime
 from abc import ABC
 from collections.abc import Mapping, Sequence
-from typing import ClassVar, Literal
+from typing import Any, ClassVar, Literal
 from uuid import UUID
 
 from elasticsearch import AsyncElasticsearch
@@ -378,14 +378,17 @@ class ReferenceESRepository(
     ) -> ESSearchResult:
         """Search references matching ``query``; structured filters AND with q."""
         # Append the unique doc id as a final tie-breaker so equal-sort-value hits
-        # have a deterministic order
-        sort = [*sort, "-id"] if sort else ["_score", "-id"]
+        # have a deterministic order. unmapped_type allows it to work prior to the
+        # migration that adds the id field, this can optionally be removed later
+        tiebreaker: dict[str, Any] = {
+            "id": {"order": "desc", "unmapped_type": "keyword"}
+        }
         return await self.search_with_query_string(
             query.query_string,
             fields=self.default_search_fields,
             page=page,
             page_size=page_size,
-            sort=sort,
+            sort=[*sort, tiebreaker] if sort else ["_score", tiebreaker],
             filter_clauses=self._build_filter_clauses(query),
             parse_document=False,
         )

--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -377,6 +377,9 @@ class ReferenceESRepository(
         sort: list[str] | None = None,
     ) -> ESSearchResult:
         """Search references matching ``query``; structured filters AND with q."""
+        # Append the unique doc id as a final tie-breaker so equal-sort-value hits
+        # have a deterministic order
+        sort = [*sort, "id"] if sort else ["_score", "id"]
         return await self.search_with_query_string(
             query.query_string,
             fields=self.default_search_fields,

--- a/app/persistence/es/index_manager.py
+++ b/app/persistence/es/index_manager.py
@@ -45,6 +45,7 @@ class IndexManager:
         repair_subset_task: AsyncTaskiqDecoratedTask[..., Coroutine[Any, Any, None]]
         | None = None,
         reindex_status_polling_interval: int = 5 * 60,  # default to 5min
+        reindex_script: dict[str, Any] | None = None,
     ) -> None:
         """
         Initialize the migration manager.
@@ -58,6 +59,7 @@ class IndexManager:
                 in which case subset repair is unsupported for this index.
             version_prefix: Prefix for version numbers in index names
             reindex_status_polling_interval: How often to check status of reindexing (defaults 5s)
+            reindex_script: Painless script applied to each doc during reindex (defaults None)
 
         """  # noqa: E501
         self.document_class = document_class
@@ -65,6 +67,7 @@ class IndexManager:
         self.repair_task = repair_task
         self.repair_subset_task = repair_subset_task
         self.reindex_status_polling_interval = reindex_status_polling_interval
+        self.reindex_script = reindex_script
 
         self.alias_name = document_class.Index.name
         self.otel_enabled = otel_enabled
@@ -362,6 +365,7 @@ class IndexManager:
             conflicts="proceed",
             source={"index": source_index},
             dest={"index": dest_index, "version_type": "external"},
+            script=self.reindex_script,
             wait_for_completion=False,
             refresh=True,
         )

--- a/app/persistence/es/index_manager.py
+++ b/app/persistence/es/index_manager.py
@@ -11,7 +11,7 @@ from elasticsearch.dsl import AsyncDocument, AsyncIndex
 from opentelemetry import trace
 from taskiq import AsyncTaskiqDecoratedTask
 
-from app.core.exceptions import NotFoundError
+from app.core.exceptions import ESError, NotFoundError
 from app.core.telemetry.attributes import (
     Attributes,
     set_span_status,
@@ -59,7 +59,8 @@ class IndexManager:
                 in which case subset repair is unsupported for this index.
             version_prefix: Prefix for version numbers in index names
             reindex_status_polling_interval: How often to check status of reindexing (defaults 5s)
-            reindex_script: Painless script applied to each doc during reindex (defaults None)
+            reindex_script: `Painless <https://www.elastic.co/docs/explore-analyze/scripting/modules-scripting-painless>`_
+                script applied to each doc during reindex (defaults None)
 
         """  # noqa: E501
         self.document_class = document_class
@@ -278,6 +279,11 @@ class IndexManager:
             attribute=Attributes.DB_COLLECTION_ALIAS_NAME, value=self.alias_name
         )
 
+        # Compile the reindex script before touching any index, so a bad script
+        # (e.g. a typo passed on the migration command line) fails fast rather than
+        # part-way through the reindex.
+        await self._validate_reindex_script()
+
         source_index = await self.get_current_index_name()
 
         if source_index is None:
@@ -331,6 +337,22 @@ class IndexManager:
 
         logger.info("Migration completed successfully to %s", destination_index)
         return destination_index
+
+    async def _validate_reindex_script(self) -> None:
+        """Compile the reindex script cluster-side without running a migration."""
+        if not self.reindex_script:
+            return
+
+        script_id = f"{self.alias_name}-reindex-validation"
+        try:
+            await self.client.put_script(
+                id=script_id, script=self.reindex_script, context="reindex"
+            )
+        except elasticsearch.BadRequestError as exc:
+            msg = f"Reindex script failed to compile: {exc}"
+            raise ESError(msg) from exc
+
+        await self.client.delete_script(id=script_id)
 
     @tracer.start_as_current_span("Reindex index")
     async def _reindex_data(self, source_index: str, dest_index: str) -> None:

--- a/app/persistence/es/repository.py
+++ b/app/persistence/es/repository.py
@@ -3,7 +3,7 @@
 import json
 from abc import ABC
 from collections.abc import AsyncGenerator, Sequence
-from typing import Generic, Never
+from typing import Any, Generic, Never
 from uuid import UUID
 
 from elasticsearch import AsyncElasticsearch, NotFoundError
@@ -217,7 +217,7 @@ class GenericAsyncESRepository(
         page: int = 1,
         page_size: int = 20,
         fields: Sequence[str] | None = None,
-        sort: list[str] | None = None,
+        sort: list[str | dict[str, Any]] | None = None,
         filter_clauses: Sequence[Query] | None = None,
         *,
         parse_document: bool = False,
@@ -234,8 +234,9 @@ class GenericAsyncESRepository(
         :param fields: The fields to search within. If None, searches all fields (unless
             the query specifies otherwise).
         :type fields: Sequence[str] | None
-        :param sort: The sorting criteria for the search results.
-        :type sort: list[str] | None
+        :param sort: The sorting criteria for the search results. Entries may be
+            field-name strings or full ES sort dicts.
+        :type sort: list[str | dict[str, Any]] | None
         :param filter_clauses: Structured DSL clauses ANDed with the query string under
             ``bool.filter`` (non-scoring). ``None`` or empty issues the bare query.
         :type filter_clauses: Sequence[Query] | None

--- a/app/utils/es/es_migration.py
+++ b/app/utils/es/es_migration.py
@@ -217,8 +217,10 @@ def argument_parser() -> argparse.ArgumentParser:
         "--reindex-script",
         type=str,
         help=(
-            "Optional painless script applied to each document during the migration "
-            "reindex, e.g. 'ctx._source.id = ctx._id'."
+            "Optional Painless script "
+            "(https://www.elastic.co/docs/explore-analyze/scripting/modules-scripting-painless) "  # noqa: E501
+            "applied to each document during the migration reindex, "
+            "e.g. 'ctx._source.id = ctx._id'."
         ),
         default=None,
     )

--- a/app/utils/es/es_migration.py
+++ b/app/utils/es/es_migration.py
@@ -66,11 +66,15 @@ def get_index_settings_changeset(
     return settings
 
 
-async def run_migration(alias: str, number_of_shards: int | None) -> None:
+async def run_migration(
+    alias: str, number_of_shards: int | None, reindex_script: str | None = None
+) -> None:
     """Run elasticsearch index migrations."""
     es_config = settings.es_config
 
     await es_manager.init(es_config)
+
+    script = {"lang": "painless", "source": reindex_script} if reindex_script else None
 
     try:
         async with es_manager.client() as client:
@@ -79,6 +83,7 @@ async def run_migration(alias: str, number_of_shards: int | None) -> None:
                 client=client,
                 otel_enabled=settings.otel_enabled,
                 reindex_status_polling_interval=settings.reindex_status_polling_interval,
+                reindex_script=script,
             )
 
             index_settings_changeset = get_index_settings_changeset(
@@ -207,6 +212,17 @@ def argument_parser() -> argparse.ArgumentParser:
         default=None,
     )
 
+    parser.add_argument(
+        "-s",
+        "--reindex-script",
+        type=str,
+        help=(
+            "Optional painless script applied to each document during the migration "
+            "reindex, e.g. 'ctx._source.id = ctx._id'."
+        ),
+        default=None,
+    )
+
     return parser
 
 
@@ -255,6 +271,10 @@ def validate_args(args: argparse.Namespace) -> None:
         msg = "You can only specify number_of_shards when migrating an index."
         raise RuntimeError(msg)
 
+    if args.reindex_script and not args.migrate:
+        msg = "You can only specify reindex_script when migrating an index."
+        raise RuntimeError(msg)
+
 
 if __name__ == "__main__":
     parser = argument_parser()
@@ -270,7 +290,11 @@ if __name__ == "__main__":
     if args.migrate:
         for alias in aliases:
             asyncio.run(
-                run_migration(alias=alias, number_of_shards=args.number_of_shards)
+                run_migration(
+                    alias=alias,
+                    number_of_shards=args.number_of_shards,
+                    reindex_script=args.reindex_script,
+                )
             )
 
     elif args.rollback:

--- a/tests/integration/test_cross_facets.py
+++ b/tests/integration/test_cross_facets.py
@@ -120,6 +120,7 @@ async def cross_references(es_client: AsyncElasticsearch) -> None:
     docs = [
         ReferenceDocument(
             meta={"id": uuid7()},
+            id=uuid7(),
             visibility=Visibility.PUBLIC,
             title="Botany in Africa one",
             linked_data_concepts=[BOTANY, AFRICA],
@@ -128,6 +129,7 @@ async def cross_references(es_client: AsyncElasticsearch) -> None:
         ),
         ReferenceDocument(
             meta={"id": uuid7()},
+            id=uuid7(),
             visibility=Visibility.PUBLIC,
             title="Botany in Africa two",
             linked_data_concepts=[BOTANY, AFRICA],
@@ -136,6 +138,7 @@ async def cross_references(es_client: AsyncElasticsearch) -> None:
         ),
         ReferenceDocument(
             meta={"id": uuid7()},
+            id=uuid7(),
             visibility=Visibility.PUBLIC,
             title="Zoology in Asia",
             linked_data_concepts=[ZOOLOGY, ASIA],
@@ -144,6 +147,7 @@ async def cross_references(es_client: AsyncElasticsearch) -> None:
         ),
         ReferenceDocument(
             meta={"id": uuid7()},
+            id=uuid7(),
             visibility=Visibility.PUBLIC,
             title="Microbiology in Europe",
             linked_data_concepts=[MICROBIOLOGY, EUROPE],
@@ -152,6 +156,7 @@ async def cross_references(es_client: AsyncElasticsearch) -> None:
         ),
         ReferenceDocument(
             meta={"id": uuid7()},
+            id=uuid7(),
             visibility=Visibility.PUBLIC,
             title="Botany and Zoology in Africa",
             linked_data_concepts=[BOTANY, ZOOLOGY, AFRICA],
@@ -160,6 +165,7 @@ async def cross_references(es_client: AsyncElasticsearch) -> None:
         ),
         ReferenceDocument(
             meta={"id": uuid7()},
+            id=uuid7(),
             visibility=Visibility.PUBLIC,
             title="More botany and zoology in Africa",
             linked_data_concepts=[BOTANY, ZOOLOGY, AFRICA],

--- a/tests/integration/test_es_index_manager.py
+++ b/tests/integration/test_es_index_manager.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import pytest
 
-from app.core.exceptions import NotFoundError
+from app.core.exceptions import ESError, NotFoundError
 from app.persistence.es.client import AsyncESClientManager
 from app.persistence.es.index_manager import IndexManager
 from tests.es_utils import delete_test_indices
@@ -570,6 +570,41 @@ async def test_migrate_applies_reindex_script(
         for doc_id in doc_ids:
             fetched = await client.get(index=new_index, id=doc_id)
             assert fetched["_source"]["content"] == doc_id
+
+        await delete_test_indices(client)
+
+
+async def test_migrate_with_invalid_reindex_script_raises(
+    es_manager_for_tests: AsyncESClientManager,
+) -> None:
+    """An uncompilable reindex script fails the migration before any index work."""
+    async with es_manager_for_tests.client() as client:
+        await delete_test_indices(client)
+        index_manager = IndexManager(
+            SimpleDoc,
+            client,
+            reindex_status_polling_interval=1,
+            # Missing right-hand side: compile error.
+            reindex_script={"lang": "painless", "source": "ctx._source.content = "},
+        )
+        await index_manager.initialize_index()
+        original_index = await index_manager.get_current_index_name()
+
+        for i in range(5):
+            doc = SimpleDoc.from_domain(SimpleDomainModel(content=f"doc {i}"))
+            await doc.save(using=client, validate=True)
+        await client.indices.refresh(index=index_manager.alias_name)
+
+        with pytest.raises(ESError, match="compile"):
+            await index_manager.migrate()
+
+        # No destination index was created; the alias still points at the intact
+        # original with all its documents.
+        indices = await client.indices.get(index=f"{index_manager.alias_name}*")
+        assert list(indices) == [original_index]
+        assert await index_manager.get_current_index_name() == original_index
+        count = await client.count(index=index_manager.alias_name)
+        assert count["count"] == 5
 
         await delete_test_indices(client)
 

--- a/tests/integration/test_es_index_manager.py
+++ b/tests/integration/test_es_index_manager.py
@@ -540,6 +540,40 @@ async def test_we_do_not_roll_back_to_nonexistent_index(index_manager: IndexMana
         await index_manager.rollback()
 
 
+async def test_migrate_applies_reindex_script(
+    es_manager_for_tests: AsyncESClientManager,
+) -> None:
+    """A configured reindex_script transforms every document during migration."""
+    async with es_manager_for_tests.client() as client:
+        await delete_test_indices(client)
+        index_manager = IndexManager(
+            SimpleDoc,
+            client,
+            reindex_status_polling_interval=1,
+            reindex_script={
+                "lang": "painless",
+                "source": "ctx._source.content = ctx._id",
+            },
+        )
+        await index_manager.initialize_index()
+
+        doc_ids = []
+        for i in range(5):
+            doc = SimpleDoc.from_domain(SimpleDomainModel(content=f"doc {i}"))
+            await doc.save(using=client, validate=True)
+            doc_ids.append(str(doc.meta.id))
+        await client.indices.refresh(index=index_manager.alias_name)
+
+        await index_manager.migrate()
+
+        new_index = await index_manager.get_current_index_name()
+        for doc_id in doc_ids:
+            fetched = await client.get(index=new_index, id=doc_id)
+            assert fetched["_source"]["content"] == doc_id
+
+        await delete_test_indices(client)
+
+
 async def get_current_index_settings(index_manager: IndexManager) -> dict[str, Any]:
     """Get index settings."""
     index_name = await index_manager.get_current_index_name()

--- a/tests/integration/test_facets.py
+++ b/tests/integration/test_facets.py
@@ -137,6 +137,7 @@ async def facet_references(es_client: AsyncElasticsearch) -> None:
     docs = [
         ReferenceDocument(
             meta={"id": uuid7()},
+            id=uuid7(),
             visibility=Visibility.PUBLIC,
             title="Climate adaptation strategies",
             linked_data_concepts=[CONCEPT_A, CONCEPT_B],
@@ -145,6 +146,7 @@ async def facet_references(es_client: AsyncElasticsearch) -> None:
         ),
         ReferenceDocument(
             meta={"id": uuid7()},
+            id=uuid7(),
             visibility=Visibility.PUBLIC,
             title="Climate modelling primer",
             linked_data_concepts=[CONCEPT_A],
@@ -153,6 +155,7 @@ async def facet_references(es_client: AsyncElasticsearch) -> None:
         ),
         ReferenceDocument(
             meta={"id": uuid7()},
+            id=uuid7(),
             visibility=Visibility.PUBLIC,
             title="Medical imaging review",
             linked_data_concepts=[CONCEPT_A, CONCEPT_C],
@@ -161,6 +164,7 @@ async def facet_references(es_client: AsyncElasticsearch) -> None:
         ),
         ReferenceDocument(
             meta={"id": uuid7()},
+            id=uuid7(),
             visibility=Visibility.PUBLIC,
             title="Medical diagnostics overview",
             linked_data_concepts=[CONCEPT_B],
@@ -169,6 +173,7 @@ async def facet_references(es_client: AsyncElasticsearch) -> None:
         ),
         ReferenceDocument(
             meta={"id": uuid7()},
+            id=uuid7(),
             visibility=Visibility.PUBLIC,
             title="Medical training handbook",
             linked_data_concepts=None,
@@ -411,6 +416,7 @@ async def sibling_references(es_client: AsyncElasticsearch) -> None:
     for i, concepts in enumerate(_SIBLING_DOC_CONCEPTS, start=1):
         await ReferenceDocument(
             meta={"id": uuid7()},
+            id=uuid7(),
             visibility=Visibility.PUBLIC,
             title=f"doc {i}",
             linked_data_concepts=concepts,

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -622,10 +622,10 @@ async def test_tied_sort_is_stable_across_doc_layouts(
         )
         for _ in range(8)
     ]
-    ascending = sorted(references, key=lambda reference: reference.id)
+    descending = sorted(references, key=lambda reference: reference.id, reverse=True)
 
-    order_a = await _reindex_and_search(es_client, ascending)
-    order_b = await _reindex_and_search(es_client, list(reversed(ascending)))
+    order_a = await _reindex_and_search(es_client, descending)
+    order_b = await _reindex_and_search(es_client, list(reversed(descending)))
 
     assert order_a == order_b
-    assert order_a == [reference.id for reference in ascending]
+    assert order_a == [reference.id for reference in descending]

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -2,6 +2,7 @@
 
 from collections.abc import AsyncGenerator, Callable
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 import pytest
 from elasticsearch import AsyncElasticsearch
@@ -15,6 +16,7 @@ from app.api.exception_handlers import (
 )
 from app.core.exceptions import ESQueryError, ParseError
 from app.domain.references import routes as references
+from app.domain.references.models.models import SearchQuery
 from app.domain.references.repository import (
     ReferenceESRepository,
     ReferenceSQLRepository,
@@ -578,3 +580,52 @@ async def test_concept_filter_empty_uri_returns_400(
         params={"q": "title:Concept", "concept": [f"{CONCEPT_A},"]},
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+async def _reindex_and_search(
+    es_client: AsyncElasticsearch, references: list["Reference"]
+) -> list[UUID]:
+    """Wipe, re-add references in order, return hit ids for an all-tied sort."""
+    await es_client.delete_by_query(
+        index="reference", body={"query": {"match_all": {}}}, conflicts="proceed"
+    )
+    await es_client.indices.refresh(index="reference")
+    repository = ReferenceESRepository(es_client)
+    for reference in references:
+        await repository.add(to_indexable(reference))
+    await es_client.indices.refresh(index="reference")
+    result = await repository.search(
+        SearchQuery(query_string="*"), page_size=50, sort=["-publication_year"]
+    )
+    return [hit.id for hit in result.hits]
+
+
+async def test_tied_sort_is_stable_across_doc_layouts(
+    es_client: AsyncElasticsearch,
+) -> None:
+    """
+    Tie-broken results order identically regardless of ``_doc`` layout.
+
+    Ensures that insertion order does not affect sort. ES uses metadata magic
+    under the hood to tiebreak, but across replicas this can lead to different
+    sorting behaviour.
+    """
+    references = [
+        ReferenceFactory.build(
+            enhancements=[
+                EnhancementFactory.build(
+                    content=BibliographicMetadataEnhancementFactory.build(
+                        publication_year=2020
+                    )
+                )
+            ]
+        )
+        for _ in range(8)
+    ]
+    ascending = sorted(references, key=lambda reference: reference.id)
+
+    order_a = await _reindex_and_search(es_client, ascending)
+    order_b = await _reindex_and_search(es_client, list(reversed(ascending)))
+
+    assert order_a == order_b
+    assert order_a == [reference.id for reference in ascending]

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -582,10 +582,10 @@ async def test_concept_filter_empty_uri_returns_400(
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-async def _reindex_and_search(
+async def _wipe_and_index(
     es_client: AsyncElasticsearch, references: list["Reference"]
-) -> list[UUID]:
-    """Wipe, re-add references in order, return hit ids for an all-tied sort."""
+) -> ReferenceESRepository:
+    """Wipe the index and re-add ``references`` in the given order."""
     await es_client.delete_by_query(
         index="reference", body={"query": {"match_all": {}}}, conflicts="proceed"
     )
@@ -594,6 +594,14 @@ async def _reindex_and_search(
     for reference in references:
         await repository.add(to_indexable(reference))
     await es_client.indices.refresh(index="reference")
+    return repository
+
+
+async def _reindex_and_search(
+    es_client: AsyncElasticsearch, references: list["Reference"]
+) -> list[UUID]:
+    """Wipe, re-add references in order, return hit ids for an all-tied sort."""
+    repository = await _wipe_and_index(es_client, references)
     result = await repository.search(
         SearchQuery(query_string="*"), page_size=50, sort=["-publication_year"]
     )
@@ -629,3 +637,53 @@ async def test_tied_sort_is_stable_across_doc_layouts(
 
     assert order_a == order_b
     assert order_a == [reference.id for reference in descending]
+
+
+async def test_relevance_pagination_is_stable_and_non_overlapping(
+    es_client: AsyncElasticsearch,
+) -> None:
+    """
+    Default relevance sort paginates deterministically when scores tie.
+
+    Every reference shares an identical title, so a title query scores them
+    equally and ordering rests entirely on the id tiebreaker. Requesting the
+    same page twice must return the same ids, and consecutive pages must not
+    overlap.
+    """
+    references = [
+        ReferenceFactory.build(
+            enhancements=[
+                EnhancementFactory.build(
+                    content=BibliographicMetadataEnhancementFactory.build(
+                        title="identicaltitletoken"
+                    )
+                )
+            ]
+        )
+        for _ in range(8)
+    ]
+    repository = await _wipe_and_index(es_client, references)
+
+    async def fetch_page(page: int) -> list[UUID]:
+        result = await repository.search(
+            SearchQuery(query_string="title:identicaltitletoken"),
+            page=page,
+            page_size=3,
+        )
+        return [hit.id for hit in result.hits]
+
+    page_1_first = await fetch_page(1)
+    page_2_first = await fetch_page(2)
+    page_1_second = await fetch_page(1)
+    page_2_second = await fetch_page(2)
+
+    # Identical requests return identical pages.
+    assert page_1_first == page_1_second
+    assert page_2_first == page_2_second
+
+    # Consecutive pages do not overlap...
+    assert set(page_1_first).isdisjoint(page_2_first)
+
+    # ...and together they follow the descending-id tiebreaker.
+    expected = sorted((r.id for r in references), reverse=True)
+    assert page_1_first + page_2_first == expected[:6]

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -2,7 +2,7 @@
 
 from collections.abc import AsyncGenerator, Callable
 from typing import TYPE_CHECKING
-from uuid import UUID
+from uuid import UUID, uuid7
 
 import pytest
 from elasticsearch import AsyncElasticsearch
@@ -687,3 +687,42 @@ async def test_relevance_pagination_is_stable_and_non_overlapping(
     # ...and together they follow the descending-id tiebreaker.
     expected = sorted((r.id for r in references), reverse=True)
     assert page_1_first + page_2_first == expected[:6]
+
+
+async def test_search_tolerates_index_without_id_mapping(
+    es_client: AsyncElasticsearch,
+) -> None:
+    """
+    Search succeeds against an index that predates the sortable ``id`` field.
+
+    This simulates a pre-migration scenario where the ``id`` field was not yet mapped,
+    and can optionally be removed later.
+    """
+    # Replace the fully-mapped test index with one lacking the `id` field.
+    for index in await es_client.indices.get(index="reference*"):
+        await es_client.indices.delete(index=index)
+    await es_client.indices.create(
+        index="reference",
+        mappings={
+            "properties": {
+                "title": {"type": "text"},
+                "abstract": {"type": "text"},
+            }
+        },
+    )
+    for _ in range(5):
+        await es_client.index(
+            index="reference",
+            id=str(uuid7()),
+            document={"title": "premigration", "abstract": "doc"},
+        )
+    await es_client.indices.refresh(index="reference")
+
+    repository = ReferenceESRepository(es_client)
+    # Without unmapped_type on the id tiebreaker this raises ESQueryError
+    result = await repository.search(
+        SearchQuery(query_string="title:premigration"), page_size=10
+    )
+
+    assert result.total.value == 5
+    assert len(result.hits) == 5

--- a/tests/unit/persistence/es/test_repository.py
+++ b/tests/unit/persistence/es/test_repository.py
@@ -367,6 +367,7 @@ async def linked_data_ref(
     ref_id = uuid7()
     doc = ReferenceDocument(
         meta={"id": ref_id},
+        id=uuid7(),
         visibility=Visibility.PUBLIC,
         title="Effectiveness of reading interventions",
         linked_data_concepts=[


### PR DESCRIPTION
Closes #770 
- Adds `id` as a first-class document field in `Reference`
- Appends `id` to the end of every sort as a stable tiebreaker
- Adds ability to run a [`painless`](https://www.elastic.co/docs/explore-analyze/scripting/modules-scripting-painless) script in migration, allowing the required migration to run entirely cloud-side