### PR TITLE
Show RESOLVED status in Slack alert header on recovery

### DIFF
--- a/infra/app/alerts.tf
+++ b/infra/app/alerts.tf
@@ -62,7 +62,7 @@ resource "azurerm_logic_app_action_http" "post_to_slack" {
           "type": "header",
           "text": {
             "type": "plain_text",
-            "text": "@{if(equals(triggerBody()?['data']?['essentials']?['severity'], 'Sev0'), '🚨 CRITICAL', if(equals(triggerBody()?['data']?['essentials']?['severity'], 'Sev1'), '❌ ERROR', '⚠️ WARNING'))} @{triggerBody()?['data']?['essentials']?['alertRule']}",
+            "text": "@{if(equals(triggerBody()?['data']?['essentials']?['monitorCondition'], 'Resolved'), '✅ RESOLVED', if(equals(triggerBody()?['data']?['essentials']?['severity'], 'Sev0'), '🚨 CRITICAL', if(equals(triggerBody()?['data']?['essentials']?['severity'], 'Sev1'), '❌ ERROR', '⚠️ WARNING')))} @{triggerBody()?['data']?['essentials']?['alertRule']}",
             "emoji": true
           }
         },


### PR DESCRIPTION
The Slack alert header was driven purely by `severity`, so a recovered alert still showed `🚨 CRITICAL`/`❌ ERROR`/`⚠️ WARNING`. This branches the header on the common-alert-schema `monitorCondition` field first, rendering `✅ RESOLVED` when Azure Monitor auto-mitigates the alert. Firing notifications are unchanged.