### PR TITLE
Candidate Selection API: evaluable baseline retrieval

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -387,6 +387,12 @@ class DedupCandidateScoringConfig(BaseModel):
         le=5,
         description="Minimum token length for author name matching.",
     )
+    candidate_k: int = Field(
+        default=100,
+        ge=1,
+        le=1000,
+        description="Default number of candidate references to retrieve.",
+    )
 
 
 class Settings(BaseSettings):

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -330,6 +330,17 @@ class GenericExternalIdentifier(DomainBaseModel):
             else None,
         )
 
+    @classmethod
+    def from_generic(cls, identifier: "GenericExternalIdentifier") -> Self:
+        """
+        Validate and canonicalise a loosely-typed identifier via the SDK models.
+
+        Raises ``pydantic.ValidationError`` if the value is not a valid identifier
+        of its declared type.
+        """
+        specific = ExternalIdentifierAdapter.validate_python(identifier.model_dump())
+        return cls.from_specific(specific)
+
 
 class IdentifierLookup(GenericExternalIdentifier):
     """Model to search for an external identifier."""
@@ -766,28 +777,17 @@ class ReferenceSearchFields(ProjectedBaseModel):
 CURRENT_FUZZY_RETRIEVAL_POLICY = "current_fuzzy_v1"
 
 
-class CandidateIdentifier(BaseModel):
-    """An external identifier, used as request input and as match provenance."""
+class CandidateIdentifier(GenericExternalIdentifier):
+    """
+    An external identifier used as candidate-search input and match provenance.
+
+    Narrows :class:`GenericExternalIdentifier` to require an explicit type;
+    candidate search does not accept database-id (untyped) lookups.
+    """
 
     identifier_type: ExternalIdentifierType = Field(
         description="The type of the identifier, e.g. doi, pm_id, open_alex."
     )
-    identifier: str = Field(description="The identifier value.")
-    other_identifier_name: str | None = Field(
-        default=None,
-        description="The name of the identifier when identifier_type is other.",
-    )
-
-    @classmethod
-    def from_specific(cls, external_identifier: ExternalIdentifier) -> Self:
-        """Build from a stored identifier, casting its value to a string."""
-        return cls(
-            identifier_type=external_identifier.identifier_type,
-            identifier=str(external_identifier.identifier),
-            other_identifier_name=getattr(
-                external_identifier, "other_identifier_name", None
-            ),
-        )
 
 
 class CandidateSelectionInput(BaseModel):
@@ -880,8 +880,8 @@ CandidateRoute = Annotated[
 ]
 
 
-class CandidateReferenceProjection(BaseModel):
-    """Hydrated bibliographic projection of a candidate reference."""
+class CandidateReference(ProjectedBaseModel):
+    """Hydrated bibliographic fields of a candidate reference."""
 
     title: str | None = None
     authors: list[str] = Field(default_factory=list)
@@ -897,7 +897,7 @@ class Candidate(BaseModel):
     routes: list[CandidateRoute] = Field(
         description="How this candidate was surfaced (ES and/or identifier)."
     )
-    reference: CandidateReferenceProjection | None = Field(
+    reference: CandidateReference | None = Field(
         default=None,
         description="Hydrated bibliographic fields; omitted when hydrate is false.",
     )

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -778,6 +778,17 @@ class CandidateIdentifier(BaseModel):
         description="The name of the identifier when identifier_type is other.",
     )
 
+    @classmethod
+    def from_specific(cls, external_identifier: ExternalIdentifier) -> Self:
+        """Build from a stored identifier, casting its value to a string."""
+        return cls(
+            identifier_type=external_identifier.identifier_type,
+            identifier=str(external_identifier.identifier),
+            other_identifier_name=getattr(
+                external_identifier, "other_identifier_name", None
+            ),
+        )
+
 
 class CandidateSelectionInput(BaseModel):
     """

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -330,20 +330,20 @@ class GenericExternalIdentifier(DomainBaseModel):
             else None,
         )
 
+
+class IdentifierLookup(GenericExternalIdentifier):
+    """Model to search for an external identifier."""
+
     @classmethod
-    def from_generic(cls, identifier: "GenericExternalIdentifier") -> Self:
+    def from_generic(cls, identifier: GenericExternalIdentifier) -> Self:
         """
-        Validate and canonicalise a loosely-typed identifier via the SDK models.
+        Build a lookup from a loosely-typed identifier, validating and canonicalising.
 
         Raises ``pydantic.ValidationError`` if the value is not a valid identifier
         of its declared type.
         """
         specific = ExternalIdentifierAdapter.validate_python(identifier.model_dump())
         return cls.from_specific(specific)
-
-
-class IdentifierLookup(GenericExternalIdentifier):
-    """Model to search for an external identifier."""
 
 
 class FullTextEnhancement(DomainBaseModel):

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -904,9 +904,15 @@ class Candidate(BaseModel):
 
 
 class InputSearchability(BaseModel):
-    """Whether the input reference is searchable for candidate retrieval."""
+    """Whether the input meets the Elasticsearch bibliographic searchability gate."""
 
-    searchable: bool = Field(description="Whether candidate retrieval was attempted.")
+    searchable: bool = Field(
+        description=(
+            "Whether the input meets the Elasticsearch searchability gate (title, "
+            "authors, publication year). Exact identifier matching runs regardless, "
+            "so candidates may be present even when this is false."
+        )
+    )
     reason: str = Field(description="Explanation of the searchability decision.")
 
 

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -763,6 +763,170 @@ class ReferenceSearchFields(ProjectedBaseModel):
         return [cls._normalise_string(v) for v in value if v]
 
 
+CURRENT_FUZZY_RETRIEVAL_POLICY = "current_fuzzy_v1"
+
+
+class CandidateIdentifier(BaseModel):
+    """An external identifier, used as request input and as match provenance."""
+
+    identifier_type: ExternalIdentifierType = Field(
+        description="The type of the identifier, e.g. doi, pm_id, open_alex."
+    )
+    identifier: str = Field(description="The identifier value.")
+    other_identifier_name: str | None = Field(
+        default=None,
+        description="The name of the identifier when identifier_type is other.",
+    )
+
+
+class CandidateSelectionInput(BaseModel):
+    """
+    The reference to find candidates for.
+
+    Provide exactly one of a stored ``reference_id`` (projected into search
+    fields server-side) or an inline set of candidate-search fields.
+    """
+
+    reference_id: UUID | None = Field(
+        default=None,
+        description="A stored reference to hydrate and project into search fields.",
+    )
+    title: str | None = Field(default=None, description="The title to search on.")
+    authors: list[str] = Field(
+        default_factory=list, description="The authors to search on."
+    )
+    publication_year: int | None = Field(
+        default=None, description="The publication year to search on."
+    )
+    identifiers: list[CandidateIdentifier] = Field(
+        default_factory=list,
+        description="Identifiers to union with the Elasticsearch candidates.",
+    )
+
+    @model_validator(mode="after")
+    def validate_exactly_one_input_mode(self) -> Self:
+        """Require exactly one of reference_id or inline candidate-search fields."""
+        has_reference_id = self.reference_id is not None
+        has_inline = bool(
+            self.title or self.authors or self.publication_year or self.identifiers
+        )
+        if has_reference_id == has_inline:
+            msg = (
+                "Provide exactly one of reference_id or inline candidate-search "
+                "fields, not both or neither."
+            )
+            raise ValueError(msg)
+        return self
+
+
+class CandidateSelectionRequest(BaseModel):
+    """A request for candidate canonical references, for dedup evaluation."""
+
+    input: CandidateSelectionInput = Field(
+        description="The reference to find candidates for."
+    )
+    k: int | None = Field(
+        default=None,
+        ge=1,
+        le=1000,
+        description=(
+            "Number of candidates to retrieve. Defaults to the configured value."
+        ),
+    )
+    include_identifier_matches: bool = Field(
+        default=True,
+        description=(
+            "Union exact identifier matches from Postgres with ES candidates."
+        ),
+    )
+    hydrate: bool = Field(
+        default=True,
+        description="Include hydrated bibliographic fields on each candidate.",
+    )
+
+
+class CandidateElasticsearchRoute(BaseModel):
+    """Provenance for a candidate surfaced by the Elasticsearch query."""
+
+    type: Literal["elasticsearch"] = "elasticsearch"
+    policy: str = Field(description="The retrieval policy that surfaced the candidate.")
+    rank: int = Field(description="Rank within the Elasticsearch results (1-based).")
+    score: float = Field(description="The Elasticsearch relevance score.")
+
+
+class CandidateIdentifierRoute(BaseModel):
+    """Provenance for a candidate surfaced by an exact identifier match."""
+
+    type: Literal["identifier"] = "identifier"
+    matched_identifiers: list[CandidateIdentifier] = Field(
+        description="The input identifiers that matched this candidate."
+    )
+
+
+CandidateRoute = Annotated[
+    CandidateElasticsearchRoute | CandidateIdentifierRoute,
+    Field(discriminator="type"),
+]
+
+
+class CandidateReferenceProjection(BaseModel):
+    """Hydrated bibliographic projection of a candidate reference."""
+
+    title: str | None = None
+    authors: list[str] = Field(default_factory=list)
+    publication_year: int | None = None
+    identifiers: list[CandidateIdentifier] = Field(default_factory=list)
+
+
+class Candidate(BaseModel):
+    """A candidate canonical reference with route provenance."""
+
+    reference_id: UUID
+    rank: int = Field(description="Overall rank across all routes (1-based).")
+    routes: list[CandidateRoute] = Field(
+        description="How this candidate was surfaced (ES and/or identifier)."
+    )
+    reference: CandidateReferenceProjection | None = Field(
+        default=None,
+        description="Hydrated bibliographic fields; omitted when hydrate is false.",
+    )
+
+
+class InputSearchability(BaseModel):
+    """Whether the input reference is searchable for candidate retrieval."""
+
+    searchable: bool = Field(description="Whether candidate retrieval was attempted.")
+    reason: str = Field(description="Explanation of the searchability decision.")
+
+
+class CandidateSelectionDiagnostics(BaseModel):
+    """Retrieval diagnostics for evaluation."""
+
+    es_took_ms: int | None = None
+    es_total_hits: int | None = None
+    es_returned: int = 0
+    identifier_returned: int = 0
+    candidate_count: int = 0
+    truncated: bool = False
+    kth_es_score: float | None = None
+    lowest_es_score: float | None = None
+
+
+class CandidateSelectionResult(BaseModel):
+    """Ranked candidates and diagnostics for a candidate-selection request."""
+
+    retrieval_policy: str = CURRENT_FUZZY_RETRIEVAL_POLICY
+    index_version: str | None = Field(
+        default=None,
+        description="The reference index version the candidates were drawn from.",
+    )
+    k_requested: int
+    include_identifier_matches: bool
+    input_searchability: InputSearchability
+    diagnostics: CandidateSelectionDiagnostics
+    candidates: list[Candidate] = Field(default_factory=list)
+
+
 class LinkedDataProjection(ProjectedBaseModel):
     """Result of projecting a LinkedDataEnhancement into flat searchable fields."""
 

--- a/app/domain/references/models/projections.py
+++ b/app/domain/references/models/projections.py
@@ -10,6 +10,8 @@ from app.core.exceptions import ProjectionError
 from app.domain.base import GenericProjection
 from app.domain.references.models.models import (
     CandidateCanonicalSearchFields,
+    CandidateIdentifier,
+    CandidateReference,
     Enhancement,
     EnhancementRequest,
     EnhancementRequestStatus,
@@ -244,6 +246,24 @@ class ReferenceSearchFieldsProjection(GenericProjection[ReferenceSearchFields]):
     ) -> CandidateCanonicalSearchFields:
         """Return fields needed for candidate canonical selection."""
         return cls.get_from_reference(reference).to_canonical_candidate_search_fields()
+
+
+class CandidateReferenceProjection(GenericProjection[CandidateReference]):
+    """Projection from a reference to hydrated candidate bibliographic fields."""
+
+    @classmethod
+    def get_from_reference(cls, reference: Reference) -> CandidateReference:
+        """Project a hydrated reference into candidate bibliographic fields."""
+        fields = ReferenceSearchFieldsProjection.get_from_reference(reference)
+        return CandidateReference(
+            title=fields.title,
+            authors=fields.authors,
+            publication_year=fields.publication_year,
+            identifiers=[
+                CandidateIdentifier.from_specific(linked.identifier)
+                for linked in (reference.identifiers or [])
+            ],
+        )
 
 
 class ReferenceRisProjection(GenericProjection[RisRecord]):

--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -687,6 +687,7 @@ class ReferenceESRepository(
         *,
         k: int,
         reference_id: UUID | None = None,
+        track_total_hits: bool = False,
     ) -> CandidateCanonicalSearchResult:
         """
         Fuzzy match candidate fingerprints to existing references.
@@ -712,6 +713,10 @@ class ReferenceESRepository(
         :param reference_id: The ID of the potential duplicate, excluded from the
             results when provided.
         :type reference_id: UUID | None
+        :param track_total_hits: Compute the exact total hit count instead of the
+            Elasticsearch default (capped at 10k). Off by default so the nomination
+            path, which ignores the total, does not pay for a full count.
+        :type track_total_hits: bool
         :return: Ranked candidate ids with scores and retrieval diagnostics.
         :rtype: CandidateCanonicalSearchResult
         """
@@ -763,8 +768,12 @@ class ReferenceESRepository(
                 )
             )
             .source(fields=False)
-            .extra(size=k, track_total_hits=True)
+            .extra(size=k)
         )
+        # Only force an exact count when asked; leaving it unset keeps the ES default
+        # (accurate up to 10k, then a lower bound) rather than disabling totals.
+        if track_total_hits:
+            search = search.extra(track_total_hits=True)
 
         response = await search.execute()
 

--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any, ClassVar, Literal
 from uuid import UUID
 
-from elasticsearch import AsyncElasticsearch
+from elasticsearch import AsyncElasticsearch, NotFoundError
 from elasticsearch.dsl import AsyncSearch, Q
 from elasticsearch.dsl.query import Bool, MatchAll, Prefix, Query, Range, Term, Terms
 from elasticsearch.dsl.response import Response
@@ -106,6 +106,7 @@ from app.domain.references.models.sql import (
 )
 from app.domain.references.models.sql import SearchExport as SQLSearchExport
 from app.persistence.es.persistence import (
+    CandidateCanonicalSearchResult,
     ESFacetBucket,
     ESScoreResult,
     ESSearchResult,
@@ -681,18 +682,20 @@ class ReferenceESRepository(
     async def search_for_candidate_canonicals(
         self,
         search_fields: CandidateCanonicalSearchFields,
-        reference_id: UUID,
         scoring_config: DedupCandidateScoringConfig,
-    ) -> list[ESScoreResult]:
+        *,
+        k: int,
+        reference_id: UUID | None = None,
+    ) -> CandidateCanonicalSearchResult:
         """
         Fuzzy match candidate fingerprints to existing references.
 
-        This is a high-recall search strategy.
+        This is a high-recall search strategy. Shared by the deduplication
+        nomination path and the candidate-selection evaluation endpoint so that
+        both exercise the same query; the query shape itself is the baseline
+        under evaluation and is not yet a chosen production policy.
 
-        NOT TESTED/EVALUATED. Thrown together as a proof of concept, this must
-        be polished and evaluated before use.
-
-        The proof of concept does:
+        The query does:
 
         - MUST: fuzzy match on title (requires 50% of terms to match)
         - SHOULD: author matching
@@ -701,12 +704,15 @@ class ReferenceESRepository(
 
         :param search_fields: The search fields of the potential duplicate.
         :type search_fields: CandidateCanonicalSearchFields
-        :param reference_id: The ID of the potential duplicate.
-        :type reference_id: UUID
         :param scoring_config: Configuration for author scoring.
         :type scoring_config: DedupCandidateScoringConfig
-        :return: A list of search results with IDs and scores.
-        :rtype: list[ESScoreResult]
+        :param k: Maximum number of candidates to return.
+        :type k: int
+        :param reference_id: The ID of the potential duplicate, excluded from the
+            results when provided.
+        :type reference_id: UUID | None
+        :return: Ranked candidate ids with scores and retrieval diagnostics.
+        :rtype: CandidateCanonicalSearchResult
         """
         author_query = self._build_author_dis_max_query(
             search_fields.authors,
@@ -752,15 +758,16 @@ class ReferenceESRepository(
                     ]
                     if search_fields.publication_year
                     else [],
-                    must_not=[Q("ids", values=[reference_id])],
+                    must_not=[Q("ids", values=[reference_id])] if reference_id else [],
                 )
             )
             .source(fields=False)
+            .extra(size=k, track_total_hits=True)
         )
 
         response = await search.execute()
 
-        return sorted(
+        hits = sorted(
             [
                 ESScoreResult(id=hit.meta.id, score=hit.meta.score)
                 for hit in response.hits
@@ -768,6 +775,27 @@ class ReferenceESRepository(
             key=lambda result: result.score,
             reverse=True,
         )
+        return CandidateCanonicalSearchResult(
+            hits=hits,
+            # ES DSL typing on response.hits is incorrect
+            total=ESSearchTotal(
+                value=response.hits.total.value,  # type: ignore[attr-defined]
+                relation=response.hits.total.relation,  # type: ignore[attr-defined]
+            ),
+            took_ms=response.took,
+        )
+
+    @trace_repository_method(tracer)
+    async def get_current_index_name(self) -> str | None:
+        """Return the physical index name currently behind the alias, if any."""
+        try:
+            alias_info = await self._client.indices.get_alias(
+                name=self._persistence_cls.Index.name
+            )
+        except NotFoundError:
+            return None
+        indices = list(alias_info.keys())
+        return indices[0] if indices else None
 
 
 class ExternalIdentifierRepositoryBase(

--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any, ClassVar, Literal
 from uuid import UUID
 
-from elasticsearch import AsyncElasticsearch, NotFoundError
+from elasticsearch import AsyncElasticsearch
 from elasticsearch.dsl import AsyncSearch, Q
 from elasticsearch.dsl.query import Bool, MatchAll, Prefix, Query, Range, Term, Terms
 from elasticsearch.dsl.response import Response
@@ -105,6 +105,7 @@ from app.domain.references.models.sql import (
     RobotEnhancementBatch as SQLRobotEnhancementBatch,
 )
 from app.domain.references.models.sql import SearchExport as SQLSearchExport
+from app.persistence.es.index_manager import IndexManager
 from app.persistence.es.persistence import (
     CandidateCanonicalSearchResult,
     ESFacetBucket,
@@ -788,14 +789,9 @@ class ReferenceESRepository(
     @trace_repository_method(tracer)
     async def get_current_index_name(self) -> str | None:
         """Return the physical index name currently behind the alias, if any."""
-        try:
-            alias_info = await self._client.indices.get_alias(
-                name=self._persistence_cls.Index.name
-            )
-        except NotFoundError:
-            return None
-        indices = list(alias_info.keys())
-        return indices[0] if indices else None
+        return await IndexManager(
+            self._persistence_cls, self._client
+        ).get_current_index_name()
 
 
 class ExternalIdentifierRepositoryBase(

--- a/app/domain/references/routes.py
+++ b/app/domain/references/routes.py
@@ -61,6 +61,8 @@ from app.core.telemetry.logger import get_logger
 from app.core.telemetry.taskiq import TaskPriority, queue_task_with_trace
 from app.domain.references.models.models import (
     AnnotationFilter,
+    CandidateSelectionRequest,
+    CandidateSelectionResult,
     ExportFormat,
     LinkedDataConceptFilter,
     LinkedDataCountryFilter,
@@ -315,6 +317,11 @@ enhancement_request_automation_router = APIRouter(
 deduplication_router = APIRouter(
     prefix="/duplicate-decisions",
     tags=["duplicate-decisions"],
+    dependencies=[Depends(reference_deduplication_auth)],
+)
+candidate_selection_router = APIRouter(
+    prefix="/deduplication",
+    tags=["deduplication"],
     dependencies=[Depends(reference_deduplication_auth)],
 )
 
@@ -1445,3 +1452,41 @@ async def make_duplicate_decisions(
 
 
 reference_router.include_router(deduplication_router)
+
+
+@candidate_selection_router.post(
+    "/candidates/",
+    status_code=status.HTTP_200_OK,
+)
+@experimental
+async def get_deduplication_candidates(
+    request: CandidateSelectionRequest,
+    reference_service: Annotated[ReferenceService, Depends(reference_service)],
+) -> CandidateSelectionResult:
+    """
+    Return ranked candidate canonicals for a reference, for dedup evaluation.
+
+    This is a read-only endpoint: it performs no deduplication and writes no
+    duplicate-decision or candidate state. It runs the same Elasticsearch
+    candidate query used by the nomination path and, by default, unions exact
+    identifier matches from Postgres.
+
+    Provide either a stored ``reference_id`` or an inline candidate-search
+    payload. Inputs that fail the searchability gate return an empty candidate
+    list with a reason rather than an error.
+    """
+    logger.info(
+        "Retrieving deduplication candidates.",
+        k=request.k,
+        include_identifier_matches=request.include_identifier_matches,
+    )
+    try:
+        return await reference_service.get_deduplication_candidates(request)
+    except DeduplicationValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(e),
+        ) from e
+
+
+reference_router.include_router(candidate_selection_router)

--- a/app/domain/references/service.py
+++ b/app/domain/references/service.py
@@ -583,7 +583,6 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
         diagnostics. It writes no duplicate-decision or candidate state.
         """
         k = request.k or settings.dedup_scoring.candidate_k
-        index_version = await self.es_uow.references.get_current_index_name()
 
         (
             search_fields,
@@ -591,39 +590,39 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
             identifier_lookups,
         ) = await self._resolve_candidate_selection_input(request.input)
 
-        if not search_fields.is_searchable:
-            return CandidateSelectionResult(
-                index_version=index_version,
-                k_requested=k,
-                include_identifier_matches=request.include_identifier_matches,
-                input_searchability=InputSearchability(
-                    searchable=False,
-                    reason=_unsearchable_reason(search_fields),
-                ),
-                diagnostics=CandidateSelectionDiagnostics(),
-            )
-
-        es_result = await self.es_uow.references.search_for_candidate_canonicals(
-            search_fields,
-            scoring_config=settings.dedup_scoring,
-            k=k,
-            reference_id=self_id,
-        )
-        es_scores = {hit.id: hit.score for hit in es_result.hits}
-        es_ranks = {hit.id: rank for rank, hit in enumerate(es_result.hits, start=1)}
-
+        # Exact identifier matching does not depend on bibliographic searchability;
+        # it is the route for records that fail the ES searchability gate, so it runs
+        # regardless of it.
         identifier_matches: dict[UUID, dict[tuple, CandidateIdentifier]] = {}
         if request.include_identifier_matches and identifier_lookups:
             identifier_matches = await self._union_identifier_matches(
                 identifier_lookups, self_id=self_id
             )
 
+        # The ES candidate query and its index-version stamp are only meaningful for
+        # searchable inputs.
+        searchable = search_fields.is_searchable
+        es_result = None
+        index_version = None
+        if searchable:
+            index_version = await self.es_uow.references.get_current_index_name()
+            es_result = await self.es_uow.references.search_for_candidate_canonicals(
+                search_fields,
+                scoring_config=settings.dedup_scoring,
+                k=k,
+                reference_id=self_id,
+            )
+
+        es_hits = es_result.hits if es_result else []
+        es_scores = {hit.id: hit.score for hit in es_hits}
+        es_ranks = {hit.id: rank for rank, hit in enumerate(es_hits, start=1)}
+
         # Identifier-only matches rank ahead of ES-scored matches for evaluator
         # visibility; everything carrying an ES score follows in score order.
         identifier_only_ids = [
             cid for cid in identifier_matches if cid not in es_scores
         ]
-        ordered_ids = identifier_only_ids + [hit.id for hit in es_result.hits]
+        ordered_ids = identifier_only_ids + [hit.id for hit in es_hits]
 
         hydrated_by_id: dict[UUID, Reference] = {}
         if request.hydrate and ordered_ids:
@@ -660,21 +659,24 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
                 )
             )
 
-        es_returned = len(es_result.hits)
+        es_returned = len(es_hits)
         return CandidateSelectionResult(
             index_version=index_version,
             k_requested=k,
             include_identifier_matches=request.include_identifier_matches,
-            input_searchability=InputSearchability(searchable=True, reason="ok"),
+            input_searchability=InputSearchability(
+                searchable=searchable,
+                reason="ok" if searchable else _unsearchable_reason(search_fields),
+            ),
             diagnostics=CandidateSelectionDiagnostics(
-                es_took_ms=es_result.took_ms,
-                es_total_hits=es_result.total.value,
+                es_took_ms=es_result.took_ms if es_result else None,
+                es_total_hits=es_result.total.value if es_result else None,
                 es_returned=es_returned,
                 identifier_returned=len(identifier_matches),
                 candidate_count=len(ordered_ids),
-                truncated=es_result.total.value > es_returned,
-                kth_es_score=es_result.hits[k - 1].score if es_returned >= k else None,
-                lowest_es_score=es_result.hits[-1].score if es_result.hits else None,
+                truncated=(es_result.total.value > es_returned) if es_result else False,
+                kth_es_score=es_hits[k - 1].score if es_returned >= k else None,
+                lowest_es_score=es_hits[-1].score if es_hits else None,
             ),
             candidates=candidates,
         )
@@ -742,8 +744,11 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
         for reference in matched_references:
             if reference.id == self_id:
                 continue
-            # A match on a duplicate resolves to its canonical, which may be a
-            # different, older reference outside the queried set.
+            # Unlike the ES query, this read-only path does not restrict to
+            # CANONICAL-at-rest references: that filter guards a nomination write
+            # race we don't have, so an exact identifier match is surfaced whatever
+            # its dedup state. A match on a duplicate resolves to its canonical,
+            # which may be a different, older reference outside the queried set.
             if reference.is_canonical_like:
                 canonical_id = reference.id
             elif (
@@ -752,7 +757,11 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
             ):
                 canonical_id = reference.duplicate_decision.canonical_reference_id
             else:
-                continue
+                msg = (
+                    "Identifier match is a determined duplicate without a canonical "
+                    "reference id. This should not happen."
+                )
+                raise RuntimeError(msg)
             if canonical_id == self_id:
                 continue
             bucket = matches.setdefault(canonical_id, {})
@@ -762,13 +771,7 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
                     str(linked.identifier.identifier),
                 )
                 if key in query_keys:
-                    bucket[key] = CandidateIdentifier(
-                        identifier_type=linked.identifier.identifier_type,
-                        identifier=str(linked.identifier.identifier),
-                        other_identifier_name=getattr(
-                            linked.identifier, "other_identifier_name", None
-                        ),
-                    )
+                    bucket[key] = CandidateIdentifier.from_specific(linked.identifier)
         return matches
 
     @staticmethod
@@ -782,13 +785,7 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
             authors=fields.authors,
             publication_year=fields.publication_year,
             identifiers=[
-                CandidateIdentifier(
-                    identifier_type=linked.identifier.identifier_type,
-                    identifier=str(linked.identifier.identifier),
-                    other_identifier_name=getattr(
-                        linked.identifier, "other_identifier_name", None
-                    ),
-                )
+                CandidateIdentifier.from_specific(linked.identifier)
                 for linked in (reference.identifiers or [])
             ],
         )

--- a/app/domain/references/service.py
+++ b/app/domain/references/service.py
@@ -122,7 +122,7 @@ _UNIONABLE_IDENTIFIER_TYPES = frozenset(
 
 
 def _unsearchable_reason(search_fields: CandidateCanonicalSearchFields) -> str:
-    """Explain which required search fields are absent."""
+    """Explain which Elasticsearch search fields are absent."""
     missing = [
         name
         for name, value in (
@@ -132,7 +132,10 @@ def _unsearchable_reason(search_fields: CandidateCanonicalSearchFields) -> str:
         )
         if not value
     ]
-    return f"Missing required search field(s): {', '.join(missing)}."
+    return (
+        f"Not searchable via Elasticsearch (missing: {', '.join(missing)}); "
+        "exact identifier matches, if any, are still returned."
+    )
 
 
 class ReferenceService(GenericService[ReferenceAntiCorruptionService]):

--- a/app/domain/references/service.py
+++ b/app/domain/references/service.py
@@ -13,6 +13,7 @@ from app.core.config import (
     get_settings,
 )
 from app.core.exceptions import (
+    DeduplicationValueError,
     DuplicateEnhancementError,
     FullTextIngestionError,
     InvalidParentEnhancementError,
@@ -23,6 +24,17 @@ from app.core.telemetry.attributes import Attributes, trace_attribute
 from app.core.telemetry.logger import get_logger
 from app.core.telemetry.taskiq import queue_task_with_trace
 from app.domain.references.models.models import (
+    CURRENT_FUZZY_RETRIEVAL_POLICY,
+    Candidate,
+    CandidateCanonicalSearchFields,
+    CandidateElasticsearchRoute,
+    CandidateIdentifier,
+    CandidateIdentifierRoute,
+    CandidateReferenceProjection,
+    CandidateSelectionDiagnostics,
+    CandidateSelectionInput,
+    CandidateSelectionRequest,
+    CandidateSelectionResult,
     CrossFacetCell,
     DuplicateDetermination,
     Enhancement,
@@ -31,8 +43,11 @@ from app.domain.references.models.models import (
     EnhancementType,
     ExportFormat,
     ExternalIdentifier,
+    ExternalIdentifierAdapter,
+    ExternalIdentifierType,
     FacetType,
     IdentifierLookup,
+    InputSearchability,
     LinkedExternalIdentifier,
     PendingEnhancement,
     PendingEnhancementStatus,
@@ -48,6 +63,7 @@ from app.domain.references.models.models import (
 from app.domain.references.models.projections import (
     DeduplicatedReferenceProjection,
     ReferenceRisProjection,
+    ReferenceSearchFieldsProjection,
 )
 from app.domain.references.models.validators import ReferenceCreateResult
 from app.domain.references.repository import (
@@ -94,6 +110,29 @@ from app.utils.time_and_date import apply_positive_timedelta
 logger = get_logger(__name__)
 settings = get_settings()
 tracer = get_tracer(__name__)
+
+# ES does not index identifiers, so exact-identifier candidates come from Postgres.
+_UNIONABLE_IDENTIFIER_TYPES = frozenset(
+    {
+        ExternalIdentifierType.DOI,
+        ExternalIdentifierType.PM_ID,
+        ExternalIdentifierType.OPEN_ALEX,
+    }
+)
+
+
+def _unsearchable_reason(search_fields: CandidateCanonicalSearchFields) -> str:
+    """Explain which required search fields are absent."""
+    missing = [
+        name
+        for name, value in (
+            ("title", search_fields.title),
+            ("authors", search_fields.authors),
+            ("publication_year", search_fields.publication_year),
+        )
+        if not value
+    ]
+    return f"Missing required search field(s): {', '.join(missing)}."
 
 
 class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
@@ -529,6 +568,230 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
         )
         # Filter again in case multiple duplicates pointed to same canonical
         return list({reference.id: reference for reference in references}.values())
+
+    @sql_unit_of_work
+    @es_unit_of_work
+    async def get_deduplication_candidates(
+        self, request: CandidateSelectionRequest
+    ) -> CandidateSelectionResult:
+        """
+        Retrieve ranked candidate canonicals for a reference, without persisting.
+
+        Read-only evaluation surface for deduplication candidate retrieval: it runs
+        the shared Elasticsearch candidate query and, optionally, unions exact
+        identifier matches from Postgres, returning route provenance and retrieval
+        diagnostics. It writes no duplicate-decision or candidate state.
+        """
+        k = request.k or settings.dedup_scoring.candidate_k
+        index_version = await self.es_uow.references.get_current_index_name()
+
+        (
+            search_fields,
+            self_id,
+            identifier_lookups,
+        ) = await self._resolve_candidate_selection_input(request.input)
+
+        if not search_fields.is_searchable:
+            return CandidateSelectionResult(
+                index_version=index_version,
+                k_requested=k,
+                include_identifier_matches=request.include_identifier_matches,
+                input_searchability=InputSearchability(
+                    searchable=False,
+                    reason=_unsearchable_reason(search_fields),
+                ),
+                diagnostics=CandidateSelectionDiagnostics(),
+            )
+
+        es_result = await self.es_uow.references.search_for_candidate_canonicals(
+            search_fields,
+            scoring_config=settings.dedup_scoring,
+            k=k,
+            reference_id=self_id,
+        )
+        es_scores = {hit.id: hit.score for hit in es_result.hits}
+        es_ranks = {hit.id: rank for rank, hit in enumerate(es_result.hits, start=1)}
+
+        identifier_matches: dict[UUID, dict[tuple, CandidateIdentifier]] = {}
+        if request.include_identifier_matches and identifier_lookups:
+            identifier_matches = await self._union_identifier_matches(
+                identifier_lookups, self_id=self_id
+            )
+
+        # Identifier-only matches rank ahead of ES-scored matches for evaluator
+        # visibility; everything carrying an ES score follows in score order.
+        identifier_only_ids = [
+            cid for cid in identifier_matches if cid not in es_scores
+        ]
+        ordered_ids = identifier_only_ids + [hit.id for hit in es_result.hits]
+
+        hydrated_by_id: dict[UUID, Reference] = {}
+        if request.hydrate and ordered_ids:
+            hydrated = await self.sql_uow.references.get_hydrated(
+                ordered_ids, enhancement_types=[EnhancementType.BIBLIOGRAPHIC]
+            )
+            hydrated_by_id = {reference.id: reference for reference in hydrated}
+
+        candidates = []
+        for rank, cid in enumerate(ordered_ids, start=1):
+            routes: list[CandidateElasticsearchRoute | CandidateIdentifierRoute] = []
+            if cid in es_scores:
+                routes.append(
+                    CandidateElasticsearchRoute(
+                        policy=CURRENT_FUZZY_RETRIEVAL_POLICY,
+                        rank=es_ranks[cid],
+                        score=es_scores[cid],
+                    )
+                )
+            if cid in identifier_matches:
+                routes.append(
+                    CandidateIdentifierRoute(
+                        matched_identifiers=list(identifier_matches[cid].values())
+                    )
+                )
+            candidates.append(
+                Candidate(
+                    reference_id=cid,
+                    rank=rank,
+                    routes=routes,
+                    reference=self._project_candidate_reference(hydrated_by_id[cid])
+                    if request.hydrate and cid in hydrated_by_id
+                    else None,
+                )
+            )
+
+        es_returned = len(es_result.hits)
+        return CandidateSelectionResult(
+            index_version=index_version,
+            k_requested=k,
+            include_identifier_matches=request.include_identifier_matches,
+            input_searchability=InputSearchability(searchable=True, reason="ok"),
+            diagnostics=CandidateSelectionDiagnostics(
+                es_took_ms=es_result.took_ms,
+                es_total_hits=es_result.total.value,
+                es_returned=es_returned,
+                identifier_returned=len(identifier_matches),
+                candidate_count=len(ordered_ids),
+                truncated=es_result.total.value > es_returned,
+                kth_es_score=es_result.hits[k - 1].score if es_returned >= k else None,
+                lowest_es_score=es_result.hits[-1].score if es_result.hits else None,
+            ),
+            candidates=candidates,
+        )
+
+    async def _resolve_candidate_selection_input(
+        self, input_: CandidateSelectionInput
+    ) -> tuple[CandidateCanonicalSearchFields, UUID | None, list[IdentifierLookup]]:
+        """Resolve request input into search fields, a self-id, and id lookups."""
+        if input_.reference_id is not None:
+            reference = await self.sql_uow.references.get_by_pk(
+                input_.reference_id, preload=["enhancements", "identifiers"]
+            )
+            search_fields = (
+                ReferenceSearchFieldsProjection.get_canonical_candidate_search_fields(
+                    reference
+                )
+            )
+            lookups = [
+                IdentifierLookup.from_specific(linked.identifier)
+                for linked in (reference.identifiers or [])
+                if linked.identifier.identifier_type in _UNIONABLE_IDENTIFIER_TYPES
+            ]
+            return search_fields, reference.id, lookups
+
+        search_fields = CandidateCanonicalSearchFields(
+            title=input_.title,
+            authors=input_.authors,
+            publication_year=input_.publication_year,
+        )
+        lookups = [
+            self._identifier_lookup_from_candidate(identifier)
+            for identifier in input_.identifiers
+            if identifier.identifier_type in _UNIONABLE_IDENTIFIER_TYPES
+        ]
+        return search_fields, None, lookups
+
+    @staticmethod
+    def _identifier_lookup_from_candidate(
+        identifier: CandidateIdentifier,
+    ) -> IdentifierLookup:
+        """Normalise an input identifier into a lookup, canonicalising its value."""
+        try:
+            specific = ExternalIdentifierAdapter.validate_python(
+                identifier.model_dump()
+            )
+        except ValueError as exc:
+            msg = f"Invalid identifier for candidate selection: {identifier.identifier}"
+            raise DeduplicationValueError(msg) from exc
+        return IdentifierLookup.from_specific(specific)
+
+    async def _union_identifier_matches(
+        self,
+        lookups: list[IdentifierLookup],
+        *,
+        self_id: UUID | None,
+    ) -> dict[UUID, dict[tuple, CandidateIdentifier]]:
+        """Exact-match identifiers in Postgres, resolved to canonical candidates."""
+        matched_references = await self.sql_uow.references.find_with_identifiers(
+            lookups,
+            preload=["identifiers", "duplicate_decision"],
+            match="any",
+        )
+        query_keys = {(lookup.identifier_type, lookup.identifier) for lookup in lookups}
+        matches: dict[UUID, dict[tuple, CandidateIdentifier]] = {}
+        for reference in matched_references:
+            if reference.id == self_id:
+                continue
+            # A match on a duplicate resolves to its canonical, which may be a
+            # different, older reference outside the queried set.
+            if reference.is_canonical_like:
+                canonical_id = reference.id
+            elif (
+                reference.duplicate_decision
+                and reference.duplicate_decision.canonical_reference_id
+            ):
+                canonical_id = reference.duplicate_decision.canonical_reference_id
+            else:
+                continue
+            if canonical_id == self_id:
+                continue
+            bucket = matches.setdefault(canonical_id, {})
+            for linked in reference.identifiers or []:
+                key = (
+                    linked.identifier.identifier_type,
+                    str(linked.identifier.identifier),
+                )
+                if key in query_keys:
+                    bucket[key] = CandidateIdentifier(
+                        identifier_type=linked.identifier.identifier_type,
+                        identifier=str(linked.identifier.identifier),
+                        other_identifier_name=getattr(
+                            linked.identifier, "other_identifier_name", None
+                        ),
+                    )
+        return matches
+
+    @staticmethod
+    def _project_candidate_reference(
+        reference: Reference,
+    ) -> CandidateReferenceProjection:
+        """Project a hydrated reference into candidate bibliographic fields."""
+        fields = ReferenceSearchFieldsProjection.get_from_reference(reference)
+        return CandidateReferenceProjection(
+            title=fields.title,
+            authors=fields.authors,
+            publication_year=fields.publication_year,
+            identifiers=[
+                CandidateIdentifier(
+                    identifier_type=linked.identifier.identifier_type,
+                    identifier=str(linked.identifier.identifier),
+                    other_identifier_name=getattr(
+                        linked.identifier, "other_identifier_name", None
+                    ),
+                )
+                for linked in (reference.identifiers or [])
+            ],
+        )
 
     @sql_unit_of_work
     async def add_identifier(

--- a/app/domain/references/service.py
+++ b/app/domain/references/service.py
@@ -614,6 +614,9 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
                 scoring_config=settings.dedup_scoring,
                 k=k,
                 reference_id=self_id,
+                # The evaluation endpoint reports the exact total; the nomination
+                # path does not, so only this caller opts into the full count.
+                track_total_hits=True,
             )
 
         es_hits = es_result.hits if es_result else []

--- a/app/domain/references/service.py
+++ b/app/domain/references/service.py
@@ -13,7 +13,6 @@ from app.core.config import (
     get_settings,
 )
 from app.core.exceptions import (
-    DeduplicationValueError,
     DuplicateEnhancementError,
     FullTextIngestionError,
     InvalidParentEnhancementError,
@@ -24,15 +23,6 @@ from app.core.telemetry.attributes import Attributes, trace_attribute
 from app.core.telemetry.logger import get_logger
 from app.core.telemetry.taskiq import queue_task_with_trace
 from app.domain.references.models.models import (
-    CURRENT_FUZZY_RETRIEVAL_POLICY,
-    Candidate,
-    CandidateCanonicalSearchFields,
-    CandidateElasticsearchRoute,
-    CandidateIdentifier,
-    CandidateIdentifierRoute,
-    CandidateReferenceProjection,
-    CandidateSelectionDiagnostics,
-    CandidateSelectionInput,
     CandidateSelectionRequest,
     CandidateSelectionResult,
     CrossFacetCell,
@@ -43,11 +33,8 @@ from app.domain.references.models.models import (
     EnhancementType,
     ExportFormat,
     ExternalIdentifier,
-    ExternalIdentifierAdapter,
-    ExternalIdentifierType,
     FacetType,
     IdentifierLookup,
-    InputSearchability,
     LinkedExternalIdentifier,
     PendingEnhancement,
     PendingEnhancementStatus,
@@ -63,7 +50,6 @@ from app.domain.references.models.models import (
 from app.domain.references.models.projections import (
     DeduplicatedReferenceProjection,
     ReferenceRisProjection,
-    ReferenceSearchFieldsProjection,
 )
 from app.domain.references.models.validators import ReferenceCreateResult
 from app.domain.references.repository import (
@@ -110,32 +96,6 @@ from app.utils.time_and_date import apply_positive_timedelta
 logger = get_logger(__name__)
 settings = get_settings()
 tracer = get_tracer(__name__)
-
-# ES does not index identifiers, so exact-identifier candidates come from Postgres.
-_UNIONABLE_IDENTIFIER_TYPES = frozenset(
-    {
-        ExternalIdentifierType.DOI,
-        ExternalIdentifierType.PM_ID,
-        ExternalIdentifierType.OPEN_ALEX,
-    }
-)
-
-
-def _unsearchable_reason(search_fields: CandidateCanonicalSearchFields) -> str:
-    """Explain which Elasticsearch search fields are absent."""
-    missing = [
-        name
-        for name, value in (
-            ("title", search_fields.title),
-            ("authors", search_fields.authors),
-            ("publication_year", search_fields.publication_year),
-        )
-        if not value
-    ]
-    return (
-        f"Not searchable via Elasticsearch (missing: {', '.join(missing)}); "
-        "exact identifier matches, if any, are still returned."
-    )
 
 
 class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
@@ -585,216 +545,7 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
         identifier matches from Postgres, returning route provenance and retrieval
         diagnostics. It writes no duplicate-decision or candidate state.
         """
-        k = request.k or settings.dedup_scoring.candidate_k
-
-        (
-            search_fields,
-            self_id,
-            identifier_lookups,
-        ) = await self._resolve_candidate_selection_input(request.input)
-
-        # Exact identifier matching does not depend on bibliographic searchability;
-        # it is the route for records that fail the ES searchability gate, so it runs
-        # regardless of it.
-        identifier_matches: dict[UUID, dict[tuple, CandidateIdentifier]] = {}
-        if request.include_identifier_matches and identifier_lookups:
-            identifier_matches = await self._union_identifier_matches(
-                identifier_lookups, self_id=self_id
-            )
-
-        # The ES candidate query and its index-version stamp are only meaningful for
-        # searchable inputs.
-        searchable = search_fields.is_searchable
-        es_result = None
-        index_version = None
-        if searchable:
-            index_version = await self.es_uow.references.get_current_index_name()
-            es_result = await self.es_uow.references.search_for_candidate_canonicals(
-                search_fields,
-                scoring_config=settings.dedup_scoring,
-                k=k,
-                reference_id=self_id,
-                # The evaluation endpoint reports the exact total; the nomination
-                # path does not, so only this caller opts into the full count.
-                track_total_hits=True,
-            )
-
-        es_hits = es_result.hits if es_result else []
-        es_scores = {hit.id: hit.score for hit in es_hits}
-        es_ranks = {hit.id: rank for rank, hit in enumerate(es_hits, start=1)}
-
-        # Identifier-only matches rank ahead of ES-scored matches for evaluator
-        # visibility; everything carrying an ES score follows in score order.
-        identifier_only_ids = [
-            cid for cid in identifier_matches if cid not in es_scores
-        ]
-        ordered_ids = identifier_only_ids + [hit.id for hit in es_hits]
-
-        hydrated_by_id: dict[UUID, Reference] = {}
-        if request.hydrate and ordered_ids:
-            hydrated = await self.sql_uow.references.get_hydrated(
-                ordered_ids, enhancement_types=[EnhancementType.BIBLIOGRAPHIC]
-            )
-            hydrated_by_id = {reference.id: reference for reference in hydrated}
-
-        candidates = []
-        for rank, cid in enumerate(ordered_ids, start=1):
-            routes: list[CandidateElasticsearchRoute | CandidateIdentifierRoute] = []
-            if cid in es_scores:
-                routes.append(
-                    CandidateElasticsearchRoute(
-                        policy=CURRENT_FUZZY_RETRIEVAL_POLICY,
-                        rank=es_ranks[cid],
-                        score=es_scores[cid],
-                    )
-                )
-            if cid in identifier_matches:
-                routes.append(
-                    CandidateIdentifierRoute(
-                        matched_identifiers=list(identifier_matches[cid].values())
-                    )
-                )
-            candidates.append(
-                Candidate(
-                    reference_id=cid,
-                    rank=rank,
-                    routes=routes,
-                    reference=self._project_candidate_reference(hydrated_by_id[cid])
-                    if request.hydrate and cid in hydrated_by_id
-                    else None,
-                )
-            )
-
-        es_returned = len(es_hits)
-        return CandidateSelectionResult(
-            index_version=index_version,
-            k_requested=k,
-            include_identifier_matches=request.include_identifier_matches,
-            input_searchability=InputSearchability(
-                searchable=searchable,
-                reason="ok" if searchable else _unsearchable_reason(search_fields),
-            ),
-            diagnostics=CandidateSelectionDiagnostics(
-                es_took_ms=es_result.took_ms if es_result else None,
-                es_total_hits=es_result.total.value if es_result else None,
-                es_returned=es_returned,
-                identifier_returned=len(identifier_matches),
-                candidate_count=len(ordered_ids),
-                truncated=(es_result.total.value > es_returned) if es_result else False,
-                kth_es_score=es_hits[k - 1].score if es_returned >= k else None,
-                lowest_es_score=es_hits[-1].score if es_hits else None,
-            ),
-            candidates=candidates,
-        )
-
-    async def _resolve_candidate_selection_input(
-        self, input_: CandidateSelectionInput
-    ) -> tuple[CandidateCanonicalSearchFields, UUID | None, list[IdentifierLookup]]:
-        """Resolve request input into search fields, a self-id, and id lookups."""
-        if input_.reference_id is not None:
-            reference = await self.sql_uow.references.get_by_pk(
-                input_.reference_id, preload=["enhancements", "identifiers"]
-            )
-            search_fields = (
-                ReferenceSearchFieldsProjection.get_canonical_candidate_search_fields(
-                    reference
-                )
-            )
-            lookups = [
-                IdentifierLookup.from_specific(linked.identifier)
-                for linked in (reference.identifiers or [])
-                if linked.identifier.identifier_type in _UNIONABLE_IDENTIFIER_TYPES
-            ]
-            return search_fields, reference.id, lookups
-
-        search_fields = CandidateCanonicalSearchFields(
-            title=input_.title,
-            authors=input_.authors,
-            publication_year=input_.publication_year,
-        )
-        lookups = [
-            self._identifier_lookup_from_candidate(identifier)
-            for identifier in input_.identifiers
-            if identifier.identifier_type in _UNIONABLE_IDENTIFIER_TYPES
-        ]
-        return search_fields, None, lookups
-
-    @staticmethod
-    def _identifier_lookup_from_candidate(
-        identifier: CandidateIdentifier,
-    ) -> IdentifierLookup:
-        """Normalise an input identifier into a lookup, canonicalising its value."""
-        try:
-            specific = ExternalIdentifierAdapter.validate_python(
-                identifier.model_dump()
-            )
-        except ValueError as exc:
-            msg = f"Invalid identifier for candidate selection: {identifier.identifier}"
-            raise DeduplicationValueError(msg) from exc
-        return IdentifierLookup.from_specific(specific)
-
-    async def _union_identifier_matches(
-        self,
-        lookups: list[IdentifierLookup],
-        *,
-        self_id: UUID | None,
-    ) -> dict[UUID, dict[tuple, CandidateIdentifier]]:
-        """Exact-match identifiers in Postgres, resolved to canonical candidates."""
-        matched_references = await self.sql_uow.references.find_with_identifiers(
-            lookups,
-            preload=["identifiers", "duplicate_decision"],
-            match="any",
-        )
-        query_keys = {(lookup.identifier_type, lookup.identifier) for lookup in lookups}
-        matches: dict[UUID, dict[tuple, CandidateIdentifier]] = {}
-        for reference in matched_references:
-            if reference.id == self_id:
-                continue
-            # Unlike the ES query, this read-only path does not restrict to
-            # CANONICAL-at-rest references: that filter guards a nomination write
-            # race we don't have, so an exact identifier match is surfaced whatever
-            # its dedup state. A match on a duplicate resolves to its canonical,
-            # which may be a different, older reference outside the queried set.
-            if reference.is_canonical_like:
-                canonical_id = reference.id
-            elif (
-                reference.duplicate_decision
-                and reference.duplicate_decision.canonical_reference_id
-            ):
-                canonical_id = reference.duplicate_decision.canonical_reference_id
-            else:
-                msg = (
-                    "Identifier match is a determined duplicate without a canonical "
-                    "reference id. This should not happen."
-                )
-                raise RuntimeError(msg)
-            if canonical_id == self_id:
-                continue
-            bucket = matches.setdefault(canonical_id, {})
-            for linked in reference.identifiers or []:
-                key = (
-                    linked.identifier.identifier_type,
-                    str(linked.identifier.identifier),
-                )
-                if key in query_keys:
-                    bucket[key] = CandidateIdentifier.from_specific(linked.identifier)
-        return matches
-
-    @staticmethod
-    def _project_candidate_reference(
-        reference: Reference,
-    ) -> CandidateReferenceProjection:
-        """Project a hydrated reference into candidate bibliographic fields."""
-        fields = ReferenceSearchFieldsProjection.get_from_reference(reference)
-        return CandidateReferenceProjection(
-            title=fields.title,
-            authors=fields.authors,
-            publication_year=fields.publication_year,
-            identifiers=[
-                CandidateIdentifier.from_specific(linked.identifier)
-                for linked in (reference.identifiers or [])
-            ],
-        )
+        return await self._deduplication_service.get_deduplication_candidates(request)
 
     @sql_unit_of_work
     async def add_identifier(

--- a/app/domain/references/services/deduplication_service.py
+++ b/app/domain/references/services/deduplication_service.py
@@ -9,14 +9,28 @@ from app.core.config import Environment, get_settings
 from app.core.exceptions import DeduplicationValueError
 from app.core.telemetry.logger import get_logger
 from app.domain.references.models.models import (
+    CURRENT_FUZZY_RETRIEVAL_POLICY,
+    Candidate,
+    CandidateCanonicalSearchFields,
+    CandidateElasticsearchRoute,
+    CandidateIdentifier,
+    CandidateIdentifierRoute,
+    CandidateSelectionDiagnostics,
+    CandidateSelectionInput,
+    CandidateSelectionRequest,
+    CandidateSelectionResult,
     DuplicateDetermination,
+    EnhancementType,
     ExternalIdentifierType,
     GenericExternalIdentifier,
+    IdentifierLookup,
+    InputSearchability,
     Reference,
     ReferenceDuplicateDecision,
     ReferenceDuplicateDeterminationResult,
 )
 from app.domain.references.models.projections import (
+    CandidateReferenceProjection,
     ReferenceSearchFieldsProjection,
 )
 from app.domain.references.services.anti_corruption_service import (
@@ -30,6 +44,32 @@ logger = get_logger(__name__)
 settings = get_settings()
 tracer = trace.get_tracer(__name__)
 
+# ES does not index identifiers, so exact-identifier candidates come from Postgres.
+_UNIONABLE_IDENTIFIER_TYPES = frozenset(
+    {
+        ExternalIdentifierType.DOI,
+        ExternalIdentifierType.PM_ID,
+        ExternalIdentifierType.OPEN_ALEX,
+    }
+)
+
+
+def _unsearchable_reason(search_fields: CandidateCanonicalSearchFields) -> str:
+    """Explain which Elasticsearch search fields are absent."""
+    missing = [
+        name
+        for name, value in (
+            ("title", search_fields.title),
+            ("authors", search_fields.authors),
+            ("publication_year", search_fields.publication_year),
+        )
+        if not value
+    ]
+    return (
+        f"Not searchable via Elasticsearch (missing: {', '.join(missing)}); "
+        "exact identifier matches, if any, are still returned."
+    )
+
 
 class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
     """Service for managing reference duplicate detection."""
@@ -42,6 +82,211 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
     ) -> None:
         """Initialize the service with a unit of work."""
         super().__init__(anti_corruption_service, sql_uow, es_uow)
+
+    async def get_deduplication_candidates(
+        self, request: CandidateSelectionRequest
+    ) -> CandidateSelectionResult:
+        """
+        Retrieve ranked candidate canonicals for a reference, without persisting.
+
+        Read-only evaluation surface for deduplication candidate retrieval: it runs
+        the shared Elasticsearch candidate query and, optionally, unions exact
+        identifier matches from Postgres, returning route provenance and retrieval
+        diagnostics. It writes no duplicate-decision or candidate state.
+        """
+        k = request.k or settings.dedup_scoring.candidate_k
+
+        (
+            search_fields,
+            self_id,
+            identifier_lookups,
+        ) = await self._resolve_candidate_selection_input(request.input)
+
+        # Exact identifier matching does not depend on bibliographic searchability;
+        # it is the route for records that fail the ES searchability gate, so it runs
+        # regardless of it.
+        identifier_matches: dict[UUID, dict[tuple, CandidateIdentifier]] = {}
+        if request.include_identifier_matches and identifier_lookups:
+            identifier_matches = await self._union_identifier_matches(
+                identifier_lookups, self_id=self_id
+            )
+
+        # The ES candidate query and its index-version stamp are only meaningful for
+        # searchable inputs.
+        searchable = search_fields.is_searchable
+        es_result = None
+        index_version = None
+        if searchable:
+            index_version = await self.es_uow.references.get_current_index_name()
+            es_result = await self.es_uow.references.search_for_candidate_canonicals(
+                search_fields,
+                scoring_config=settings.dedup_scoring,
+                k=k,
+                reference_id=self_id,
+                # The evaluation endpoint reports the exact total; the nomination
+                # path does not, so only this caller opts into the full count.
+                track_total_hits=True,
+            )
+
+        es_hits = es_result.hits if es_result else []
+        es_scores = {hit.id: hit.score for hit in es_hits}
+        es_ranks = {hit.id: rank for rank, hit in enumerate(es_hits, start=1)}
+
+        # Identifier-only matches rank ahead of ES-scored matches for evaluator
+        # visibility; everything carrying an ES score follows in score order.
+        identifier_only_ids = [
+            cid for cid in identifier_matches if cid not in es_scores
+        ]
+        ordered_ids = identifier_only_ids + [hit.id for hit in es_hits]
+
+        hydrated_by_id: dict[UUID, Reference] = {}
+        if request.hydrate and ordered_ids:
+            hydrated = await self.sql_uow.references.get_hydrated(
+                ordered_ids, enhancement_types=[EnhancementType.BIBLIOGRAPHIC]
+            )
+            hydrated_by_id = {reference.id: reference for reference in hydrated}
+
+        candidates = []
+        for rank, cid in enumerate(ordered_ids, start=1):
+            routes: list[CandidateElasticsearchRoute | CandidateIdentifierRoute] = []
+            if cid in es_scores:
+                routes.append(
+                    CandidateElasticsearchRoute(
+                        policy=CURRENT_FUZZY_RETRIEVAL_POLICY,
+                        rank=es_ranks[cid],
+                        score=es_scores[cid],
+                    )
+                )
+            if cid in identifier_matches:
+                routes.append(
+                    CandidateIdentifierRoute(
+                        matched_identifiers=list(identifier_matches[cid].values())
+                    )
+                )
+            candidates.append(
+                Candidate(
+                    reference_id=cid,
+                    rank=rank,
+                    routes=routes,
+                    reference=CandidateReferenceProjection.get_from_reference(
+                        hydrated_by_id[cid]
+                    )
+                    if request.hydrate and cid in hydrated_by_id
+                    else None,
+                )
+            )
+
+        es_returned = len(es_hits)
+        return CandidateSelectionResult(
+            index_version=index_version,
+            k_requested=k,
+            include_identifier_matches=request.include_identifier_matches,
+            input_searchability=InputSearchability(
+                searchable=searchable,
+                reason="ok" if searchable else _unsearchable_reason(search_fields),
+            ),
+            diagnostics=CandidateSelectionDiagnostics(
+                es_took_ms=es_result.took_ms if es_result else None,
+                es_total_hits=es_result.total.value if es_result else None,
+                es_returned=es_returned,
+                identifier_returned=len(identifier_matches),
+                candidate_count=len(ordered_ids),
+                truncated=(es_result.total.value > es_returned) if es_result else False,
+                kth_es_score=es_hits[k - 1].score if es_returned >= k else None,
+                lowest_es_score=es_hits[-1].score if es_hits else None,
+            ),
+            candidates=candidates,
+        )
+
+    async def _resolve_candidate_selection_input(
+        self, input_: CandidateSelectionInput
+    ) -> tuple[CandidateCanonicalSearchFields, UUID | None, list[IdentifierLookup]]:
+        """Resolve request input into search fields, a self-id, and id lookups."""
+        if input_.reference_id is not None:
+            reference = await self.sql_uow.references.get_by_pk(
+                input_.reference_id, preload=["enhancements", "identifiers"]
+            )
+            search_fields = (
+                ReferenceSearchFieldsProjection.get_canonical_candidate_search_fields(
+                    reference
+                )
+            )
+            lookups = [
+                IdentifierLookup.from_specific(linked.identifier)
+                for linked in (reference.identifiers or [])
+                if linked.identifier.identifier_type in _UNIONABLE_IDENTIFIER_TYPES
+            ]
+            return search_fields, reference.id, lookups
+
+        search_fields = CandidateCanonicalSearchFields(
+            title=input_.title,
+            authors=input_.authors,
+            publication_year=input_.publication_year,
+        )
+        lookups = [
+            self._identifier_lookup_from_candidate(identifier)
+            for identifier in input_.identifiers
+            if identifier.identifier_type in _UNIONABLE_IDENTIFIER_TYPES
+        ]
+        return search_fields, None, lookups
+
+    @staticmethod
+    def _identifier_lookup_from_candidate(
+        identifier: CandidateIdentifier,
+    ) -> IdentifierLookup:
+        """Normalise an input identifier into a lookup, canonicalising its value."""
+        try:
+            return IdentifierLookup.from_generic(identifier)
+        except ValueError as exc:
+            msg = f"Invalid identifier for candidate selection: {identifier.identifier}"
+            raise DeduplicationValueError(msg) from exc
+
+    async def _union_identifier_matches(
+        self,
+        lookups: list[IdentifierLookup],
+        *,
+        self_id: UUID | None,
+    ) -> dict[UUID, dict[tuple, CandidateIdentifier]]:
+        """Exact-match identifiers in Postgres, resolved to canonical candidates."""
+        matched_references = await self.sql_uow.references.find_with_identifiers(
+            lookups,
+            preload=["identifiers", "duplicate_decision"],
+            match="any",
+        )
+        query_keys = {(lookup.identifier_type, lookup.identifier) for lookup in lookups}
+        matches: dict[UUID, dict[tuple, CandidateIdentifier]] = {}
+        for reference in matched_references:
+            if reference.id == self_id:
+                continue
+            # Unlike the ES query, this read-only path does not restrict to
+            # CANONICAL-at-rest references: that filter guards a nomination write
+            # race we don't have, so an exact identifier match is surfaced whatever
+            # its dedup state. A match on a duplicate resolves to its canonical,
+            # which may be a different, older reference outside the queried set.
+            if reference.is_canonical_like:
+                canonical_id = reference.id
+            elif (
+                reference.duplicate_decision
+                and reference.duplicate_decision.canonical_reference_id
+            ):
+                canonical_id = reference.duplicate_decision.canonical_reference_id
+            else:
+                msg = (
+                    "Identifier match is a determined duplicate without a canonical "
+                    "reference id. This should not happen."
+                )
+                raise RuntimeError(msg)
+            if canonical_id == self_id:
+                continue
+            bucket = matches.setdefault(canonical_id, {})
+            for linked in reference.identifiers or []:
+                key = (
+                    linked.identifier.identifier_type,
+                    str(linked.identifier.identifier),
+                )
+                if key in query_keys:
+                    bucket[key] = CandidateIdentifier.from_specific(linked.identifier)
+        return matches
 
     async def find_exact_duplicate(self, reference: Reference) -> Reference | None:
         """

--- a/app/domain/references/services/deduplication_service.py
+++ b/app/domain/references/services/deduplication_service.py
@@ -194,13 +194,16 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
                 reference_duplicate_decision.id,
                 duplicate_determination=DuplicateDetermination.UNSEARCHABLE,
             )
+        # The candidate depth here preserves this path's historical behaviour; the
+        # production K is chosen by the recall@K evaluation, not this path.
         search_result = await self.es_uow.references.search_for_candidate_canonicals(
             search_fields,
             reference_id=reference.id,
             scoring_config=settings.dedup_scoring,
+            k=10,
         )
 
-        if not search_result:
+        if not search_result.hits:
             reference_duplicate_decision = (
                 await self.sql_uow.reference_duplicate_decisions.update_by_pk(
                     reference_duplicate_decision.id,
@@ -217,7 +220,9 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
             reference_duplicate_decision = (
                 await self.sql_uow.reference_duplicate_decisions.update_by_pk(
                     reference_duplicate_decision.id,
-                    candidate_canonical_ids=[result.id for result in search_result],
+                    candidate_canonical_ids=[
+                        result.id for result in search_result.hits
+                    ],
                     duplicate_determination=DuplicateDetermination.NOMINATED,
                 )
             )

--- a/app/persistence/es/persistence.py
+++ b/app/persistence/es/persistence.py
@@ -117,6 +117,21 @@ class ESSearchResult(BaseModel):
     )
 
 
+class CandidateCanonicalSearchResult(BaseModel):
+    """Candidate-canonical search results with retrieval diagnostics."""
+
+    hits: list[ESScoreResult] = Field(
+        default_factory=list,
+        description="Candidate references, ranked by score descending.",
+    )
+    total: ESSearchTotal = Field(
+        description="Total references matching the query (see track_total_hits).",
+    )
+    took_ms: int = Field(
+        description="Elasticsearch-reported query duration in milliseconds.",
+    )
+
+
 class ESFacetBucket(BaseModel):
     """A single bucket from a terms aggregation."""
 

--- a/tests/e2e/imports/test_candidate_selection.py
+++ b/tests/e2e/imports/test_candidate_selection.py
@@ -222,6 +222,21 @@ async def test_candidates_unsearchable_returns_empty_200(
     assert body["candidates"] == []
 
 
+async def test_candidates_invalid_identifier_returns_422(
+    destiny_client_v1: httpx.AsyncClient,
+):
+    """A malformed identifier value fails normalisation with a 422."""
+    response = await destiny_client_v1.post(
+        CANDIDATES_URL,
+        json={
+            "input": {
+                "identifiers": [{"identifier_type": "doi", "identifier": "not-a-doi"}]
+            }
+        },
+    )
+    assert response.status_code == 422
+
+
 async def test_candidates_rejects_both_and_neither_inputs(
     destiny_client_v1: httpx.AsyncClient,
 ):

--- a/tests/e2e/imports/test_candidate_selection.py
+++ b/tests/e2e/imports/test_candidate_selection.py
@@ -1,0 +1,196 @@
+"""End-to-end tests for the candidate-selection API."""
+
+from collections.abc import Callable
+from contextlib import _AsyncGeneratorContextManager
+
+import httpx
+import pytest
+from destiny_sdk.enhancements import Authorship
+from destiny_sdk.identifiers import DOIIdentifier
+from destiny_sdk.references import ReferenceFileInput
+from elasticsearch import AsyncElasticsearch
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domain.references.models.models import Reference, Visibility
+from tests.e2e.utils import import_references, refresh_reference_index
+from tests.factories import (
+    BibliographicMetadataEnhancementFactory,
+    DOIIdentifierFactory,
+    EnhancementFactory,
+    LinkedExternalIdentifierFactory,
+    ReferenceFactory,
+)
+
+CANDIDATES_URL = "references/deduplication/candidates/"
+
+
+@pytest.fixture
+def doi() -> DOIIdentifier:
+    """Build a DOI reused across the reference and the request payload."""
+    return DOIIdentifierFactory.build()
+
+
+@pytest.fixture
+def canonical_reference(doi: DOIIdentifier) -> Reference:
+    """Build a searchable reference with a bibliographic enhancement and a DOI."""
+    return ReferenceFactory.build(
+        enhancements=[
+            EnhancementFactory.build(
+                content=BibliographicMetadataEnhancementFactory.build(
+                    title="A Distinctive Candidate Selection Study",
+                    authorship=[
+                        Authorship(display_name="Ada Lovelace", position="first"),
+                        Authorship(display_name="Alan Turing", position="last"),
+                    ],
+                    publication_year=2024,
+                )
+            )
+        ],
+        identifiers=[LinkedExternalIdentifierFactory.build(identifier=doi)],
+        visibility=Visibility.PUBLIC,
+    )
+
+
+async def _count_duplicate_decisions(pg_session: AsyncSession) -> int:
+    result = await pg_session.execute(
+        text("SELECT COUNT(*) FROM reference_duplicate_decision;")
+    )
+    return result.scalar_one()
+
+
+async def test_candidates_inline_unions_es_and_identifier_without_persisting(  # noqa: PLR0913
+    destiny_client_v1: httpx.AsyncClient,
+    pg_session: AsyncSession,
+    es_client: AsyncElasticsearch,
+    get_import_file_signed_url: Callable[
+        [list[ReferenceFileInput]], _AsyncGeneratorContextManager[str]
+    ],
+    canonical_reference: Reference,
+    doi: DOIIdentifier,
+):
+    """Inline input returns the seeded canonical via both ES and identifier routes."""
+    reference_id = (
+        await import_references(
+            destiny_client_v1,
+            pg_session,
+            es_client,
+            [canonical_reference],
+            get_import_file_signed_url,
+        )
+    ).pop()
+    await refresh_reference_index(es_client)
+
+    decisions_before = await _count_duplicate_decisions(pg_session)
+
+    response = await destiny_client_v1.post(
+        CANDIDATES_URL,
+        json={
+            "input": {
+                "title": "A Distinctive Candidate Selection Study",
+                "authors": ["Ada Lovelace", "Alan Turing"],
+                "publication_year": 2024,
+                "identifiers": [
+                    {"identifier_type": "doi", "identifier": str(doi.identifier)}
+                ],
+            },
+            "k": 50,
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["retrieval_policy"] == "current_fuzzy_v1"
+    assert body["index_version"].startswith("reference_v")
+    assert body["k_requested"] == 50
+    assert body["input_searchability"]["searchable"] is True
+
+    candidate = next(
+        c for c in body["candidates"] if c["reference_id"] == str(reference_id)
+    )
+    route_types = {route["type"] for route in candidate["routes"]}
+    assert route_types == {"elasticsearch", "identifier"}
+    identifier_route = next(r for r in candidate["routes"] if r["type"] == "identifier")
+    assert identifier_route["matched_identifiers"][0]["identifier"] == str(
+        doi.identifier
+    )
+    assert candidate["reference"]["title"] == "A Distinctive Candidate Selection Study"
+    assert candidate["reference"]["publication_year"] == 2024
+
+    assert body["diagnostics"]["es_returned"] >= 1
+    assert body["diagnostics"]["identifier_returned"] >= 1
+    assert body["diagnostics"]["candidate_count"] >= 1
+
+    # Read-only: the request must not create or change any duplicate-decision state.
+    assert await _count_duplicate_decisions(pg_session) == decisions_before
+
+
+async def test_candidates_by_reference_id_is_searchable_and_read_only(
+    destiny_client_v1: httpx.AsyncClient,
+    pg_session: AsyncSession,
+    es_client: AsyncElasticsearch,
+    get_import_file_signed_url: Callable[
+        [list[ReferenceFileInput]], _AsyncGeneratorContextManager[str]
+    ],
+    canonical_reference: Reference,
+):
+    """reference_id input projects the stored reference and writes no state."""
+    reference_id = (
+        await import_references(
+            destiny_client_v1,
+            pg_session,
+            es_client,
+            [canonical_reference],
+            get_import_file_signed_url,
+        )
+    ).pop()
+    await refresh_reference_index(es_client)
+
+    decisions_before = await _count_duplicate_decisions(pg_session)
+
+    response = await destiny_client_v1.post(
+        CANDIDATES_URL,
+        json={"input": {"reference_id": str(reference_id)}},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["input_searchability"]["searchable"] is True
+    assert body["k_requested"] == 100  # configured default
+    # The input reference excludes itself from its own candidates.
+    assert all(c["reference_id"] != str(reference_id) for c in body["candidates"])
+    assert await _count_duplicate_decisions(pg_session) == decisions_before
+
+
+async def test_candidates_unsearchable_returns_empty_200(
+    destiny_client_v1: httpx.AsyncClient,
+):
+    """A record without enough bibliographic signal returns empty candidates."""
+    response = await destiny_client_v1.post(
+        CANDIDATES_URL,
+        json={"input": {"title": "Lonely title, no authors or year"}},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["input_searchability"]["searchable"] is False
+    assert body["candidates"] == []
+
+
+async def test_candidates_rejects_both_and_neither_inputs(
+    destiny_client_v1: httpx.AsyncClient,
+):
+    """The input must be exactly one of reference_id or inline fields."""
+    neither = await destiny_client_v1.post(CANDIDATES_URL, json={"input": {}})
+    assert neither.status_code == 422
+
+    both = await destiny_client_v1.post(
+        CANDIDATES_URL,
+        json={
+            "input": {
+                "reference_id": str(ReferenceFactory.build().id),
+                "title": "A title",
+            }
+        },
+    )
+    assert both.status_code == 422

--- a/tests/e2e/imports/test_candidate_selection.py
+++ b/tests/e2e/imports/test_candidate_selection.py
@@ -9,10 +9,11 @@ from destiny_sdk.enhancements import Authorship
 from destiny_sdk.identifiers import DOIIdentifier
 from destiny_sdk.references import ReferenceFileInput
 from elasticsearch import AsyncElasticsearch
-from sqlalchemy import text
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.domain.references.models.models import Reference, Visibility
+from app.domain.references.models.sql import ReferenceDuplicateDecision
 from tests.e2e.utils import import_references, refresh_reference_index
 from tests.factories import (
     BibliographicMetadataEnhancementFactory,
@@ -54,7 +55,7 @@ def canonical_reference(doi: DOIIdentifier) -> Reference:
 
 async def _count_duplicate_decisions(pg_session: AsyncSession) -> int:
     result = await pg_session.execute(
-        text("SELECT COUNT(*) FROM reference_duplicate_decision;")
+        select(func.count()).select_from(ReferenceDuplicateDecision)
     )
     return result.scalar_one()
 

--- a/tests/e2e/imports/test_candidate_selection.py
+++ b/tests/e2e/imports/test_candidate_selection.py
@@ -162,6 +162,48 @@ async def test_candidates_by_reference_id_is_searchable_and_read_only(
     assert await _count_duplicate_decisions(pg_session) == decisions_before
 
 
+async def test_candidates_identifier_only_input_matches_despite_unsearchable(  # noqa: PLR0913
+    destiny_client_v1: httpx.AsyncClient,
+    pg_session: AsyncSession,
+    es_client: AsyncElasticsearch,
+    get_import_file_signed_url: Callable[
+        [list[ReferenceFileInput]], _AsyncGeneratorContextManager[str]
+    ],
+    canonical_reference: Reference,
+    doi: DOIIdentifier,
+):
+    """An identifier-only payload (no title/authors/year) still matches by DOI."""
+    reference_id = (
+        await import_references(
+            destiny_client_v1,
+            pg_session,
+            es_client,
+            [canonical_reference],
+            get_import_file_signed_url,
+        )
+    ).pop()
+    await refresh_reference_index(es_client)
+
+    response = await destiny_client_v1.post(
+        CANDIDATES_URL,
+        json={
+            "input": {
+                "identifiers": [
+                    {"identifier_type": "doi", "identifier": str(doi.identifier)}
+                ]
+            }
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["input_searchability"]["searchable"] is False
+    candidate = next(
+        c for c in body["candidates"] if c["reference_id"] == str(reference_id)
+    )
+    assert [route["type"] for route in candidate["routes"]] == ["identifier"]
+
+
 async def test_candidates_unsearchable_returns_empty_200(
     destiny_client_v1: httpx.AsyncClient,
 ):

--- a/tests/e2e/imports/test_candidate_selection.py
+++ b/tests/e2e/imports/test_candidate_selection.py
@@ -118,9 +118,11 @@ async def test_candidates_inline_unions_es_and_identifier_without_persisting(  #
     assert candidate["reference"]["title"] == "A Distinctive Candidate Selection Study"
     assert candidate["reference"]["publication_year"] == 2024
 
-    assert body["diagnostics"]["es_returned"] >= 1
-    assert body["diagnostics"]["identifier_returned"] >= 1
-    assert body["diagnostics"]["candidate_count"] >= 1
+    # Isolated per test: exactly the one imported reference, found by both routes
+    # and collapsed to a single candidate by the union.
+    assert body["diagnostics"]["es_returned"] == 1
+    assert body["diagnostics"]["identifier_returned"] == 1
+    assert body["diagnostics"]["candidate_count"] == 1
 
     # Read-only: the request must not create or change any duplicate-decision state.
     assert await _count_duplicate_decisions(pg_session) == decisions_before

--- a/tests/integration/test_es_references.py
+++ b/tests/integration/test_es_references.py
@@ -655,9 +655,12 @@ async def test_canonical_candidate_search(
         search_fields=matching_search_fields,
         reference_id=matching_ref1.id,
         scoring_config=DedupCandidateScoringConfig(),
+        k=100,
     )
 
-    assert {reference.id for reference in results} == {matching_ref2.id}
+    assert {hit.id for hit in results.hits} == {matching_ref2.id}
+    assert results.total.value == 1
+    assert results.took_ms >= 0
 
     non_matching_search_fields = (
         ReferenceSearchFieldsProjection.get_canonical_candidate_search_fields(
@@ -669,5 +672,6 @@ async def test_canonical_candidate_search(
         non_matching_search_fields,
         reference_id=non_matching_ref.id,
         scoring_config=DedupCandidateScoringConfig(),
+        k=100,
     )
-    assert not results
+    assert not results.hits

--- a/tests/unit/domain/references/deduplication/test_candidate_selection.py
+++ b/tests/unit/domain/references/deduplication/test_candidate_selection.py
@@ -337,6 +337,45 @@ async def test_hydrate_includes_reference_projection(build_service):
 
 
 @pytest.mark.asyncio
+async def test_identifier_only_input_matches_when_es_unsearchable(build_service):
+    """An identifier-only input still surfaces exact matches despite the gate."""
+    doi = DOIIdentifierFactory.build()
+    identifier_ref = ReferenceFactory.build(visibility="public")
+    identifier_ref = identifier_ref.model_copy(
+        update={
+            "identifiers": [
+                LinkedExternalIdentifierFactory.build(
+                    identifier=doi, reference_id=identifier_ref.id
+                )
+            ],
+            "duplicate_decision": None,
+        }
+    )
+    service, es_refs, _, _ = build_service(found_references=[identifier_ref])
+
+    result = await service.get_deduplication_candidates(
+        CandidateSelectionRequest(
+            input=CandidateSelectionInput(
+                identifiers=[
+                    CandidateIdentifier(
+                        identifier_type=ExternalIdentifierType.DOI,
+                        identifier=str(doi.identifier),
+                    )
+                ]
+            ),
+            hydrate=False,
+        )
+    )
+
+    # The ES gate is not met, but the identifier route still returns the match.
+    assert result.input_searchability.searchable is False
+    es_refs.search_for_candidate_canonicals.assert_not_awaited()
+    assert [c.reference_id for c in result.candidates] == [identifier_ref.id]
+    assert result.candidates[0].routes[0].type == "identifier"
+    assert result.diagnostics.identifier_returned == 1
+    assert result.diagnostics.es_total_hits is None
+
+
 async def test_unsearchable_input_returns_empty_200(build_service):
     service, es_refs, _, _ = build_service()
 

--- a/tests/unit/domain/references/deduplication/test_candidate_selection.py
+++ b/tests/unit/domain/references/deduplication/test_candidate_selection.py
@@ -1,0 +1,375 @@
+"""Unit tests for the candidate-selection API orchestration and models."""
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid7
+
+import pytest
+from destiny_sdk.enhancements import Authorship
+from pydantic import ValidationError
+
+from app.domain.references.models.models import (
+    CURRENT_FUZZY_RETRIEVAL_POLICY,
+    CandidateIdentifier,
+    CandidateSelectionInput,
+    CandidateSelectionRequest,
+    DuplicateDetermination,
+    ExternalIdentifierType,
+    Reference,
+    ReferenceDuplicateDecision,
+)
+from app.domain.references.service import ReferenceService
+from app.domain.references.services.anti_corruption_service import (
+    ReferenceAntiCorruptionService,
+)
+from app.persistence.es.persistence import (
+    CandidateCanonicalSearchResult,
+    ESScoreResult,
+    ESSearchTotal,
+)
+from tests.factories import (
+    BibliographicMetadataEnhancementFactory,
+    DOIIdentifierFactory,
+    EnhancementFactory,
+    LinkedExternalIdentifierFactory,
+    ReferenceFactory,
+)
+
+
+def _searchable_reference(**update: object) -> Reference:
+    """Build a reference with a searchable bibliographic enhancement."""
+    reference = ReferenceFactory.build(visibility="public")
+    return reference.model_copy(
+        update={
+            "enhancements": [
+                EnhancementFactory.build(
+                    reference_id=reference.id,
+                    content=BibliographicMetadataEnhancementFactory.build(
+                        authorship=[
+                            Authorship(display_name="John Doe", position="first")
+                        ],
+                        publication_year=2025,
+                        title="Maybe a duplicate reference, maybe not",
+                    ),
+                )
+            ],
+            **update,
+        }
+    )
+
+
+def _es_result(
+    *hits: ESScoreResult, total: int | None = None
+) -> CandidateCanonicalSearchResult:
+    return CandidateCanonicalSearchResult(
+        hits=list(hits),
+        total=ESSearchTotal(
+            value=total if total is not None else len(hits), relation="eq"
+        ),
+        took_ms=7,
+    )
+
+
+@pytest.fixture
+def anti_corruption_service():
+    return MagicMock(spec=ReferenceAntiCorruptionService)
+
+
+@pytest.fixture
+def build_service(fake_uow, anti_corruption_service):
+    """Build a ReferenceService with mocked ES/SQL reference repositories."""
+
+    def _build(
+        *,
+        es_result: CandidateCanonicalSearchResult | None = None,
+        found_references: list[Reference] | None = None,
+        hydrated: list[Reference] | None = None,
+        reference: Reference | None = None,
+        index_name: str | None = "reference_v3",
+    ) -> tuple[ReferenceService, MagicMock, MagicMock, MagicMock]:
+        es_refs = MagicMock()
+        es_refs.get_current_index_name = AsyncMock(return_value=index_name)
+        es_refs.search_for_candidate_canonicals = AsyncMock(
+            return_value=es_result if es_result is not None else _es_result()
+        )
+
+        sql_refs = MagicMock()
+        sql_refs.get_by_pk = AsyncMock(return_value=reference)
+        sql_refs.find_with_identifiers = AsyncMock(return_value=found_references or [])
+        sql_refs.get_hydrated = AsyncMock(return_value=hydrated or [])
+
+        decisions = MagicMock()
+        decisions.add = AsyncMock()
+        decisions.add_bulk = AsyncMock()
+        decisions.update_by_pk = AsyncMock()
+        decisions.merge = AsyncMock()
+
+        service = ReferenceService(
+            anti_corruption_service,
+            fake_uow(references=sql_refs, reference_duplicate_decisions=decisions),
+            fake_uow(references=es_refs),
+        )
+        return service, es_refs, sql_refs, decisions
+
+    return _build
+
+
+class TestCandidateSelectionInputValidation:
+    def test_rejects_neither(self):
+        with pytest.raises(ValidationError):
+            CandidateSelectionInput()
+
+    def test_rejects_both(self):
+        with pytest.raises(ValidationError):
+            CandidateSelectionInput(reference_id=uuid7(), title="A title")
+
+    def test_accepts_reference_id(self):
+        input_ = CandidateSelectionInput(reference_id=uuid7())
+        assert input_.reference_id is not None
+
+    def test_accepts_inline(self):
+        input_ = CandidateSelectionInput(
+            title="A title", authors=["Jane"], publication_year=2020
+        )
+        assert input_.title == "A title"
+
+    def test_k_bounds_enforced(self):
+        with pytest.raises(ValidationError):
+            CandidateSelectionRequest(
+                input=CandidateSelectionInput(reference_id=uuid7()), k=0
+            )
+        with pytest.raises(ValidationError):
+            CandidateSelectionRequest(
+                input=CandidateSelectionInput(reference_id=uuid7()), k=1001
+            )
+
+
+@pytest.mark.asyncio
+async def test_inline_input_returns_ranked_es_candidates(build_service):
+    id1, id2 = uuid7(), uuid7()
+    es_result = _es_result(
+        ESScoreResult(id=id1, score=9.0), ESScoreResult(id=id2, score=8.0)
+    )
+    service, es_refs, _, _ = build_service(es_result=es_result)
+
+    result = await service.get_deduplication_candidates(
+        CandidateSelectionRequest(
+            input=CandidateSelectionInput(
+                title="A study", authors=["Jane Doe"], publication_year=2025
+            ),
+            include_identifier_matches=False,
+            hydrate=False,
+        )
+    )
+
+    assert result.retrieval_policy == CURRENT_FUZZY_RETRIEVAL_POLICY
+    assert result.index_version == "reference_v3"
+    assert result.input_searchability.searchable is True
+    assert [c.reference_id for c in result.candidates] == [id1, id2]
+    assert [c.rank for c in result.candidates] == [1, 2]
+    first_route = result.candidates[0].routes[0]
+    assert first_route.type == "elasticsearch"
+    assert first_route.score == 9.0
+    assert result.candidates[0].reference is None
+    assert result.diagnostics.es_returned == 2
+    assert result.diagnostics.candidate_count == 2
+    assert result.diagnostics.identifier_returned == 0
+    assert result.diagnostics.lowest_es_score == 8.0
+
+
+@pytest.mark.asyncio
+async def test_reference_id_input_self_excludes_and_defaults_k(build_service):
+    reference = _searchable_reference()
+    hit = uuid7()
+    service, es_refs, sql_refs, _ = build_service(
+        reference=reference,
+        es_result=_es_result(ESScoreResult(id=hit, score=3.0)),
+    )
+
+    result = await service.get_deduplication_candidates(
+        CandidateSelectionRequest(
+            input=CandidateSelectionInput(reference_id=reference.id),
+            include_identifier_matches=False,
+            hydrate=False,
+        )
+    )
+
+    sql_refs.get_by_pk.assert_awaited_once()
+    _, kwargs = es_refs.search_for_candidate_canonicals.call_args
+    assert kwargs["reference_id"] == reference.id
+    assert kwargs["k"] == 100  # configured default
+    assert result.k_requested == 100
+    assert [c.reference_id for c in result.candidates] == [hit]
+
+
+@pytest.mark.asyncio
+async def test_k_override_passed_to_es(build_service):
+    service, es_refs, _, _ = build_service()
+
+    result = await service.get_deduplication_candidates(
+        CandidateSelectionRequest(
+            input=CandidateSelectionInput(
+                title="A study", authors=["Jane Doe"], publication_year=2025
+            ),
+            k=25,
+            include_identifier_matches=False,
+            hydrate=False,
+        )
+    )
+
+    _, kwargs = es_refs.search_for_candidate_canonicals.call_args
+    assert kwargs["k"] == 25
+    assert result.k_requested == 25
+
+
+@pytest.mark.asyncio
+async def test_identifier_only_match_ranks_ahead_of_es(build_service):
+    doi = DOIIdentifierFactory.build()
+    identifier_ref = ReferenceFactory.build(visibility="public")
+    identifier_ref = identifier_ref.model_copy(
+        update={
+            "identifiers": [
+                LinkedExternalIdentifierFactory.build(
+                    identifier=doi, reference_id=identifier_ref.id
+                )
+            ],
+            "duplicate_decision": None,  # canonical-like
+        }
+    )
+    es_id = uuid7()
+    service, _, sql_refs, _ = build_service(
+        es_result=_es_result(ESScoreResult(id=es_id, score=5.0)),
+        found_references=[identifier_ref],
+    )
+
+    result = await service.get_deduplication_candidates(
+        CandidateSelectionRequest(
+            input=CandidateSelectionInput(
+                title="A study",
+                authors=["Jane Doe"],
+                publication_year=2025,
+                identifiers=[
+                    CandidateIdentifier(
+                        identifier_type=ExternalIdentifierType.DOI,
+                        identifier=str(doi.identifier),
+                    )
+                ],
+            ),
+            hydrate=False,
+        )
+    )
+
+    # Identifier-only match first, then the ES-scored candidate.
+    assert [c.reference_id for c in result.candidates] == [identifier_ref.id, es_id]
+    assert result.candidates[0].rank == 1
+    id_route = result.candidates[0].routes[0]
+    assert id_route.type == "identifier"
+    assert id_route.matched_identifiers[0].identifier == str(doi.identifier)
+    assert result.candidates[1].routes[0].type == "elasticsearch"
+    assert result.diagnostics.identifier_returned == 1
+    assert result.diagnostics.candidate_count == 2
+
+
+@pytest.mark.asyncio
+async def test_identifier_match_on_duplicate_resolves_to_canonical(build_service):
+    doi = DOIIdentifierFactory.build()
+    canonical_id = uuid7()
+    duplicate = ReferenceFactory.build(visibility="public")
+    duplicate = duplicate.model_copy(
+        update={
+            "identifiers": [
+                LinkedExternalIdentifierFactory.build(
+                    identifier=doi, reference_id=duplicate.id
+                )
+            ],
+            "duplicate_decision": ReferenceDuplicateDecision(
+                reference_id=duplicate.id,
+                active_decision=True,
+                duplicate_determination=DuplicateDetermination.DUPLICATE,
+                canonical_reference_id=canonical_id,
+            ),
+        }
+    )
+    service, _, _, _ = build_service(found_references=[duplicate])
+
+    result = await service.get_deduplication_candidates(
+        CandidateSelectionRequest(
+            input=CandidateSelectionInput(
+                title="A study",
+                authors=["Jane Doe"],
+                publication_year=2025,
+                identifiers=[
+                    CandidateIdentifier(
+                        identifier_type=ExternalIdentifierType.DOI,
+                        identifier=str(doi.identifier),
+                    )
+                ],
+            ),
+            hydrate=False,
+        )
+    )
+
+    assert [c.reference_id for c in result.candidates] == [canonical_id]
+
+
+@pytest.mark.asyncio
+async def test_hydrate_includes_reference_projection(build_service):
+    hit = uuid7()
+    hydrated = _searchable_reference().model_copy(update={"id": hit})
+    service, _, _, _ = build_service(
+        es_result=_es_result(ESScoreResult(id=hit, score=4.0)),
+        hydrated=[hydrated],
+    )
+
+    result = await service.get_deduplication_candidates(
+        CandidateSelectionRequest(
+            input=CandidateSelectionInput(
+                title="A study", authors=["Jane Doe"], publication_year=2025
+            ),
+            include_identifier_matches=False,
+            hydrate=True,
+        )
+    )
+
+    candidate = result.candidates[0]
+    assert candidate.reference is not None
+    assert candidate.reference.title == "Maybe a duplicate reference, maybe not"
+    assert candidate.reference.publication_year == 2025
+
+
+@pytest.mark.asyncio
+async def test_unsearchable_input_returns_empty_200(build_service):
+    service, es_refs, _, _ = build_service()
+
+    result = await service.get_deduplication_candidates(
+        CandidateSelectionRequest(
+            # No authors -> not searchable.
+            input=CandidateSelectionInput(title="A study", publication_year=2025),
+        )
+    )
+
+    assert result.input_searchability.searchable is False
+    assert "authors" in result.input_searchability.reason
+    assert result.candidates == []
+    es_refs.search_for_candidate_canonicals.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_writes_no_duplicate_decision_state(build_service):
+    service, _, _, decisions = build_service(
+        es_result=_es_result(ESScoreResult(id=uuid7(), score=1.0))
+    )
+
+    await service.get_deduplication_candidates(
+        CandidateSelectionRequest(
+            input=CandidateSelectionInput(
+                title="A study", authors=["Jane Doe"], publication_year=2025
+            ),
+            include_identifier_matches=False,
+            hydrate=False,
+        )
+    )
+
+    decisions.add.assert_not_awaited()
+    decisions.add_bulk.assert_not_awaited()
+    decisions.update_by_pk.assert_not_awaited()
+    decisions.merge.assert_not_awaited()

--- a/tests/unit/domain/references/deduplication/test_candidate_selection.py
+++ b/tests/unit/domain/references/deduplication/test_candidate_selection.py
@@ -7,6 +7,7 @@ import pytest
 from destiny_sdk.enhancements import Authorship
 from pydantic import ValidationError
 
+from app.core.exceptions import DeduplicationValueError
 from app.domain.references.models.models import (
     CURRENT_FUZZY_RETRIEVAL_POLICY,
     CandidateIdentifier,
@@ -374,6 +375,25 @@ async def test_identifier_only_input_matches_when_es_unsearchable(build_service)
     assert result.candidates[0].routes[0].type == "identifier"
     assert result.diagnostics.identifier_returned == 1
     assert result.diagnostics.es_total_hits is None
+
+
+async def test_invalid_identifier_raises(build_service):
+    """A malformed identifier value fails normalisation and raises (422 in the API)."""
+    service, _, _, _ = build_service()
+    with pytest.raises(DeduplicationValueError):
+        await service.get_deduplication_candidates(
+            CandidateSelectionRequest(
+                input=CandidateSelectionInput(
+                    identifiers=[
+                        CandidateIdentifier(
+                            identifier_type=ExternalIdentifierType.DOI,
+                            identifier="not-a-doi",
+                        )
+                    ]
+                ),
+                hydrate=False,
+            )
+        )
 
 
 async def test_unsearchable_input_returns_empty_200(build_service):

--- a/tests/unit/domain/references/services/test_deduplication_service.py
+++ b/tests/unit/domain/references/services/test_deduplication_service.py
@@ -292,13 +292,13 @@ async def test_nominate_candidate_canonicals_candidates_found(
 
     # Patch service.es_uow to mock search_for_candidate_duplicates
     service.es_uow = MagicMock()
-    candidate_result = [MagicMock(id=uuid7())]
+    candidate_hit = MagicMock(id=uuid7())
     service.es_uow.references.search_for_candidate_canonicals = AsyncMock(
-        return_value=candidate_result
+        return_value=MagicMock(hits=[candidate_hit])
     )
     result = await service.nominate_candidate_canonicals(decision)
     assert result.duplicate_determination == DuplicateDetermination.NOMINATED
-    assert result.candidate_canonical_ids == [candidate_result[0].id]
+    assert result.candidate_canonical_ids == [candidate_hit.id]
     service.es_uow.references.search_for_candidate_canonicals.assert_awaited()
 
 
@@ -360,7 +360,7 @@ async def test_nominate_candidate_canonicals_no_candidates(
     # Patch service.es_uow to mock search_for_candidate_canonicals
     service.es_uow = MagicMock()
     service.es_uow.references.search_for_candidate_canonicals = AsyncMock(
-        return_value=[]
+        return_value=MagicMock(hits=[])
     )
     result = await service.nominate_candidate_canonicals(decision)
     assert result.duplicate_determination == DuplicateDetermination.CANONICAL


### PR DESCRIPTION
Part of #791. Closes #818.

Adds a read-only, zero-persistence `POST /references/deduplication/candidates/` endpoint so we can measure candidate-retrieval recall@K against production-like data without writing dedup decisions.

## What's here
- **Shared ES retrieval** — the existing candidate query is refactored into one method taking explicit `k` (fixing the silent ES `size=10` cap), used by both this endpoint and the nomination path. The nomination path's result count is unchanged (production K stays the recall@K evaluation's decision).
- **Endpoint** — accepts either a `reference_id` or an inline payload (title/authors/year/identifiers); guarded by the existing `reference.deduplicator` scope; writes nothing.
- **Identifier union** — optional Postgres exact-identifier matches (DOI, `pm_id`, OpenAlex), unioned with ES results and resolved to canonical. ES score and identifier evidence stay separate as `routes`; identifier-only matches rank ahead.
- **Diagnostics** — `index_version`, ES took/total/returned, candidate count, truncation, and ES score floor.
- Request/response are **local domain models** (not the SDK), since the contract is an evolving evaluation surface (#819 may fold `include_identifier_matches`/`k` into named policies).

## Notes / decisions
- Unsearchable inputs (missing title/authors/year) return `200` with empty candidates + a reason, per the issue.
- The canonical-only ES filter stays coupled to publication-year presence (documented, not changed — out of scope); the searchability gate guarantees a year is present.

## Tests
- 13 unit tests (orchestration, identifier-union ranking, duplicate→canonical resolution, `k`, hydration, unsearchable, validation, no-persistence).
- 4 e2e tests against the real stack (ES ∪ identifier union, hydration, `reference_id` input, unsearchable, validation, and a real no-persistence row-count check).
- Existing unit + integration tests updated for the new signature.