### PR TITLE
Add cluster manage perms to migrator

### DIFF
--- a/infra/app/main.tf
+++ b/infra/app/main.tf
@@ -721,7 +721,8 @@ resource "elasticstack_elasticsearch_security_api_key" "es_index_migrator" {
   name = local.es_index_migrator_name
   role_descriptors = jsonencode({
     app_access = {
-      cluster = ["monitor"]
+      # "manage" is required to pre-compile index migration scripts
+      cluster = ["monitor", "manage"]
       indices = [
         {
           names                    = local.managed_indices


### PR DESCRIPTION
Unfortunately no finer-grained permissions are possible. Cluster management feels like a fair enough scope for the migrator anyway, it includes things like task management, snapshots, routing and **not** security.