### PR TITLE
Demojibake outgoing enhancements

### DIFF
--- a/app/domain/references/models/ris.py
+++ b/app/domain/references/models/ris.py
@@ -15,7 +15,7 @@ from typing import Annotated
 from pydantic import Field
 
 from app.domain.base import ProjectedBaseModel
-from app.utils.strings import flatten_newlines
+from app.utils.strings import demojibake, flatten_newlines
 
 
 class RisType(StrEnum):
@@ -95,4 +95,4 @@ class RisRecord(ProjectedBaseModel):
     @staticmethod
     def _line(tag: str, value: object) -> str:
         """Format a single ``TAG  - value`` line, flattening internal newlines."""
-        return f"{tag}  - {flatten_newlines(str(value))}"
+        return f"{tag}  - {flatten_newlines(demojibake(str(value)))}"

--- a/app/domain/references/services/anti_corruption_service.py
+++ b/app/domain/references/services/anti_corruption_service.py
@@ -39,6 +39,10 @@ from app.persistence.es.persistence import (
     ESSearchResult,
     ESSearchTotal,
 )
+from app.utils.strings import demojibake, demojibake_walk
+
+# JSON-LD literal keys carrying human-readable free text
+_LINKED_DATA_TEXT_KEYS = frozenset({"name", "description", "supportingText", "@value"})
 
 
 class ReferenceAntiCorruptionService(GenericAntiCorruptionService):
@@ -163,6 +167,27 @@ class ReferenceAntiCorruptionService(GenericAntiCorruptionService):
         else:
             return full_text
 
+    def _demojibake_enhancement_content(
+        self,
+        content: destiny_sdk.enhancements.EnhancementContent,
+    ) -> None:
+        """In-place repair of legacy import mojibake for human display."""
+        match content:
+            case destiny_sdk.enhancements.BibliographicMetadataEnhancement():
+                content.title = demojibake(content.title)
+                content.publisher = demojibake(content.publisher)
+                for author in content.authorship or []:
+                    author.display_name = demojibake(author.display_name)
+                if venue := content.publication_venue:
+                    venue.display_name = demojibake(venue.display_name)
+                    venue.host_organization_name = demojibake(
+                        venue.host_organization_name
+                    )
+            case destiny_sdk.enhancements.AbstractContentEnhancement():
+                content.abstract = demojibake(content.abstract)
+            case destiny_sdk.enhancements.LinkedDataEnhancement():
+                demojibake_walk(content.data, _LINKED_DATA_TEXT_KEYS)
+
     async def enhancement_to_sdk(
         self, enhancement: Enhancement
     ) -> destiny_sdk.references.Enhancement:
@@ -173,9 +198,12 @@ class ReferenceAntiCorruptionService(GenericAntiCorruptionService):
                 dumped["content"] = (
                     await self.full_text_enhancement_content_to_sdk(enhancement.content)
                 ).model_dump()
-            return destiny_sdk.references.Enhancement.model_validate(dumped)
+            sdk_enhancement = destiny_sdk.references.Enhancement.model_validate(dumped)
+            self._demojibake_enhancement_content(sdk_enhancement.content)
         except ValidationError as exception:
             raise DomainToSDKError(errors=exception.errors()) from exception
+        else:
+            return sdk_enhancement
 
     def enhancement_from_sdk(
         self,

--- a/app/utils/regex.py
+++ b/app/utils/regex.py
@@ -7,6 +7,14 @@ _camel_case_pattern = re.compile(r"(?<!^)(?=[A-Z])")
 
 UNICODE_LETTER_PATTERN = re.compile(r"[^\W\d_]+", flags=re.UNICODE)
 
+# A UTF-8 multi-byte sequence misdecoded as latin-1 surfaces as a lead code point
+# in U+00C2-U+00F4 (the 0xC2-0xF4 UTF-8 lead bytes) followed by a continuation in
+# U+0080-U+00BF (the 0x80-0xBF continuation bytes), or a single (U+0080-U+009F)
+# control code point.
+MOJIBAKE_SIGNATURE = re.compile(
+    f"[{chr(0xC2)}-{chr(0xF4)}][{chr(0x80)}-{chr(0xBF)}]|[{chr(0x80)}-{chr(0x9F)}]"
+)
+
 
 def is_meaningful_token(token: str, min_token_length: int) -> bool:
     """

--- a/app/utils/strings.py
+++ b/app/utils/strings.py
@@ -1,5 +1,9 @@
 """Utility functions for string operations."""
 
+from typing import overload
+
+from app.utils.regex import MOJIBAKE_SIGNATURE
+
 # Newline code points (LF, CR, NEL, LINE/PARAGRAPH SEPARATOR) that break line-based
 # formats, mapped to spaces.
 _NEWLINE_TO_SPACE = {
@@ -14,3 +18,41 @@ _NEWLINE_TO_SPACE = {
 def flatten_newlines(value: str) -> str:
     """Replace every newline code point with a space, keeping the text on one line."""
     return value.translate(_NEWLINE_TO_SPACE)
+
+
+@overload
+def demojibake(value: str) -> str: ...
+
+
+@overload
+def demojibake(value: None) -> None: ...
+
+
+def demojibake(value: str | None) -> str | None:
+    """Reverse a latin-1 misdecode of UTF-8 bytes, when the string looks mojibake'd."""
+    if value is None or not MOJIBAKE_SIGNATURE.search(value):
+        return value
+    try:
+        return value.encode("latin-1").decode("utf-8")
+    except UnicodeError:
+        return value
+
+
+def demojibake_walk(
+    node: object, text_keys: frozenset[str], *, under_text_key: bool = False
+) -> None:
+    """Recursively repair mojibake in string values whose key is in text_keys."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if isinstance(value, str):
+                if key in text_keys:
+                    node[key] = demojibake(value)
+            else:
+                demojibake_walk(value, text_keys, under_text_key=key in text_keys)
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            if isinstance(value, str):
+                if under_text_key:
+                    node[index] = demojibake(value)
+            else:
+                demojibake_walk(value, text_keys, under_text_key=under_text_key)

--- a/tests/unit/domain/references/models/test_ris.py
+++ b/tests/unit/domain/references/models/test_ris.py
@@ -74,6 +74,15 @@ def test_render_flattens_internal_newlines():
     ]
 
 
+def test_render_demojibakes_display_text():
+    """Legacy import mojibake in free-text fields is repaired on render."""
+    clean = "Café Über: a Study"
+    mojibake = clean.encode("utf-8").decode("latin-1")
+    record = RisRecord(reference_type=RisType.JOURNAL, title=mojibake)
+
+    assert f"TI  - {clean}" in record.render().split("\n")
+
+
 def test_render_excludes_abstract_by_default():
     """The abstract is omitted by default and included only when not excluded."""
     record = RisRecord(reference_type=RisType.JOURNAL, abstract="An abstract.")

--- a/tests/unit/domain/references/services/test_anti_corruption_service.py
+++ b/tests/unit/domain/references/services/test_anti_corruption_service.py
@@ -153,6 +153,95 @@ class TestFullTextEnhancementFromSdk:
         assert domain_ft.blob.to_uri() == str(sdk_full_text.file_url)
 
 
+def _mojibake(value: str) -> str:
+    """Reproduce the legacy import bug: UTF-8 bytes misdecoded as latin-1."""
+    return value.encode("utf-8").decode("latin-1")
+
+
+_CLEAN_TITLE = "Teachers’ training"  # noqa: RUF001
+_CLEAN_DESCRIPTION = "Détails de l’étude"  # noqa: RUF001
+_CLEAN_SUPPORTING = "supporting ’text’"  # noqa: RUF001
+
+
+class TestEnhancementToSdkDemojibake:
+    """Legacy import mojibake is repaired for display at the ACS seam (#781)."""
+
+    @pytest.fixture
+    def service(self):
+        return ReferenceAntiCorruptionService(sign_url=AsyncMock())
+
+    async def test_repairs_bibliographic_display_text(self, service):
+        content = destiny_sdk.enhancements.BibliographicMetadataEnhancement(
+            title=_mojibake(_CLEAN_TITLE),
+            publisher=_mojibake("Éditeur Universitaire"),
+            authorship=[
+                destiny_sdk.enhancements.Authorship(
+                    display_name=_mojibake("José Peña"),
+                    position=destiny_sdk.enhancements.AuthorPosition.FIRST,
+                )
+            ],
+            publication_venue=destiny_sdk.enhancements.PublicationVenue(
+                display_name=_mojibake("Régional Review"),
+                host_organization_name=_mojibake("Universität Zürich"),
+            ),
+        )
+        enhancement = EnhancementFactory.build(content=content)
+
+        sdk = await service.enhancement_to_sdk(enhancement)
+
+        assert isinstance(
+            sdk.content, destiny_sdk.enhancements.BibliographicMetadataEnhancement
+        )
+        assert sdk.content.title == _CLEAN_TITLE
+        assert sdk.content.publisher == "Éditeur Universitaire"
+        assert sdk.content.authorship is not None
+        assert sdk.content.authorship[0].display_name == "José Peña"
+        assert sdk.content.publication_venue is not None
+        assert sdk.content.publication_venue.display_name == "Régional Review"
+        assert (
+            sdk.content.publication_venue.host_organization_name == "Universität Zürich"
+        )
+
+    async def test_repairs_abstract_text(self, service):
+        content = destiny_sdk.enhancements.AbstractContentEnhancement(
+            process=AbstractProcessType.OTHER,
+            abstract=_mojibake("Über die Grénze — a café study"),
+        )
+        enhancement = EnhancementFactory.build(content=content)
+
+        sdk = await service.enhancement_to_sdk(enhancement)
+
+        assert isinstance(
+            sdk.content, destiny_sdk.enhancements.AbstractContentEnhancement
+        )
+        assert sdk.content.abstract == "Über die Grénze — a café study"
+
+    async def test_repairs_linked_data_literals_but_not_identifiers(self, service):
+        # An @id carrying the mojibake byte pattern must survive untouched even
+        # though it sits alongside repaired literals.
+        unsafe_id = "https://id.example.org/" + _mojibake("Ünsafe")
+        content = destiny_sdk.enhancements.LinkedDataEnhancement(
+            vocabulary_uri=HttpUrl("https://vocab.example.org/v1"),
+            data={
+                "@context": "https://vocab.example.org/v1",
+                "@id": unsafe_id,
+                "name": _mojibake("Klíma"),
+                "description": _mojibake(_CLEAN_DESCRIPTION),
+                "supportingText": _mojibake(_CLEAN_SUPPORTING),
+            },
+        )
+        enhancement = EnhancementFactory.build(content=content)
+
+        sdk = await service.enhancement_to_sdk(enhancement)
+
+        assert isinstance(sdk.content, destiny_sdk.enhancements.LinkedDataEnhancement)
+        assert sdk.content.data["name"] == "Klíma"
+        assert sdk.content.data["description"] == _CLEAN_DESCRIPTION
+        assert sdk.content.data["supportingText"] == _CLEAN_SUPPORTING
+        assert sdk.content.data["@id"] == unsafe_id
+        assert sdk.content.data["@context"] == "https://vocab.example.org/v1"
+
+
 class TestLinkedDataConceptFilterFromQueryParameter:
     """Tests for parsing concept filters from query parameter values."""
 

--- a/tests/unit/test_strings.py
+++ b/tests/unit/test_strings.py
@@ -1,0 +1,103 @@
+"""Tests for string utilities, including the mojibake display remap."""
+
+from typing import Any
+
+import pytest
+
+from app.utils.strings import demojibake, demojibake_walk
+
+
+def _mojibake(value: str) -> str:
+    """Reproduce mojibaked chars: UTF-8 bytes misdecoded as latin-1."""
+    return value.encode("utf-8").decode("latin-1")
+
+
+_CURLY_CLEAN = "Teachers’ training"  # noqa: RUF001
+_QUOTED_CLEAN = "literal ’quoted’"  # noqa: RUF001
+
+
+class TestDemojibake:
+    """Tests for the single-string mojibake remap."""
+
+    @pytest.mark.parametrize(
+        "clean",
+        [
+            _CURLY_CLEAN,
+            "a café and a naïve résumé",
+            "«guillemets» and — em dashes",
+            "Über die Grénze",
+        ],
+    )
+    def test_reverses_latin1_misdecode(self, clean: str) -> None:
+        assert demojibake(_mojibake(clean)) == clean
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "ASCII only",
+            "café",  # accented char not followed by a continuation byte
+            "naïve",
+            "Beyoncé",
+            "à la carte",
+            "£5 and 50¢",
+            "Zürich",
+            "こんにちは",  # already-clean multi-byte text
+        ],
+    )
+    def test_leaves_clean_text_untouched(self, text: str) -> None:
+        assert demojibake(text) is text
+
+    def test_leaves_non_round_tripping_match_untouched(self) -> None:
+        # Matches the signature but is not valid UTF-8 when re-encoded.
+        assert demojibake("Aâ\x80Z\x80") == "Aâ\x80Z\x80"
+
+    def test_is_idempotent(self) -> None:
+        once = demojibake(_mojibake(_CURLY_CLEAN))
+        assert demojibake(once) == once
+
+
+class TestDemojibakeTextValues:
+    """Tests for the in-place, key-scoped structural remap."""
+
+    def test_repairs_only_allowlisted_keys(self) -> None:
+        text_keys = frozenset({"title", "display_name"})
+        node = {
+            "title": _mojibake(_CURLY_CLEAN),
+            "publisher": _mojibake("Éditeur"),  # not in the allowlist
+        }
+
+        demojibake_walk(node, text_keys)
+
+        assert node["title"] == _CURLY_CLEAN
+        assert node["publisher"] == _mojibake("Éditeur")
+
+    def test_recurses_nested_mappings_and_lists(self) -> None:
+        text_keys = frozenset({"display_name", "description"})
+        node: dict[str, Any] = {
+            "authorship": [{"display_name": _mojibake("José"), "orcid": "0000-0002"}],
+            "description": [_mojibake("First"), _mojibake("Sécond")],
+        }
+
+        demojibake_walk(node, text_keys)
+
+        assert node["authorship"][0]["display_name"] == "José"
+        assert node["authorship"][0]["orcid"] == "0000-0002"
+        assert node["description"] == ["First", "Sécond"]
+
+    def test_never_touches_identifiers_under_a_text_key(self) -> None:
+        # A JSON-LD literal object nested under a text key must still have its
+        # own @id/@type left alone; only @value is a text key here.
+        text_keys = frozenset({"supportingText", "@value"})
+        unsafe_id = "https://id.example.org/" + _mojibake("Ünsafe")
+        node = {
+            "supportingText": {
+                "@value": _mojibake(_QUOTED_CLEAN),
+                "@id": unsafe_id,
+                "@type": "xsd:string",
+            }
+        }
+
+        demojibake_walk(node, text_keys)
+
+        assert node["supportingText"]["@value"] == _QUOTED_CLEAN
+        assert node["supportingText"]["@id"] == unsafe_id


### PR DESCRIPTION
Closes #781 

Adds a step to the anti-corruption layer that amends the mojibake corruption on specified fields.

(Sidebar: this architecture is glorious - one tiny touch point to change all exports/endpoints/etc (except RIS :())