### PR TITLE
feat(dedup): named candidate-retrieval policies for candidate selection

### DIFF
--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -774,7 +774,23 @@ class ReferenceSearchFields(ProjectedBaseModel):
         return [cls._normalise_string(v) for v in value if v]
 
 
-CURRENT_FUZZY_RETRIEVAL_POLICY = "current_fuzzy_v1"
+class RetrievalPolicyName(StrEnum):
+    """
+    Named, versioned candidate-retrieval policies for the Candidate Selection API.
+
+    Each value fixes a full retrieval regime (query shape, year strategy,
+    identifier union) under a stable name so recall@K stays comparable across
+    runs. A name's semantics never change; a new regime gets a new name.
+    """
+
+    CURRENT_FUZZY_V1 = "current_fuzzy_v1"
+    """Control: fuzzy title/author match with a hard +/-1 publication-year
+    window; requires publication year as input. Mirrors the baseline gate."""
+    NO_YEAR_FILTER_V1 = "no_year_filter_v1"
+    """Drops the year filter from the query, but still requires publication year
+    as input."""
+    NO_YEAR_FILTER_YEAR_OPTIONAL_V1 = "no_year_filter_year_optional_v1"
+    """Drops the year filter and makes publication year optional as input."""
 
 
 class CandidateIdentifier(GenericExternalIdentifier):
@@ -838,8 +854,8 @@ class CandidateSelectionRequest(BaseModel):
     input: CandidateSelectionInput = Field(
         description="The reference to find candidates for."
     )
-    retrieval_policy: str = Field(
-        default=CURRENT_FUZZY_RETRIEVAL_POLICY,
+    retrieval_policy: RetrievalPolicyName = Field(
+        default=RetrievalPolicyName.CURRENT_FUZZY_V1,
         description=(
             "Named, server-side retrieval policy fixing the full candidate regime "
             "(query shape, year strategy, identifier union). Defaults to the "
@@ -937,7 +953,7 @@ class CandidateSelectionDiagnostics(BaseModel):
 class CandidateSelectionResult(BaseModel):
     """Ranked candidates and diagnostics for a candidate-selection request."""
 
-    retrieval_policy: str = CURRENT_FUZZY_RETRIEVAL_POLICY
+    retrieval_policy: RetrievalPolicyName = RetrievalPolicyName.CURRENT_FUZZY_V1
     index_version: str | None = Field(
         default=None,
         description="The reference index version the candidates were drawn from.",

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -913,8 +913,9 @@ class InputSearchability(BaseModel):
     searchable: bool = Field(
         description=(
             "Whether the input meets the Elasticsearch searchability gate (title, "
-            "authors, publication year). Exact identifier matching runs regardless, "
-            "so candidates may be present even when this is false."
+            "authors, and publication year unless the selected retrieval policy "
+            "makes it optional). Exact identifier matching runs regardless, so "
+            "candidates may be present even when this is false."
         )
     )
     reason: str = Field(description="Explanation of the searchability decision.")

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -652,8 +652,8 @@ class CandidateCanonicalSearchFields(ProjectedBaseModel):
     """
     Fields used for candidate canonical selection.
 
-    The search implementation lives at
-    :attr:`app.domain.references.repository.ReferenceESRepository.search_for_candidate_canonicals`.
+    The retrieval policy is interpreted by
+    :func:`app.domain.references.services.deduplication_service.build_candidate_canonical_search_query`.
     """
 
     publication_year: int | None = Field(
@@ -672,6 +672,23 @@ class CandidateCanonicalSearchFields(ProjectedBaseModel):
     def is_searchable(self) -> bool:
         """Whether the projection has the fields required to search for candidates."""
         return all((self.publication_year, self.authors, self.title))
+
+
+class CandidateCanonicalSearchQuery(BaseModel):
+    """Service-owned candidate query specification for Elasticsearch translation."""
+
+    model_config = ConfigDict(frozen=True)
+
+    title: str
+    title_fuzziness: str
+    title_boost: float
+    title_operator: Literal["or"]
+    title_minimum_should_match: str
+    author_terms: tuple[str, ...]
+    author_tie_breaker: float
+    publication_year_range: tuple[int, int] | None
+    duplicate_determination: DuplicateDetermination
+    excluded_reference_id: UUID | None
 
 
 class ReferenceSearchFields(ProjectedBaseModel):

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -833,8 +833,18 @@ class CandidateSelectionInput(BaseModel):
 class CandidateSelectionRequest(BaseModel):
     """A request for candidate canonical references, for dedup evaluation."""
 
+    model_config = ConfigDict(extra="forbid")
+
     input: CandidateSelectionInput = Field(
         description="The reference to find candidates for."
+    )
+    retrieval_policy: str = Field(
+        default=CURRENT_FUZZY_RETRIEVAL_POLICY,
+        description=(
+            "Named, server-side retrieval policy fixing the full candidate regime "
+            "(query shape, year strategy, identifier union). Defaults to the "
+            "current fuzzy baseline."
+        ),
     )
     k: int | None = Field(
         default=None,
@@ -842,12 +852,6 @@ class CandidateSelectionRequest(BaseModel):
         le=1000,
         description=(
             "Number of candidates to retrieve. Defaults to the configured value."
-        ),
-    )
-    include_identifier_matches: bool = Field(
-        default=True,
-        description=(
-            "Union exact identifier matches from Postgres with ES candidates."
         ),
     )
     hydrate: bool = Field(
@@ -938,7 +942,6 @@ class CandidateSelectionResult(BaseModel):
         description="The reference index version the candidates were drawn from.",
     )
     k_requested: int
-    include_identifier_matches: bool
     input_searchability: InputSearchability
     diagnostics: CandidateSelectionDiagnostics
     candidates: list[Candidate] = Field(default_factory=list)

--- a/app/domain/references/models/retrieval_policy.py
+++ b/app/domain/references/models/retrieval_policy.py
@@ -56,31 +56,30 @@ NO_YEAR_FILTER_POLICY = "no_year_filter_v1"
 YEAR_OPTIONAL_POLICY = "no_year_filter_year_optional_v1"
 
 
-_RETRIEVAL_POLICIES: dict[str, RetrievalPolicy] = {
-    policy.name: policy
-    for policy in (
-        RetrievalPolicy(
-            name=CURRENT_FUZZY_RETRIEVAL_POLICY,
-            union_identifiers=True,
-            year_strategy=YearStrategy.HARD_WINDOW,
-        ),
-        RetrievalPolicy(
-            name=NO_YEAR_FILTER_POLICY,
-            union_identifiers=True,
-            year_strategy=YearStrategy.NO_FILTER,
-        ),
-        RetrievalPolicy(
-            name=YEAR_OPTIONAL_POLICY,
-            union_identifiers=True,
-            year_strategy=YearStrategy.NO_FILTER,
-            requires_publication_year=False,
-        ),
-    )
-}
-
-# Exposed read-only so a policy name's semantics cannot be mutated at runtime.
+# Wrapped read-only with no module-level handle to the backing dict, so a policy
+# name's semantics cannot be remapped at runtime.
 RETRIEVAL_POLICIES: Mapping[str, RetrievalPolicy] = MappingProxyType(
-    _RETRIEVAL_POLICIES
+    {
+        policy.name: policy
+        for policy in (
+            RetrievalPolicy(
+                name=CURRENT_FUZZY_RETRIEVAL_POLICY,
+                union_identifiers=True,
+                year_strategy=YearStrategy.HARD_WINDOW,
+            ),
+            RetrievalPolicy(
+                name=NO_YEAR_FILTER_POLICY,
+                union_identifiers=True,
+                year_strategy=YearStrategy.NO_FILTER,
+            ),
+            RetrievalPolicy(
+                name=YEAR_OPTIONAL_POLICY,
+                union_identifiers=True,
+                year_strategy=YearStrategy.NO_FILTER,
+                requires_publication_year=False,
+            ),
+        )
+    }
 )
 
 

--- a/app/domain/references/models/retrieval_policy.py
+++ b/app/domain/references/models/retrieval_policy.py
@@ -20,11 +20,13 @@ class YearStrategy(Enum):
     """
     How a policy treats the publication-year signal.
 
-    Extension seam: HARD_WINDOW is the only strategy today. A soft
-    year-distance decay strategy is added here with its policy, not before.
+    Extension seam: HARD_WINDOW keeps the hard ±1 filter, NO_FILTER drops the
+    year clause. A soft year-distance decay strategy (SOFT_DECAY) is added here
+    once we have grounding on its weights/policy.
     """
 
     HARD_WINDOW = "hard_window"
+    NO_FILTER = "no_filter"
 
 
 class RetrievalPolicy(BaseModel):
@@ -37,6 +39,9 @@ class RetrievalPolicy(BaseModel):
     year_strategy: YearStrategy
 
 
+NO_YEAR_FILTER_POLICY = "no_year_filter_v1"
+
+
 _RETRIEVAL_POLICIES: dict[str, RetrievalPolicy] = {
     policy.name: policy
     for policy in (
@@ -44,6 +49,11 @@ _RETRIEVAL_POLICIES: dict[str, RetrievalPolicy] = {
             name=CURRENT_FUZZY_RETRIEVAL_POLICY,
             union_identifiers=True,
             year_strategy=YearStrategy.HARD_WINDOW,
+        ),
+        RetrievalPolicy(
+            name=NO_YEAR_FILTER_POLICY,
+            union_identifiers=True,
+            year_strategy=YearStrategy.NO_FILTER,
         ),
     )
 }

--- a/app/domain/references/models/retrieval_policy.py
+++ b/app/domain/references/models/retrieval_policy.py
@@ -47,7 +47,8 @@ class RetrievalPolicy(BaseModel):
     ) -> bool:
         """Whether the input has the fields this policy needs for ES retrieval."""
         has_core = bool(search_fields.title and search_fields.authors)
-        has_year = search_fields.publication_year is not None
+        # Falsy year (0/None) counts as absent, matching the baseline all(...) gate.
+        has_year = bool(search_fields.publication_year)
         return has_core and (has_year or not self.requires_publication_year)
 
 

--- a/app/domain/references/models/retrieval_policy.py
+++ b/app/domain/references/models/retrieval_policy.py
@@ -1,0 +1,64 @@
+"""
+Named, immutable candidate-retrieval policies for the Candidate Selection API.
+
+A policy fixes the full retrieval regime under one stable name so recall@K
+numbers stay comparable across runs. New policies are added only through a
+focused experiment cycle; a policy name's semantics never change.
+"""
+
+from collections.abc import Mapping
+from enum import Enum
+from types import MappingProxyType
+
+from pydantic import BaseModel, ConfigDict
+
+from app.core.exceptions import DeduplicationValueError
+from app.domain.references.models.models import CURRENT_FUZZY_RETRIEVAL_POLICY
+
+
+class YearStrategy(Enum):
+    """
+    How a policy treats the publication-year signal.
+
+    Extension seam: HARD_WINDOW is the only strategy today. A soft
+    year-distance decay strategy is added here with its policy, not before.
+    """
+
+    HARD_WINDOW = "hard_window"
+
+
+class RetrievalPolicy(BaseModel):
+    """An immutable candidate-retrieval policy bundle."""
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    union_identifiers: bool
+    year_strategy: YearStrategy
+
+
+_RETRIEVAL_POLICIES: dict[str, RetrievalPolicy] = {
+    policy.name: policy
+    for policy in (
+        RetrievalPolicy(
+            name=CURRENT_FUZZY_RETRIEVAL_POLICY,
+            union_identifiers=True,
+            year_strategy=YearStrategy.HARD_WINDOW,
+        ),
+    )
+}
+
+# Exposed read-only so a policy name's semantics cannot be mutated at runtime.
+RETRIEVAL_POLICIES: Mapping[str, RetrievalPolicy] = MappingProxyType(
+    _RETRIEVAL_POLICIES
+)
+
+
+def resolve_retrieval_policy(name: str) -> RetrievalPolicy:
+    """Return the named policy, or raise DeduplicationValueError if unknown."""
+    try:
+        return RETRIEVAL_POLICIES[name]
+    except KeyError as exc:
+        valid = ", ".join(sorted(RETRIEVAL_POLICIES))
+        msg = f"Unknown retrieval_policy '{name}'. Valid policies: {valid}."
+        raise DeduplicationValueError(msg) from exc

--- a/app/domain/references/models/retrieval_policy.py
+++ b/app/domain/references/models/retrieval_policy.py
@@ -13,7 +13,10 @@ from types import MappingProxyType
 from pydantic import BaseModel, ConfigDict
 
 from app.core.exceptions import DeduplicationValueError
-from app.domain.references.models.models import CURRENT_FUZZY_RETRIEVAL_POLICY
+from app.domain.references.models.models import (
+    CURRENT_FUZZY_RETRIEVAL_POLICY,
+    CandidateCanonicalSearchFields,
+)
 
 
 class YearStrategy(Enum):
@@ -37,9 +40,19 @@ class RetrievalPolicy(BaseModel):
     name: str
     union_identifiers: bool
     year_strategy: YearStrategy
+    requires_publication_year: bool = True
+
+    def is_input_searchable(
+        self, search_fields: CandidateCanonicalSearchFields
+    ) -> bool:
+        """Whether the input has the fields this policy needs for ES retrieval."""
+        has_core = bool(search_fields.title and search_fields.authors)
+        has_year = search_fields.publication_year is not None
+        return has_core and (has_year or not self.requires_publication_year)
 
 
 NO_YEAR_FILTER_POLICY = "no_year_filter_v1"
+YEAR_OPTIONAL_POLICY = "no_year_filter_year_optional_v1"
 
 
 _RETRIEVAL_POLICIES: dict[str, RetrievalPolicy] = {
@@ -54,6 +67,12 @@ _RETRIEVAL_POLICIES: dict[str, RetrievalPolicy] = {
             name=NO_YEAR_FILTER_POLICY,
             union_identifiers=True,
             year_strategy=YearStrategy.NO_FILTER,
+        ),
+        RetrievalPolicy(
+            name=YEAR_OPTIONAL_POLICY,
+            union_identifiers=True,
+            year_strategy=YearStrategy.NO_FILTER,
+            requires_publication_year=False,
         ),
     )
 }

--- a/app/domain/references/models/retrieval_policy.py
+++ b/app/domain/references/models/retrieval_policy.py
@@ -12,10 +12,9 @@ from types import MappingProxyType
 
 from pydantic import BaseModel, ConfigDict
 
-from app.core.exceptions import DeduplicationValueError
 from app.domain.references.models.models import (
-    CURRENT_FUZZY_RETRIEVAL_POLICY,
     CandidateCanonicalSearchFields,
+    RetrievalPolicyName,
 )
 
 
@@ -37,7 +36,7 @@ class RetrievalPolicy(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    name: str
+    name: RetrievalPolicyName
     union_identifiers: bool
     year_strategy: YearStrategy
     requires_publication_year: bool = True
@@ -52,28 +51,24 @@ class RetrievalPolicy(BaseModel):
         return has_core and (has_year or not self.requires_publication_year)
 
 
-NO_YEAR_FILTER_POLICY = "no_year_filter_v1"
-YEAR_OPTIONAL_POLICY = "no_year_filter_year_optional_v1"
-
-
 # Wrapped read-only with no module-level handle to the backing dict, so a policy
 # name's semantics cannot be remapped at runtime.
-RETRIEVAL_POLICIES: Mapping[str, RetrievalPolicy] = MappingProxyType(
+RETRIEVAL_POLICIES: Mapping[RetrievalPolicyName, RetrievalPolicy] = MappingProxyType(
     {
         policy.name: policy
         for policy in (
             RetrievalPolicy(
-                name=CURRENT_FUZZY_RETRIEVAL_POLICY,
+                name=RetrievalPolicyName.CURRENT_FUZZY_V1,
                 union_identifiers=True,
                 year_strategy=YearStrategy.HARD_WINDOW,
             ),
             RetrievalPolicy(
-                name=NO_YEAR_FILTER_POLICY,
+                name=RetrievalPolicyName.NO_YEAR_FILTER_V1,
                 union_identifiers=True,
                 year_strategy=YearStrategy.NO_FILTER,
             ),
             RetrievalPolicy(
-                name=YEAR_OPTIONAL_POLICY,
+                name=RetrievalPolicyName.NO_YEAR_FILTER_YEAR_OPTIONAL_V1,
                 union_identifiers=True,
                 year_strategy=YearStrategy.NO_FILTER,
                 requires_publication_year=False,
@@ -83,11 +78,6 @@ RETRIEVAL_POLICIES: Mapping[str, RetrievalPolicy] = MappingProxyType(
 )
 
 
-def resolve_retrieval_policy(name: str) -> RetrievalPolicy:
-    """Return the named policy, or raise DeduplicationValueError if unknown."""
-    try:
-        return RETRIEVAL_POLICIES[name]
-    except KeyError as exc:
-        valid = ", ".join(sorted(RETRIEVAL_POLICIES))
-        msg = f"Unknown retrieval_policy '{name}'. Valid policies: {valid}."
-        raise DeduplicationValueError(msg) from exc
+def resolve_retrieval_policy(name: RetrievalPolicyName) -> RetrievalPolicy:
+    """Return the immutable policy bundle registered under this name."""
+    return RETRIEVAL_POLICIES[name]

--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -718,10 +718,8 @@ class ReferenceESRepository(
             min_token_length=scoring_config.min_author_token_length,
         )
         should_clauses = [author_query] if author_query else []
-        # Canonical filter is unconditional: duplicates are never candidates,
-        # whatever the year strategy or year presence. Only the year range is
-        # strategy-dependent. (This also avoids race conditions where two references
-        # being deduplicated concurrently could create conflicting relationships.)
+        # Requiring CANONICAL prevents two references being deduplicated
+        # concurrently from forming conflicting relationships.
         filter_clauses = [
             *self._year_filter_clauses(search_fields.publication_year, year_strategy),
             Q("term", duplicate_determination=DuplicateDetermination.CANONICAL),

--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -23,7 +23,7 @@ from sqlalchemy import (
     update,
 )
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import selectinload
 
 from app.core.config import DedupCandidateScoringConfig, get_settings
 from app.core.telemetry.repository import trace_repository_method
@@ -173,17 +173,17 @@ class ReferenceSQLRepository(
         query = select(SQLReference).where(SQLReference.id.in_(reference_ids))
         if enhancement_types:
             query = query.options(
-                joinedload(
+                selectinload(
                     SQLReference.enhancements.and_(
                         SQLEnhancement.enhancement_type.in_(enhancement_types)
                     )
                 )
             )
         else:
-            query = query.options(joinedload(SQLReference.enhancements))
+            query = query.options(selectinload(SQLReference.enhancements))
         if external_identifier_types:
             query = query.options(
-                joinedload(
+                selectinload(
                     SQLReference.identifiers.and_(
                         SQLExternalIdentifier.identifier_type.in_(
                             external_identifier_types
@@ -192,7 +192,7 @@ class ReferenceSQLRepository(
                 )
             )
         else:
-            query = query.options(joinedload(SQLReference.identifiers))
+            query = query.options(selectinload(SQLReference.identifiers))
         result = await self._session.execute(query)
         db_references = result.unique().scalars().all()
         return [

--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -3,7 +3,7 @@
 import datetime
 from abc import ABC
 from collections.abc import Mapping, Sequence
-from typing import Any, ClassVar, Literal
+from typing import Any, ClassVar, Literal, assert_never
 from uuid import UUID
 
 from elasticsearch import AsyncElasticsearch
@@ -83,6 +83,7 @@ from app.domain.references.models.models import (
 from app.domain.references.models.projections import (
     EnhancementRequestStatusProjection,
 )
+from app.domain.references.models.retrieval_policy import YearStrategy
 from app.domain.references.models.sql import (
     Enhancement as SQLEnhancement,
 )
@@ -679,8 +680,73 @@ class ReferenceESRepository(
         # Enough to prefer multi-author overlap without summing to inflation.
         return Q("dis_max", queries=queries, tie_breaker=0.1)
 
+    @staticmethod
+    def _year_filter_clauses(
+        publication_year: int | None, year_strategy: YearStrategy
+    ) -> list[Q]:
+        """Year range clauses for the strategy; empty when unfiltered or year absent."""
+        match year_strategy:
+            case YearStrategy.HARD_WINDOW:
+                if publication_year is None:
+                    return []
+                return [
+                    Q(
+                        "range",
+                        publication_year={
+                            "gte": publication_year - 1,
+                            "lte": publication_year + 1,
+                        },
+                    )
+                ]
+            case YearStrategy.NO_FILTER:
+                return []
+            case _:  # pragma: no cover - exhaustiveness guard
+                assert_never(year_strategy)
+
+    def _build_candidate_query(
+        self,
+        search_fields: CandidateCanonicalSearchFields,
+        *,
+        scoring_config: DedupCandidateScoringConfig,
+        year_strategy: YearStrategy,
+        reference_id: UUID | None,
+    ) -> Q:
+        """Build the candidate bool query for a retrieval policy's year strategy."""
+        author_query = self._build_author_dis_max_query(
+            search_fields.authors,
+            max_clauses=scoring_config.max_author_clauses,
+            min_token_length=scoring_config.min_author_token_length,
+        )
+        should_clauses = [author_query] if author_query else []
+        # Canonical filter is unconditional: duplicates are never candidates,
+        # whatever the year strategy or year presence. Only the year range is
+        # strategy-dependent. (This also avoids race conditions where two references
+        # being deduplicated concurrently could create conflicting relationships.)
+        filter_clauses = [
+            *self._year_filter_clauses(search_fields.publication_year, year_strategy),
+            Q("term", duplicate_determination=DuplicateDetermination.CANONICAL),
+        ]
+        return Q(
+            "bool",
+            must=[
+                Q(
+                    "match",
+                    title={
+                        "query": search_fields.title,
+                        "fuzziness": "AUTO",
+                        "boost": 2.0,
+                        "operator": "or",
+                        "minimum_should_match": "50%",
+                    },
+                )
+            ],
+            should=should_clauses,
+            filter=filter_clauses,
+            must_not=[Q("ids", values=[reference_id])] if reference_id else [],
+        )
+
     @trace_repository_method(tracer)
-    async def search_for_candidate_canonicals(
+    async def search_for_candidate_canonicals(  # noqa: PLR0913
         self,
         search_fields: CandidateCanonicalSearchFields,
         scoring_config: DedupCandidateScoringConfig,
@@ -688,6 +754,7 @@ class ReferenceESRepository(
         k: int,
         reference_id: UUID | None = None,
         track_total_hits: bool = False,
+        year_strategy: YearStrategy = YearStrategy.HARD_WINDOW,
     ) -> CandidateCanonicalSearchResult:
         """
         Fuzzy match candidate fingerprints to existing references.
@@ -720,51 +787,14 @@ class ReferenceESRepository(
         :return: Ranked candidate ids with scores and retrieval diagnostics.
         :rtype: CandidateCanonicalSearchResult
         """
-        author_query = self._build_author_dis_max_query(
-            search_fields.authors,
-            max_clauses=scoring_config.max_author_clauses,
-            min_token_length=scoring_config.min_author_token_length,
-        )
-        should_clauses = [author_query] if author_query else []
-
         search = (
             AsyncSearch(using=self._client, index=self._persistence_cls.Index.name)
             .query(
-                Q(
-                    "bool",
-                    must=[
-                        Q(
-                            "match",
-                            title={
-                                "query": search_fields.title,
-                                "fuzziness": "AUTO",
-                                "boost": 2.0,
-                                "operator": "or",
-                                "minimum_should_match": "50%",
-                            },
-                        )
-                    ],
-                    should=should_clauses,
-                    filter=[
-                        Q(
-                            "range",
-                            publication_year={
-                                "gte": search_fields.publication_year - 1,
-                                "lte": search_fields.publication_year + 1,
-                            },
-                        ),
-                        # Only match against canonical references that are "at rest".
-                        # Duplicates are never candidates. This also avoids race
-                        # conditions where two references being deduplicated
-                        # concurrently could create conflicting relationships.
-                        Q(
-                            "term",
-                            duplicate_determination=DuplicateDetermination.CANONICAL,
-                        ),
-                    ]
-                    if search_fields.publication_year
-                    else [],
-                    must_not=[Q("ids", values=[reference_id])] if reference_id else [],
+                self._build_candidate_query(
+                    search_fields,
+                    scoring_config=scoring_config,
+                    year_strategy=year_strategy,
+                    reference_id=reference_id,
                 )
             )
             .source(fields=False)

--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -3,7 +3,7 @@
 import datetime
 from abc import ABC
 from collections.abc import Mapping, Sequence
-from typing import Any, ClassVar, Literal, assert_never
+from typing import Any, ClassVar, Literal
 from uuid import UUID
 
 from elasticsearch import AsyncElasticsearch
@@ -25,7 +25,7 @@ from sqlalchemy import (
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.core.config import DedupCandidateScoringConfig, get_settings
+from app.core.config import get_settings
 from app.core.telemetry.repository import trace_repository_method
 from app.domain.references.models.es import (
     ReferenceDocument,
@@ -33,7 +33,7 @@ from app.domain.references.models.es import (
 )
 from app.domain.references.models.models import (
     AnnotationFilter,
-    CandidateCanonicalSearchFields,
+    CandidateCanonicalSearchQuery,
     CrossFacetAxis,
     CrossFacetCell,
     DuplicateDetermination,
@@ -83,7 +83,6 @@ from app.domain.references.models.models import (
 from app.domain.references.models.projections import (
     EnhancementRequestStatusProjection,
 )
-from app.domain.references.models.retrieval_policy import YearStrategy
 from app.domain.references.models.sql import (
     Enhancement as SQLEnhancement,
 )
@@ -118,7 +117,6 @@ from app.persistence.es.repository import GenericAsyncESRepository
 from app.persistence.generics import GenericPersistenceType
 from app.persistence.repository import GenericAsyncRepository
 from app.persistence.sql.repository import GenericAsyncSqlRepository
-from app.utils.regex import UNICODE_LETTER_PATTERN, is_meaningful_token
 
 settings = get_settings()
 tracer = trace.get_tracer(__name__)
@@ -625,159 +623,73 @@ class ReferenceESRepository(
         return cells
 
     @staticmethod
-    def _build_author_dis_max_query(
-        authors: list[str],
-        *,
-        max_clauses: int,
-        min_token_length: int,
-    ) -> Q | None:
-        """
-        Build a dis_max query for author matching with bounded score contribution.
-
-        Uses dis_max instead of bool.should to prevent author-count inflation.
-        bool.should sums all matching clauses, so papers with thousands of authors
-        (e.g. CERN collaborations) produce inflated scores that drown out title
-        relevance. dis_max takes the best clause score and discounts the rest, bounding
-        the author contribution regardless of author count.
-
-        Caps the clause count to avoid sending redundant clauses to ES (dis_max
-        discounts them anyway). Filters short tokens because single-letter
-        initials match too broadly and produce false positive score boosts.
-
-        Args:
-            authors: Author names to build match queries from.
-            max_clauses: Maximum number of match queries to emit.
-            min_token_length: Minimum token length; filters initials.
-
-        Returns:
-            A dis_max Q object, or None if no valid queries remain.
-
-        """
-        queries: list[Q] = []
-        seen_terms: set[str] = set()
-        for author in authors:
-            tokens = [
-                token
-                for token in UNICODE_LETTER_PATTERN.findall(author)
-                if is_meaningful_token(token, min_token_length)
-            ]
-            if not tokens:
-                continue
-
-            terms = " ".join(tokens)
-            if terms in seen_terms:
-                continue
-
-            seen_terms.add(terms)
-            queries.append(Q("match", authors=terms))
-            if len(queries) >= max_clauses:
-                break
-
-        if not queries:
-            return None
-
-        # 0.1 = best-matching author dominates, additional matches add 10% each.
-        # Enough to prefer multi-author overlap without summing to inflation.
-        return Q("dis_max", queries=queries, tie_breaker=0.1)
-
-    @staticmethod
-    def _year_filter_clauses(
-        publication_year: int | None, year_strategy: YearStrategy
-    ) -> list[Q]:
-        """Year range clauses for the strategy; empty when unfiltered or year absent."""
-        match year_strategy:
-            case YearStrategy.HARD_WINDOW:
-                if publication_year is None:
-                    return []
-                return [
-                    Q(
-                        "range",
-                        publication_year={
-                            "gte": publication_year - 1,
-                            "lte": publication_year + 1,
-                        },
-                    )
-                ]
-            case YearStrategy.NO_FILTER:
-                return []
-            case _:  # pragma: no cover - exhaustiveness guard
-                assert_never(year_strategy)
-
-    def _build_candidate_query(
-        self,
-        search_fields: CandidateCanonicalSearchFields,
-        *,
-        scoring_config: DedupCandidateScoringConfig,
-        year_strategy: YearStrategy,
-        reference_id: UUID | None,
-    ) -> Q:
-        """Build the candidate bool query for a retrieval policy's year strategy."""
-        author_query = self._build_author_dis_max_query(
-            search_fields.authors,
-            max_clauses=scoring_config.max_author_clauses,
-            min_token_length=scoring_config.min_author_token_length,
+    def _to_es_candidate_query(query: CandidateCanonicalSearchQuery) -> Q:
+        """Translate a domain candidate query into Elasticsearch DSL."""
+        # bool.should sums every matching author clause, so large collaborations can
+        # drown out title relevance. dis_max bounds that contribution around the best
+        # author match while its tie-breaker gives smaller credit to additional ones.
+        author_query = (
+            Q(
+                "dis_max",
+                queries=[Q("match", authors=terms) for terms in query.author_terms],
+                tie_breaker=query.author_tie_breaker,
+            )
+            if query.author_terms
+            else None
         )
         should_clauses = [author_query] if author_query else []
-        # Requiring CANONICAL prevents two references being deduplicated
-        # concurrently from forming conflicting relationships.
-        filter_clauses = [
-            *self._year_filter_clauses(search_fields.publication_year, year_strategy),
-            Q("term", duplicate_determination=DuplicateDetermination.CANONICAL),
-        ]
+        filter_clauses = []
+        if query.publication_year_range is not None:
+            start, end = query.publication_year_range
+            filter_clauses.append(
+                Q("range", publication_year={"gte": start, "lte": end})
+            )
+        filter_clauses.append(
+            Q(
+                "term",
+                duplicate_determination=query.duplicate_determination,
+            )
+        )
         return Q(
             "bool",
             must=[
                 Q(
                     "match",
                     title={
-                        "query": search_fields.title,
-                        "fuzziness": "AUTO",
-                        "boost": 2.0,
-                        "operator": "or",
-                        "minimum_should_match": "50%",
+                        "query": query.title,
+                        "fuzziness": query.title_fuzziness,
+                        "boost": query.title_boost,
+                        "operator": query.title_operator,
+                        "minimum_should_match": query.title_minimum_should_match,
                     },
                 )
             ],
             should=should_clauses,
             filter=filter_clauses,
-            must_not=[Q("ids", values=[reference_id])] if reference_id else [],
+            must_not=[Q("ids", values=[query.excluded_reference_id])]
+            if query.excluded_reference_id
+            else [],
         )
 
     @trace_repository_method(tracer)
-    async def search_for_candidate_canonicals(  # noqa: PLR0913
+    async def search_for_candidate_canonicals(
         self,
-        search_fields: CandidateCanonicalSearchFields,
-        scoring_config: DedupCandidateScoringConfig,
+        query: CandidateCanonicalSearchQuery,
         *,
         k: int,
-        reference_id: UUID | None = None,
         track_total_hits: bool = False,
-        year_strategy: YearStrategy = YearStrategy.HARD_WINDOW,
     ) -> CandidateCanonicalSearchResult:
         """
-        Fuzzy match candidate fingerprints to existing references.
+        Execute a candidate-canonical search specification in Elasticsearch.
 
-        This is a high-recall search strategy. Shared by the deduplication
-        nomination path and the candidate-selection evaluation endpoint so that
-        both exercise the same query; the query shape itself is the baseline
-        under evaluation and is not yet a chosen production policy.
+        The deduplication service owns retrieval-policy interpretation and query
+        semantics; this repository translates the resulting specification into
+        Elasticsearch DSL and executes it.
 
-        The query does:
-
-        - MUST: fuzzy match on title (requires 50% of terms to match)
-        - SHOULD: author matching
-        - FILTER: publication year within ±1 year range (non-scoring)
-        - FILTER: only canonical references (at rest)
-
-        :param search_fields: The search fields of the potential duplicate.
-        :type search_fields: CandidateCanonicalSearchFields
-        :param scoring_config: Configuration for author scoring.
-        :type scoring_config: DedupCandidateScoringConfig
+        :param query: The domain search specification to execute.
+        :type query: CandidateCanonicalSearchQuery
         :param k: Maximum number of candidates to return.
         :type k: int
-        :param reference_id: The ID of the potential duplicate, excluded from the
-            results when provided.
-        :type reference_id: UUID | None
         :param track_total_hits: Compute the exact total hit count instead of the
             Elasticsearch default (capped at 10k). Off by default so the nomination
             path, which ignores the total, does not pay for a full count.
@@ -787,14 +699,7 @@ class ReferenceESRepository(
         """
         search = (
             AsyncSearch(using=self._client, index=self._persistence_cls.Index.name)
-            .query(
-                self._build_candidate_query(
-                    search_fields,
-                    scoring_config=scoring_config,
-                    year_strategy=year_strategy,
-                    reference_id=reference_id,
-                )
-            )
+            .query(self._to_es_candidate_query(query))
             .source(fields=False)
             .extra(size=k)
         )

--- a/app/domain/references/routes.py
+++ b/app/domain/references/routes.py
@@ -1478,7 +1478,7 @@ async def get_deduplication_candidates(
     logger.info(
         "Retrieving deduplication candidates.",
         k=request.k,
-        include_identifier_matches=request.include_identifier_matches,
+        retrieval_policy=request.retrieval_policy,
     )
     try:
         return await reference_service.get_deduplication_candidates(request)

--- a/app/domain/references/services/deduplication_service.py
+++ b/app/domain/references/services/deduplication_service.py
@@ -9,7 +9,6 @@ from app.core.config import Environment, get_settings
 from app.core.exceptions import DeduplicationValueError
 from app.core.telemetry.logger import get_logger
 from app.domain.references.models.models import (
-    CURRENT_FUZZY_RETRIEVAL_POLICY,
     Candidate,
     CandidateCanonicalSearchFields,
     CandidateElasticsearchRoute,
@@ -33,6 +32,7 @@ from app.domain.references.models.projections import (
     CandidateReferenceProjection,
     ReferenceSearchFieldsProjection,
 )
+from app.domain.references.models.retrieval_policy import resolve_retrieval_policy
 from app.domain.references.services.anti_corruption_service import (
     ReferenceAntiCorruptionService,
 )
@@ -95,6 +95,7 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
         diagnostics. It writes no duplicate-decision or candidate state.
         """
         k = request.k or settings.dedup_scoring.candidate_k
+        policy = resolve_retrieval_policy(request.retrieval_policy)
 
         (
             search_fields,
@@ -106,7 +107,7 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
         # it is the route for records that fail the ES searchability gate, so it runs
         # regardless of it.
         identifier_matches: dict[UUID, dict[tuple, CandidateIdentifier]] = {}
-        if request.include_identifier_matches and identifier_lookups:
+        if policy.union_identifiers and identifier_lookups:
             identifier_matches = await self._union_identifier_matches(
                 identifier_lookups, self_id=self_id
             )
@@ -152,7 +153,7 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
             if cid in es_scores:
                 routes.append(
                     CandidateElasticsearchRoute(
-                        policy=CURRENT_FUZZY_RETRIEVAL_POLICY,
+                        policy=policy.name,
                         rank=es_ranks[cid],
                         score=es_scores[cid],
                     )
@@ -178,9 +179,9 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
 
         es_returned = len(es_hits)
         return CandidateSelectionResult(
+            retrieval_policy=policy.name,
             index_version=index_version,
             k_requested=k,
-            include_identifier_matches=request.include_identifier_matches,
             input_searchability=InputSearchability(
                 searchable=searchable,
                 reason="ok" if searchable else _unsearchable_reason(search_fields),

--- a/app/domain/references/services/deduplication_service.py
+++ b/app/domain/references/services/deduplication_service.py
@@ -1,16 +1,17 @@
 """Service for managing reference duplicate detection."""
 
-from typing import Literal
+from typing import Literal, assert_never
 from uuid import UUID
 
 from opentelemetry import trace
 
-from app.core.config import Environment, get_settings
+from app.core.config import DedupCandidateScoringConfig, Environment, get_settings
 from app.core.exceptions import DeduplicationValueError
 from app.core.telemetry.logger import get_logger
 from app.domain.references.models.models import (
     Candidate,
     CandidateCanonicalSearchFields,
+    CandidateCanonicalSearchQuery,
     CandidateElasticsearchRoute,
     CandidateIdentifier,
     CandidateIdentifierRoute,
@@ -27,6 +28,7 @@ from app.domain.references.models.models import (
     Reference,
     ReferenceDuplicateDecision,
     ReferenceDuplicateDeterminationResult,
+    RetrievalPolicyName,
 )
 from app.domain.references.models.projections import (
     CandidateReferenceProjection,
@@ -34,6 +36,7 @@ from app.domain.references.models.projections import (
 )
 from app.domain.references.models.retrieval_policy import (
     RetrievalPolicy,
+    YearStrategy,
     resolve_retrieval_policy,
 )
 from app.domain.references.services.anti_corruption_service import (
@@ -42,6 +45,7 @@ from app.domain.references.services.anti_corruption_service import (
 from app.domain.service import GenericService
 from app.persistence.es.uow import AsyncESUnitOfWork
 from app.persistence.sql.uow import AsyncSqlUnitOfWork
+from app.utils.regex import UNICODE_LETTER_PATTERN, is_meaningful_token
 
 logger = get_logger(__name__)
 settings = get_settings()
@@ -55,6 +59,78 @@ _UNIONABLE_IDENTIFIER_TYPES = frozenset(
         ExternalIdentifierType.OPEN_ALEX,
     }
 )
+
+
+def _candidate_author_terms(
+    authors: list[str], *, scoring_config: DedupCandidateScoringConfig
+) -> tuple[str, ...]:
+    """Return bounded, deduplicated author terms for candidate retrieval."""
+    queries: list[str] = []
+    seen_terms: set[str] = set()
+    for author in authors:
+        tokens = [
+            token
+            for token in UNICODE_LETTER_PATTERN.findall(author)
+            if is_meaningful_token(token, scoring_config.min_author_token_length)
+        ]
+        if not tokens:
+            continue
+
+        terms = " ".join(tokens)
+        if terms in seen_terms:
+            continue
+
+        seen_terms.add(terms)
+        queries.append(terms)
+        if len(queries) >= scoring_config.max_author_clauses:
+            break
+
+    return tuple(queries)
+
+
+def build_candidate_canonical_search_query(
+    search_fields: CandidateCanonicalSearchFields,
+    *,
+    scoring_config: DedupCandidateScoringConfig,
+    policy: RetrievalPolicy,
+    reference_id: UUID | None,
+) -> CandidateCanonicalSearchQuery:
+    """Interpret a retrieval policy as a service-owned search specification."""
+    if not search_fields.title:
+        msg = "Candidate retrieval requires a title."
+        raise DeduplicationValueError(msg)
+
+    match policy.year_strategy:
+        case YearStrategy.HARD_WINDOW:
+            publication_year_range = (
+                (
+                    search_fields.publication_year - 1,
+                    search_fields.publication_year + 1,
+                )
+                if search_fields.publication_year
+                else None
+            )
+        case YearStrategy.NO_FILTER:
+            publication_year_range = None
+        case _:  # pragma: no cover - exhaustiveness guard
+            assert_never(policy.year_strategy)
+
+    return CandidateCanonicalSearchQuery(
+        title=search_fields.title,
+        title_fuzziness="AUTO",
+        title_boost=2.0,
+        title_operator="or",
+        title_minimum_should_match="50%",
+        author_terms=_candidate_author_terms(
+            search_fields.authors, scoring_config=scoring_config
+        ),
+        # The best-matching author dominates; additional matches add 10% each.
+        author_tie_breaker=0.1,
+        publication_year_range=publication_year_range,
+        # Prevent concurrently deduplicated references forming conflicting links.
+        duplicate_determination=DuplicateDetermination.CANONICAL,
+        excluded_reference_id=reference_id,
+    )
 
 
 def _unsearchable_reason(
@@ -139,15 +215,18 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
         index_version = None
         if searchable:
             index_version = await self.es_uow.references.get_current_index_name()
-            es_result = await self.es_uow.references.search_for_candidate_canonicals(
+            query = build_candidate_canonical_search_query(
                 search_fields,
                 scoring_config=settings.dedup_scoring,
-                k=k,
+                policy=policy,
                 reference_id=self_id,
+            )
+            es_result = await self.es_uow.references.search_for_candidate_canonicals(
+                query,
+                k=k,
                 # The evaluation endpoint reports the exact total; the nomination
                 # path does not, so only this caller opts into the full count.
                 track_total_hits=True,
-                year_strategy=policy.year_strategy,
             )
 
         es_hits = es_result.hits if es_result else []
@@ -432,8 +511,7 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
         """
         Nominate candidate canonical references for the given decision.
 
-        This uses the search strategy in
-        :attr:`app.domain.references.repository.ReferenceESRepository.search_for_candidate_canonicals`.
+        This uses the control retrieval policy's search strategy.
 
         :param reference_duplicate_decision: The decision to find candidates for.
         :type reference_duplicate_decision: ReferenceDuplicateDecision
@@ -465,10 +543,14 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
             )
         # The candidate depth here preserves this path's historical behaviour; the
         # production K is chosen by the recall@K evaluation, not this path.
-        search_result = await self.es_uow.references.search_for_candidate_canonicals(
+        query = build_candidate_canonical_search_query(
             search_fields,
-            reference_id=reference.id,
             scoring_config=settings.dedup_scoring,
+            policy=resolve_retrieval_policy(RetrievalPolicyName.CURRENT_FUZZY_V1),
+            reference_id=reference.id,
+        )
+        search_result = await self.es_uow.references.search_for_candidate_canonicals(
+            query,
             k=10,
         )
 

--- a/app/domain/references/services/deduplication_service.py
+++ b/app/domain/references/services/deduplication_service.py
@@ -32,7 +32,10 @@ from app.domain.references.models.projections import (
     CandidateReferenceProjection,
     ReferenceSearchFieldsProjection,
 )
-from app.domain.references.models.retrieval_policy import resolve_retrieval_policy
+from app.domain.references.models.retrieval_policy import (
+    RetrievalPolicy,
+    resolve_retrieval_policy,
+)
 from app.domain.references.services.anti_corruption_service import (
     ReferenceAntiCorruptionService,
 )
@@ -54,21 +57,38 @@ _UNIONABLE_IDENTIFIER_TYPES = frozenset(
 )
 
 
-def _unsearchable_reason(search_fields: CandidateCanonicalSearchFields) -> str:
-    """Explain which Elasticsearch search fields are absent."""
-    missing = [
-        name
-        for name, value in (
-            ("title", search_fields.title),
-            ("authors", search_fields.authors),
-            ("publication_year", search_fields.publication_year),
-        )
-        if not value
+def _unsearchable_reason(
+    search_fields: CandidateCanonicalSearchFields, policy: RetrievalPolicy
+) -> str:
+    """Explain which Elasticsearch search fields are absent, per policy."""
+    checks: list[tuple[str, object]] = [
+        ("title", search_fields.title),
+        ("authors", search_fields.authors),
     ]
+    if policy.requires_publication_year:
+        checks.append(("publication_year", search_fields.publication_year))
+    missing = [name for name, value in checks if not value]
     return (
         f"Not searchable via Elasticsearch (missing: {', '.join(missing)}); "
         "exact identifier matches, if any, are still returned."
     )
+
+
+def _searchability_reason(
+    search_fields: CandidateCanonicalSearchFields,
+    policy: RetrievalPolicy,
+    *,
+    searchable: bool,
+) -> str:
+    """Reason string separating year-absent-but-permitted from ordinary cases."""
+    if not searchable:
+        return _unsearchable_reason(search_fields, policy)
+    if search_fields.publication_year is None:
+        return (
+            f"searchable: publication_year absent, not required by "
+            f"policy '{policy.name}'"
+        )
+    return "ok"
 
 
 class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
@@ -114,7 +134,7 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
 
         # The ES candidate query and its index-version stamp are only meaningful for
         # searchable inputs.
-        searchable = search_fields.is_searchable
+        searchable = policy.is_input_searchable(search_fields)
         es_result = None
         index_version = None
         if searchable:
@@ -185,7 +205,9 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
             k_requested=k,
             input_searchability=InputSearchability(
                 searchable=searchable,
-                reason="ok" if searchable else _unsearchable_reason(search_fields),
+                reason=_searchability_reason(
+                    search_fields, policy, searchable=searchable
+                ),
             ),
             diagnostics=CandidateSelectionDiagnostics(
                 es_took_ms=es_result.took_ms if es_result else None,

--- a/app/domain/references/services/deduplication_service.py
+++ b/app/domain/references/services/deduplication_service.py
@@ -127,6 +127,7 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
                 # The evaluation endpoint reports the exact total; the nomination
                 # path does not, so only this caller opts into the full count.
                 track_total_hits=True,
+                year_strategy=policy.year_strategy,
             )
 
         es_hits = es_result.hits if es_result else []

--- a/tests/e2e/imports/test_candidate_selection.py
+++ b/tests/e2e/imports/test_candidate_selection.py
@@ -237,6 +237,35 @@ async def test_candidates_invalid_identifier_returns_422(
     assert response.status_code == 422
 
 
+async def test_candidates_rejects_removed_include_identifier_matches(
+    destiny_client_v1: httpx.AsyncClient,
+):
+    """The retired include_identifier_matches flag is now an unknown field (422)."""
+    response = await destiny_client_v1.post(
+        CANDIDATES_URL,
+        json={
+            "input": {"title": "t", "authors": ["a"], "publication_year": 2020},
+            "include_identifier_matches": False,
+        },
+    )
+    assert response.status_code == 422
+
+
+async def test_candidates_unknown_retrieval_policy_returns_422(
+    destiny_client_v1: httpx.AsyncClient,
+):
+    """An unknown retrieval_policy surfaces a helpful 422."""
+    response = await destiny_client_v1.post(
+        CANDIDATES_URL,
+        json={
+            "input": {"title": "t", "authors": ["a"], "publication_year": 2020},
+            "retrieval_policy": "no_such_policy",
+        },
+    )
+    assert response.status_code == 422
+    assert "no_such_policy" in response.text
+
+
 async def test_candidates_rejects_both_and_neither_inputs(
     destiny_client_v1: httpx.AsyncClient,
 ):

--- a/tests/e2e/imports/test_candidate_selection.py
+++ b/tests/e2e/imports/test_candidate_selection.py
@@ -222,6 +222,26 @@ async def test_candidates_unsearchable_returns_empty_200(
     assert body["candidates"] == []
 
 
+async def test_candidates_year_optional_policy_admits_missing_year(
+    destiny_client_v1: httpx.AsyncClient,
+):
+    """The year-optional policy admits a title+authors input that lacks a year."""
+    payload = {"input": {"title": "A title without a year", "authors": ["Jane Doe"]}}
+
+    default = await destiny_client_v1.post(CANDIDATES_URL, json=payload)
+    assert default.status_code == 200
+    assert default.json()["input_searchability"]["searchable"] is False
+
+    year_optional = await destiny_client_v1.post(
+        CANDIDATES_URL,
+        json={**payload, "retrieval_policy": "no_year_filter_year_optional_v1"},
+    )
+    assert year_optional.status_code == 200
+    body = year_optional.json()
+    assert body["input_searchability"]["searchable"] is True
+    assert body["retrieval_policy"] == "no_year_filter_year_optional_v1"
+
+
 async def test_candidates_invalid_identifier_returns_422(
     destiny_client_v1: httpx.AsyncClient,
 ):

--- a/tests/integration/test_es_references.py
+++ b/tests/integration/test_es_references.py
@@ -20,15 +20,19 @@ from app.domain.references.models.models import (
     Reference,
     ReferenceSearchProjection,
     ReferenceWithChangeset,
+    RetrievalPolicyName,
     RobotAutomation,
 )
 from app.domain.references.models.projections import (
     ReferenceSearchFieldsProjection,
 )
-from app.domain.references.models.retrieval_policy import YearStrategy
+from app.domain.references.models.retrieval_policy import resolve_retrieval_policy
 from app.domain.references.repository import (
     ReferenceESRepository,
     RobotAutomationESRepository,
+)
+from app.domain.references.services.deduplication_service import (
+    build_candidate_canonical_search_query,
 )
 from app.utils.time_and_date import utc_now
 from tests.factories import to_indexable
@@ -652,10 +656,14 @@ async def test_canonical_candidate_search(
     )
 
     # Test the search_for_candidate_canonicals method
-    results = await es_reference_repository.search_for_candidate_canonicals(
-        search_fields=matching_search_fields,
-        reference_id=matching_ref1.id,
+    matching_query = build_candidate_canonical_search_query(
+        matching_search_fields,
         scoring_config=DedupCandidateScoringConfig(),
+        policy=resolve_retrieval_policy(RetrievalPolicyName.CURRENT_FUZZY_V1),
+        reference_id=matching_ref1.id,
+    )
+    results = await es_reference_repository.search_for_candidate_canonicals(
+        matching_query,
         k=100,
     )
 
@@ -669,10 +677,14 @@ async def test_canonical_candidate_search(
         )
     )
 
-    results = await es_reference_repository.search_for_candidate_canonicals(
+    non_matching_query = build_candidate_canonical_search_query(
         non_matching_search_fields,
-        reference_id=non_matching_ref.id,
         scoring_config=DedupCandidateScoringConfig(),
+        policy=resolve_retrieval_policy(RetrievalPolicyName.CURRENT_FUZZY_V1),
+        reference_id=non_matching_ref.id,
+    )
+    results = await es_reference_repository.search_for_candidate_canonicals(
+        non_matching_query,
         k=100,
     )
     assert not results.hits
@@ -729,19 +741,25 @@ async def test_no_year_filter_returns_year_drifted_candidate(
         ReferenceSearchFieldsProjection.get_canonical_candidate_search_fields(query_ref)
     )
 
-    hard = await es_reference_repository.search_for_candidate_canonicals(
+    hard_query = build_candidate_canonical_search_query(
         search_fields,
         scoring_config=DedupCandidateScoringConfig(),
-        k=100,
+        policy=resolve_retrieval_policy(RetrievalPolicyName.CURRENT_FUZZY_V1),
         reference_id=query_ref.id,
-        year_strategy=YearStrategy.HARD_WINDOW,
+    )
+    unfiltered_query = build_candidate_canonical_search_query(
+        search_fields,
+        scoring_config=DedupCandidateScoringConfig(),
+        policy=resolve_retrieval_policy(RetrievalPolicyName.NO_YEAR_FILTER_V1),
+        reference_id=query_ref.id,
+    )
+    hard = await es_reference_repository.search_for_candidate_canonicals(
+        hard_query,
+        k=100,
     )
     unfiltered = await es_reference_repository.search_for_candidate_canonicals(
-        search_fields,
-        scoring_config=DedupCandidateScoringConfig(),
+        unfiltered_query,
         k=100,
-        reference_id=query_ref.id,
-        year_strategy=YearStrategy.NO_FILTER,
     )
 
     hard_ids = {hit.id for hit in hard.hits}

--- a/tests/integration/test_es_references.py
+++ b/tests/integration/test_es_references.py
@@ -25,6 +25,7 @@ from app.domain.references.models.models import (
 from app.domain.references.models.projections import (
     ReferenceSearchFieldsProjection,
 )
+from app.domain.references.models.retrieval_policy import YearStrategy
 from app.domain.references.repository import (
     ReferenceESRepository,
     RobotAutomationESRepository,
@@ -675,3 +676,77 @@ async def test_canonical_candidate_search(
         k=100,
     )
     assert not results.hits
+
+
+async def test_no_year_filter_returns_year_drifted_candidate(
+    es_reference_repository: ReferenceESRepository, reference: Reference
+):
+    """NO_FILTER drops the ±1 year gate: a 10-year-drifted duplicate is returned."""
+
+    def _with_biblio(ref_id: object, year: int) -> Reference:
+        return reference.model_copy(
+            update={
+                "id": ref_id,
+                "enhancements": [
+                    enhancement.model_copy(
+                        update={
+                            "id": uuid7(),
+                            "reference_id": ref_id,
+                            "content": (
+                                enhancement.content.model_copy(
+                                    update={
+                                        "title": "Shared Drifted Title",
+                                        "authorship": [
+                                            Authorship(
+                                                display_name="Jane Smith",
+                                                position=AuthorPosition.FIRST,
+                                            )
+                                        ],
+                                        "publication_year": year,
+                                    }
+                                )
+                                if enhancement.content.enhancement_type
+                                == EnhancementType.BIBLIOGRAPHIC
+                                else enhancement.content
+                            ),
+                        }
+                    )
+                    for enhancement in (reference.enhancements or [])
+                ],
+            }
+        )
+
+    query_ref = _with_biblio(uuid7(), 2000)
+    drifted_target = _with_biblio(uuid7(), 2010)
+
+    await es_reference_repository.add(to_indexable(query_ref))
+    await es_reference_repository.add(to_indexable(drifted_target))
+    await es_reference_repository._client.indices.refresh(  # noqa: SLF001
+        index=es_reference_repository._persistence_cls.Index.name  # noqa: SLF001
+    )
+
+    search_fields = (
+        ReferenceSearchFieldsProjection.get_canonical_candidate_search_fields(query_ref)
+    )
+
+    hard = await es_reference_repository.search_for_candidate_canonicals(
+        search_fields,
+        scoring_config=DedupCandidateScoringConfig(),
+        k=100,
+        reference_id=query_ref.id,
+        year_strategy=YearStrategy.HARD_WINDOW,
+    )
+    unfiltered = await es_reference_repository.search_for_candidate_canonicals(
+        search_fields,
+        scoring_config=DedupCandidateScoringConfig(),
+        k=100,
+        reference_id=query_ref.id,
+        year_strategy=YearStrategy.NO_FILTER,
+    )
+
+    hard_ids = {hit.id for hit in hard.hits}
+    unfiltered_ids = {hit.id for hit in unfiltered.hits}
+    assert drifted_target.id not in hard_ids
+    assert drifted_target.id in unfiltered_ids
+    # Tiny index: removing the year gate strictly widens eligibility.
+    assert unfiltered.total.value >= hard.total.value

--- a/tests/unit/domain/references/deduplication/test_candidate_search.py
+++ b/tests/unit/domain/references/deduplication/test_candidate_search.py
@@ -1,56 +1,42 @@
-# ruff: noqa: SLF001
-"""Tests for ReferenceESRepository._build_author_dis_max_query."""
+"""Tests for service-side candidate author-query construction."""
 
 from app.core.config import DedupCandidateScoringConfig
-from app.domain.references.repository import ReferenceESRepository
+from app.domain.references.services.deduplication_service import (
+    _candidate_author_terms,
+)
 
 _CONFIG_DEFAULTS = DedupCandidateScoringConfig()
 
-_DEFAULTS = {
-    "max_clauses": _CONFIG_DEFAULTS.max_author_clauses,
-    "min_token_length": _CONFIG_DEFAULTS.min_author_token_length,
-}
+
+def _queries(
+    authors: list[str],
+    *,
+    max_clauses: int = _CONFIG_DEFAULTS.max_author_clauses,
+    min_token_length: int = _CONFIG_DEFAULTS.min_author_token_length,
+) -> tuple[str, ...]:
+    config = DedupCandidateScoringConfig(
+        max_author_clauses=max_clauses,
+        min_author_token_length=min_token_length,
+    )
+    return _candidate_author_terms(authors, scoring_config=config)
 
 
-def _dis_max(result):
-    """Extract the dis_max dict from a Q object."""
-    return result.to_dict()["dis_max"]
-
-
-class TestBuildAuthorDisMaxQuery:
+class TestBuildCandidateAuthorQueries:
     def test_empty_authors(self):
-        assert (
-            ReferenceESRepository._build_author_dis_max_query([], **_DEFAULTS) is None
-        )
+        assert _queries([]) == ()
 
     def test_single_author(self):
-        result = ReferenceESRepository._build_author_dis_max_query(
-            ["George Harrison"], **_DEFAULTS
-        )
-        assert result is not None
-        queries = _dis_max(result)["queries"]
-        assert len(queries) == 1
-        assert "authors" in queries[0]["match"]
+        assert _queries(["George Harrison"]) == ("George Harrison",)
 
     def test_multiple_authors(self):
-        result = ReferenceESRepository._build_author_dis_max_query(
-            ["George Harrison", "Ringo Starr", "Paul McCartney"], **_DEFAULTS
-        )
-        assert result is not None
-        assert len(_dis_max(result)["queries"]) == 3
+        assert len(_queries(["George Harrison", "Ringo Starr", "Paul McCartney"])) == 3
 
     def test_max_clauses_limits_queries(self):
         alphabet = "abcdefghijklmnopqrstuvwxyz"
         authors = [
             f"Author {alphabet[i]}{alphabet[j]}" for i in range(5) for j in range(6)
         ]
-        result = ReferenceESRepository._build_author_dis_max_query(
-            authors,
-            max_clauses=10,
-            min_token_length=_CONFIG_DEFAULTS.min_author_token_length,
-        )
-        assert result is not None
-        assert len(_dis_max(result)["queries"]) == 10
+        assert len(_queries(authors, max_clauses=10)) == 10
 
     def test_large_author_list_caps_at_default(self):
         """200 authors still produces a query, capped at the default max_clauses."""
@@ -58,82 +44,38 @@ class TestBuildAuthorDisMaxQuery:
         authors = [
             f"Author {alphabet[i]}{alphabet[j]}" for i in range(8) for j in range(26)
         ][:200]
-        result = ReferenceESRepository._build_author_dis_max_query(authors, **_DEFAULTS)
-        assert result is not None
-        assert len(_dis_max(result)["queries"]) == _CONFIG_DEFAULTS.max_author_clauses
+        assert len(_queries(authors)) == _CONFIG_DEFAULTS.max_author_clauses
 
     def test_filters_single_letter_initials(self):
-        result = ReferenceESRepository._build_author_dis_max_query(
-            ["G Harrison"], **_DEFAULTS
-        )
-        assert result is not None
-        match_value = _dis_max(result)["queries"][0]["match"]["authors"]
+        match_value = _queries(["G Harrison"])[0]
         assert "harrison" in match_value.lower()
         assert "g" not in match_value.lower().split()
 
     def test_author_with_only_initials_excluded(self):
-        assert (
-            ReferenceESRepository._build_author_dis_max_query(["J S"], **_DEFAULTS)
-            is None
-        )
-        assert (
-            ReferenceESRepository._build_author_dis_max_query(["É D"], **_DEFAULTS)
-            is None
-        )
+        assert _queries(["J S"]) == ()
+        assert _queries(["É D"]) == ()
 
     def test_mixed_authors_some_filtered(self):
         """Only authors with meaningful tokens produce clauses."""
-        result = ReferenceESRepository._build_author_dis_max_query(
-            ["G H", "Ringo Starr", "P M"], **_DEFAULTS
-        )
-        assert result is not None
-        assert len(_dis_max(result)["queries"]) == 1
+        assert _queries(["G H", "Ringo Starr", "P M"]) == ("Ringo Starr",)
 
     def test_max_clauses_skips_invalid_authors(self):
-        result = ReferenceESRepository._build_author_dis_max_query(
-            ["G H", "Ringo Starr"],
-            max_clauses=1,
-            min_token_length=_CONFIG_DEFAULTS.min_author_token_length,
-        )
-        assert result is not None
-        assert len(_dis_max(result)["queries"]) == 1
+        assert _queries(["G H", "Ringo Starr"], max_clauses=1) == ("Ringo Starr",)
 
     def test_min_token_length_custom(self):
-        # "Ringo" and "Starr" are both 5 chars
-        assert (
-            ReferenceESRepository._build_author_dis_max_query(
-                ["Ringo Starr"],
-                max_clauses=_CONFIG_DEFAULTS.max_author_clauses,
-                min_token_length=6,
-            )
-            is None
-        )
-        assert (
-            ReferenceESRepository._build_author_dis_max_query(
-                ["Ringo Starr"],
-                max_clauses=_CONFIG_DEFAULTS.max_author_clauses,
-                min_token_length=5,
-            )
-            is not None
-        )
+        # "John" and "Paul" are both 4 chars.
+        assert _queries(["John Paul"], min_token_length=5) == ()
+        assert _queries(["John Paul"], min_token_length=4) == ("John Paul",)
 
     def test_preserves_meaningful_tokens(self):
-        result = ReferenceESRepository._build_author_dis_max_query(
-            ["George Harrison"], **_DEFAULTS
-        )
-        assert result is not None
-        match_value = _dis_max(result)["queries"][0]["match"]["authors"]
+        match_value = _queries(["George Harrison"])[0]
         assert "George" in match_value
         assert "Harrison" in match_value
 
     def test_preserves_non_ascii_tokens(self):
-        result = ReferenceESRepository._build_author_dis_max_query(
-            ["José Álvarez", "李 雷"], **_DEFAULTS
-        )
-        assert result is not None
-        queries = _dis_max(result)["queries"]
+        queries = _queries(["José Álvarez", "李 雷"])
         assert len(queries) == 2
-        assert "José" in queries[0]["match"]["authors"]
-        assert "Álvarez" in queries[0]["match"]["authors"]
-        assert "李" in queries[1]["match"]["authors"]
-        assert "雷" in queries[1]["match"]["authors"]
+        assert "José" in queries[0]
+        assert "Álvarez" in queries[0]
+        assert "李" in queries[1]
+        assert "雷" in queries[1]

--- a/tests/unit/domain/references/deduplication/test_candidate_selection.py
+++ b/tests/unit/domain/references/deduplication/test_candidate_selection.py
@@ -217,6 +217,41 @@ async def test_no_year_filter_v1_passes_strategy_and_stamps_policy(build_service
 
 
 @pytest.mark.asyncio
+async def test_year_optional_policy_searches_missing_year_input(build_service):
+    service, es_refs, _, _ = build_service(
+        es_result=_es_result(ESScoreResult(id=uuid7(), score=4.0))
+    )
+
+    result = await service.get_deduplication_candidates(
+        CandidateSelectionRequest(
+            input=CandidateSelectionInput(title="t", authors=["a"]),  # no year
+            retrieval_policy="no_year_filter_year_optional_v1",
+            hydrate=False,
+        )
+    )
+
+    assert result.input_searchability.searchable is True
+    es_refs.search_for_candidate_canonicals.assert_awaited_once()
+    _, kwargs = es_refs.search_for_candidate_canonicals.call_args
+    assert kwargs["year_strategy"] is YearStrategy.NO_FILTER
+
+
+@pytest.mark.asyncio
+async def test_missing_year_input_unsearchable_under_control(build_service):
+    service, es_refs, _, _ = build_service()
+
+    result = await service.get_deduplication_candidates(
+        CandidateSelectionRequest(
+            input=CandidateSelectionInput(title="t", authors=["a"]),  # no year
+            retrieval_policy="current_fuzzy_v1",
+        )
+    )
+
+    assert result.input_searchability.searchable is False
+    es_refs.search_for_candidate_canonicals.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_inline_input_returns_ranked_es_candidates(build_service):
     id1, id2 = uuid7(), uuid7()
     es_result = _es_result(

--- a/tests/unit/domain/references/deduplication/test_candidate_selection.py
+++ b/tests/unit/domain/references/deduplication/test_candidate_selection.py
@@ -9,7 +9,6 @@ from pydantic import ValidationError
 
 from app.core.exceptions import DeduplicationValueError
 from app.domain.references.models.models import (
-    CURRENT_FUZZY_RETRIEVAL_POLICY,
     CandidateElasticsearchRoute,
     CandidateIdentifier,
     CandidateSelectionInput,
@@ -18,6 +17,7 @@ from app.domain.references.models.models import (
     ExternalIdentifierType,
     Reference,
     ReferenceDuplicateDecision,
+    RetrievalPolicyName,
 )
 from app.domain.references.models.retrieval_policy import YearStrategy
 from app.domain.references.service import ReferenceService
@@ -172,17 +172,14 @@ class TestCandidateSelectionInputValidation:
             )
 
 
-@pytest.mark.asyncio
-async def test_unknown_retrieval_policy_raises(build_service):
-    service, _, _, _ = build_service()
-    with pytest.raises(DeduplicationValueError):
-        await service.get_deduplication_candidates(
-            CandidateSelectionRequest(
-                input=CandidateSelectionInput(
-                    title="t", authors=["a"], publication_year=2020
-                ),
-                retrieval_policy="no_such_policy",
-            )
+def test_unknown_retrieval_policy_rejected_by_request_model():
+    """An unknown policy is rejected when the request is built (a 422 at the API)."""
+    with pytest.raises(ValidationError):
+        CandidateSelectionRequest(
+            input=CandidateSelectionInput(
+                title="t", authors=["a"], publication_year=2020
+            ),
+            retrieval_policy="no_such_policy",  # type: ignore[arg-type]
         )
 
 
@@ -198,14 +195,14 @@ async def test_no_year_filter_v1_passes_strategy_and_stamps_policy(build_service
             input=CandidateSelectionInput(
                 title="t", authors=["a"], publication_year=2020
             ),
-            retrieval_policy="no_year_filter_v1",
+            retrieval_policy=RetrievalPolicyName.NO_YEAR_FILTER_V1,
             hydrate=False,
         )
     )
 
     _, kwargs = es_refs.search_for_candidate_canonicals.call_args
     assert kwargs["year_strategy"] is YearStrategy.NO_FILTER
-    assert result.retrieval_policy == "no_year_filter_v1"
+    assert result.retrieval_policy == RetrievalPolicyName.NO_YEAR_FILTER_V1
     es_route_policies = [
         route.policy
         for candidate in result.candidates
@@ -225,7 +222,7 @@ async def test_year_optional_policy_searches_missing_year_input(build_service):
     result = await service.get_deduplication_candidates(
         CandidateSelectionRequest(
             input=CandidateSelectionInput(title="t", authors=["a"]),  # no year
-            retrieval_policy="no_year_filter_year_optional_v1",
+            retrieval_policy=RetrievalPolicyName.NO_YEAR_FILTER_YEAR_OPTIONAL_V1,
             hydrate=False,
         )
     )
@@ -243,7 +240,7 @@ async def test_missing_year_input_unsearchable_under_control(build_service):
     result = await service.get_deduplication_candidates(
         CandidateSelectionRequest(
             input=CandidateSelectionInput(title="t", authors=["a"]),  # no year
-            retrieval_policy="current_fuzzy_v1",
+            retrieval_policy=RetrievalPolicyName.CURRENT_FUZZY_V1,
         )
     )
 
@@ -268,7 +265,7 @@ async def test_inline_input_returns_ranked_es_candidates(build_service):
         )
     )
 
-    assert result.retrieval_policy == CURRENT_FUZZY_RETRIEVAL_POLICY
+    assert result.retrieval_policy == RetrievalPolicyName.CURRENT_FUZZY_V1
     assert result.index_version == "reference_v3"
     assert result.input_searchability.searchable is True
     assert [c.reference_id for c in result.candidates] == [id1, id2]

--- a/tests/unit/domain/references/deduplication/test_candidate_selection.py
+++ b/tests/unit/domain/references/deduplication/test_candidate_selection.py
@@ -143,6 +143,46 @@ class TestCandidateSelectionInputValidation:
                 input=CandidateSelectionInput(reference_id=uuid7()), k=1001
             )
 
+    def test_rejects_removed_include_identifier_matches(self):
+        with pytest.raises(ValidationError):
+            CandidateSelectionRequest.model_validate(
+                {
+                    "input": {
+                        "title": "t",
+                        "authors": ["a"],
+                        "publication_year": 2020,
+                    },
+                    "include_identifier_matches": False,
+                }
+            )
+
+    def test_rejects_unknown_field(self):
+        with pytest.raises(ValidationError):
+            CandidateSelectionRequest.model_validate(
+                {
+                    "input": {
+                        "title": "t",
+                        "authors": ["a"],
+                        "publication_year": 2020,
+                    },
+                    "not_a_real_field": 1,
+                }
+            )
+
+
+@pytest.mark.asyncio
+async def test_unknown_retrieval_policy_raises(build_service):
+    service, _, _, _ = build_service()
+    with pytest.raises(DeduplicationValueError):
+        await service.get_deduplication_candidates(
+            CandidateSelectionRequest(
+                input=CandidateSelectionInput(
+                    title="t", authors=["a"], publication_year=2020
+                ),
+                retrieval_policy="no_such_policy",
+            )
+        )
+
 
 @pytest.mark.asyncio
 async def test_inline_input_returns_ranked_es_candidates(build_service):
@@ -157,7 +197,6 @@ async def test_inline_input_returns_ranked_es_candidates(build_service):
             input=CandidateSelectionInput(
                 title="A study", authors=["Jane Doe"], publication_year=2025
             ),
-            include_identifier_matches=False,
             hydrate=False,
         )
     )
@@ -189,7 +228,6 @@ async def test_reference_id_input_self_excludes_and_defaults_k(build_service):
     result = await service.get_deduplication_candidates(
         CandidateSelectionRequest(
             input=CandidateSelectionInput(reference_id=reference.id),
-            include_identifier_matches=False,
             hydrate=False,
         )
     )
@@ -212,7 +250,6 @@ async def test_k_override_passed_to_es(build_service):
                 title="A study", authors=["Jane Doe"], publication_year=2025
             ),
             k=25,
-            include_identifier_matches=False,
             hydrate=False,
         )
     )
@@ -326,7 +363,6 @@ async def test_hydrate_includes_reference_projection(build_service):
             input=CandidateSelectionInput(
                 title="A study", authors=["Jane Doe"], publication_year=2025
             ),
-            include_identifier_matches=False,
             hydrate=True,
         )
     )
@@ -423,7 +459,6 @@ async def test_writes_no_duplicate_decision_state(build_service):
             input=CandidateSelectionInput(
                 title="A study", authors=["Jane Doe"], publication_year=2025
             ),
-            include_identifier_matches=False,
             hydrate=False,
         )
     )

--- a/tests/unit/domain/references/deduplication/test_candidate_selection.py
+++ b/tests/unit/domain/references/deduplication/test_candidate_selection.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 from app.core.exceptions import DeduplicationValueError
 from app.domain.references.models.models import (
     CURRENT_FUZZY_RETRIEVAL_POLICY,
+    CandidateElasticsearchRoute,
     CandidateIdentifier,
     CandidateSelectionInput,
     CandidateSelectionRequest,
@@ -18,6 +19,7 @@ from app.domain.references.models.models import (
     Reference,
     ReferenceDuplicateDecision,
 )
+from app.domain.references.models.retrieval_policy import YearStrategy
 from app.domain.references.service import ReferenceService
 from app.domain.references.services.anti_corruption_service import (
     ReferenceAntiCorruptionService,
@@ -182,6 +184,36 @@ async def test_unknown_retrieval_policy_raises(build_service):
                 retrieval_policy="no_such_policy",
             )
         )
+
+
+@pytest.mark.asyncio
+async def test_no_year_filter_v1_passes_strategy_and_stamps_policy(build_service):
+    hit = uuid7()
+    service, es_refs, _, _ = build_service(
+        es_result=_es_result(ESScoreResult(id=hit, score=5.0))
+    )
+
+    result = await service.get_deduplication_candidates(
+        CandidateSelectionRequest(
+            input=CandidateSelectionInput(
+                title="t", authors=["a"], publication_year=2020
+            ),
+            retrieval_policy="no_year_filter_v1",
+            hydrate=False,
+        )
+    )
+
+    _, kwargs = es_refs.search_for_candidate_canonicals.call_args
+    assert kwargs["year_strategy"] is YearStrategy.NO_FILTER
+    assert result.retrieval_policy == "no_year_filter_v1"
+    es_route_policies = [
+        route.policy
+        for candidate in result.candidates
+        for route in candidate.routes
+        if isinstance(route, CandidateElasticsearchRoute)
+    ]
+    assert es_route_policies
+    assert all(p == "no_year_filter_v1" for p in es_route_policies)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/domain/references/deduplication/test_candidate_selection.py
+++ b/tests/unit/domain/references/deduplication/test_candidate_selection.py
@@ -19,7 +19,6 @@ from app.domain.references.models.models import (
     ReferenceDuplicateDecision,
     RetrievalPolicyName,
 )
-from app.domain.references.models.retrieval_policy import YearStrategy
 from app.domain.references.service import ReferenceService
 from app.domain.references.services.anti_corruption_service import (
     ReferenceAntiCorruptionService,
@@ -200,8 +199,8 @@ async def test_no_year_filter_v1_passes_strategy_and_stamps_policy(build_service
         )
     )
 
-    _, kwargs = es_refs.search_for_candidate_canonicals.call_args
-    assert kwargs["year_strategy"] is YearStrategy.NO_FILTER
+    query = es_refs.search_for_candidate_canonicals.call_args.args[0]
+    assert query.publication_year_range is None
     assert result.retrieval_policy == RetrievalPolicyName.NO_YEAR_FILTER_V1
     es_route_policies = [
         route.policy
@@ -229,8 +228,8 @@ async def test_year_optional_policy_searches_missing_year_input(build_service):
 
     assert result.input_searchability.searchable is True
     es_refs.search_for_candidate_canonicals.assert_awaited_once()
-    _, kwargs = es_refs.search_for_candidate_canonicals.call_args
-    assert kwargs["year_strategy"] is YearStrategy.NO_FILTER
+    query = es_refs.search_for_candidate_canonicals.call_args.args[0]
+    assert query.publication_year_range is None
 
 
 @pytest.mark.asyncio
@@ -297,8 +296,9 @@ async def test_reference_id_input_self_excludes_and_defaults_k(build_service):
     )
 
     sql_refs.get_by_pk.assert_awaited_once()
-    _, kwargs = es_refs.search_for_candidate_canonicals.call_args
-    assert kwargs["reference_id"] == reference.id
+    query = es_refs.search_for_candidate_canonicals.call_args.args[0]
+    kwargs = es_refs.search_for_candidate_canonicals.call_args.kwargs
+    assert query.excluded_reference_id == reference.id
     assert kwargs["k"] == 100  # configured default
     assert result.k_requested == 100
     assert [c.reference_id for c in result.candidates] == [hit]

--- a/tests/unit/domain/references/models/test_retrieval_policy.py
+++ b/tests/unit/domain/references/models/test_retrieval_policy.py
@@ -1,0 +1,43 @@
+"""Tests for the candidate-retrieval policy registry."""
+
+import pytest
+from pydantic import ValidationError
+
+from app.core.exceptions import DeduplicationValueError
+from app.domain.references.models.models import CURRENT_FUZZY_RETRIEVAL_POLICY
+from app.domain.references.models.retrieval_policy import (
+    RETRIEVAL_POLICIES,
+    YearStrategy,
+    resolve_retrieval_policy,
+)
+
+
+def test_resolve_returns_current_fuzzy_v1_regime():
+    policy = resolve_retrieval_policy(CURRENT_FUZZY_RETRIEVAL_POLICY)
+    assert policy.name == CURRENT_FUZZY_RETRIEVAL_POLICY
+    assert policy.union_identifiers is True
+    assert policy.year_strategy is YearStrategy.HARD_WINDOW
+
+
+def test_resolve_unknown_policy_raises():
+    with pytest.raises(DeduplicationValueError) as exc:
+        resolve_retrieval_policy("does_not_exist")
+    assert "does_not_exist" in str(exc.value)
+    assert CURRENT_FUZZY_RETRIEVAL_POLICY in str(exc.value)
+
+
+def test_current_fuzzy_v1_is_registered():
+    assert CURRENT_FUZZY_RETRIEVAL_POLICY in RETRIEVAL_POLICIES
+
+
+def test_policy_is_immutable():
+    policy = resolve_retrieval_policy(CURRENT_FUZZY_RETRIEVAL_POLICY)
+    with pytest.raises(ValidationError):
+        policy.union_identifiers = False
+
+
+def test_registry_is_read_only():
+    with pytest.raises(TypeError):
+        RETRIEVAL_POLICIES["injected"] = resolve_retrieval_policy(
+            CURRENT_FUZZY_RETRIEVAL_POLICY
+        )

--- a/tests/unit/domain/references/models/test_retrieval_policy.py
+++ b/tests/unit/domain/references/models/test_retrieval_policy.py
@@ -19,6 +19,13 @@ def test_resolve_returns_current_fuzzy_v1_regime():
     assert policy.year_strategy is YearStrategy.HARD_WINDOW
 
 
+def test_no_year_filter_v1_regime():
+    policy = resolve_retrieval_policy("no_year_filter_v1")
+    assert policy.name == "no_year_filter_v1"
+    assert policy.union_identifiers is True
+    assert policy.year_strategy is YearStrategy.NO_FILTER
+
+
 def test_resolve_unknown_policy_raises():
     with pytest.raises(DeduplicationValueError) as exc:
         resolve_retrieval_policy("does_not_exist")

--- a/tests/unit/domain/references/models/test_retrieval_policy.py
+++ b/tests/unit/domain/references/models/test_retrieval_policy.py
@@ -4,7 +4,10 @@ import pytest
 from pydantic import ValidationError
 
 from app.core.exceptions import DeduplicationValueError
-from app.domain.references.models.models import CURRENT_FUZZY_RETRIEVAL_POLICY
+from app.domain.references.models.models import (
+    CURRENT_FUZZY_RETRIEVAL_POLICY,
+    CandidateCanonicalSearchFields,
+)
 from app.domain.references.models.retrieval_policy import (
     RETRIEVAL_POLICIES,
     YearStrategy,
@@ -24,6 +27,35 @@ def test_no_year_filter_v1_regime():
     assert policy.name == "no_year_filter_v1"
     assert policy.union_identifiers is True
     assert policy.year_strategy is YearStrategy.NO_FILTER
+
+
+def test_year_optional_policy_regime():
+    policy = resolve_retrieval_policy("no_year_filter_year_optional_v1")
+    assert policy.year_strategy is YearStrategy.NO_FILTER
+    assert policy.requires_publication_year is False
+
+
+def test_year_required_policies_default_true():
+    for name in (CURRENT_FUZZY_RETRIEVAL_POLICY, "no_year_filter_v1"):
+        assert resolve_retrieval_policy(name).requires_publication_year is True
+
+
+def test_is_input_searchable_year_optional_admits_missing_year():
+    fields = CandidateCanonicalSearchFields(
+        title="t", authors=["a"], publication_year=None
+    )
+    year_optional = resolve_retrieval_policy("no_year_filter_year_optional_v1")
+    year_required = resolve_retrieval_policy("no_year_filter_v1")
+    assert year_optional.is_input_searchable(fields) is True
+    assert year_required.is_input_searchable(fields) is False
+
+
+def test_is_input_searchable_requires_title_and_authors():
+    fields = CandidateCanonicalSearchFields(
+        title="t", authors=[], publication_year=2020
+    )
+    policy = resolve_retrieval_policy("no_year_filter_year_optional_v1")
+    assert policy.is_input_searchable(fields) is False
 
 
 def test_resolve_unknown_policy_raises():

--- a/tests/unit/domain/references/models/test_retrieval_policy.py
+++ b/tests/unit/domain/references/models/test_retrieval_policy.py
@@ -3,10 +3,9 @@
 import pytest
 from pydantic import ValidationError
 
-from app.core.exceptions import DeduplicationValueError
 from app.domain.references.models.models import (
-    CURRENT_FUZZY_RETRIEVAL_POLICY,
     CandidateCanonicalSearchFields,
+    RetrievalPolicyName,
 )
 from app.domain.references.models.retrieval_policy import (
     RETRIEVAL_POLICIES,
@@ -16,27 +15,32 @@ from app.domain.references.models.retrieval_policy import (
 
 
 def test_resolve_returns_current_fuzzy_v1_regime():
-    policy = resolve_retrieval_policy(CURRENT_FUZZY_RETRIEVAL_POLICY)
-    assert policy.name == CURRENT_FUZZY_RETRIEVAL_POLICY
+    policy = resolve_retrieval_policy(RetrievalPolicyName.CURRENT_FUZZY_V1)
+    assert policy.name is RetrievalPolicyName.CURRENT_FUZZY_V1
     assert policy.union_identifiers is True
     assert policy.year_strategy is YearStrategy.HARD_WINDOW
 
 
 def test_no_year_filter_v1_regime():
-    policy = resolve_retrieval_policy("no_year_filter_v1")
-    assert policy.name == "no_year_filter_v1"
+    policy = resolve_retrieval_policy(RetrievalPolicyName.NO_YEAR_FILTER_V1)
+    assert policy.name is RetrievalPolicyName.NO_YEAR_FILTER_V1
     assert policy.union_identifiers is True
     assert policy.year_strategy is YearStrategy.NO_FILTER
 
 
 def test_year_optional_policy_regime():
-    policy = resolve_retrieval_policy("no_year_filter_year_optional_v1")
+    policy = resolve_retrieval_policy(
+        RetrievalPolicyName.NO_YEAR_FILTER_YEAR_OPTIONAL_V1
+    )
     assert policy.year_strategy is YearStrategy.NO_FILTER
     assert policy.requires_publication_year is False
 
 
 def test_year_required_policies_default_true():
-    for name in (CURRENT_FUZZY_RETRIEVAL_POLICY, "no_year_filter_v1"):
+    for name in (
+        RetrievalPolicyName.CURRENT_FUZZY_V1,
+        RetrievalPolicyName.NO_YEAR_FILTER_V1,
+    ):
         assert resolve_retrieval_policy(name).requires_publication_year is True
 
 
@@ -44,8 +48,10 @@ def test_is_input_searchable_year_optional_admits_missing_year():
     fields = CandidateCanonicalSearchFields(
         title="t", authors=["a"], publication_year=None
     )
-    year_optional = resolve_retrieval_policy("no_year_filter_year_optional_v1")
-    year_required = resolve_retrieval_policy("no_year_filter_v1")
+    year_optional = resolve_retrieval_policy(
+        RetrievalPolicyName.NO_YEAR_FILTER_YEAR_OPTIONAL_V1
+    )
+    year_required = resolve_retrieval_policy(RetrievalPolicyName.NO_YEAR_FILTER_V1)
     assert year_optional.is_input_searchable(fields) is True
     assert year_required.is_input_searchable(fields) is False
 
@@ -54,7 +60,9 @@ def test_is_input_searchable_requires_title_and_authors():
     fields = CandidateCanonicalSearchFields(
         title="t", authors=[], publication_year=2020
     )
-    policy = resolve_retrieval_policy("no_year_filter_year_optional_v1")
+    policy = resolve_retrieval_policy(
+        RetrievalPolicyName.NO_YEAR_FILTER_YEAR_OPTIONAL_V1
+    )
     assert policy.is_input_searchable(fields) is False
 
 
@@ -63,24 +71,28 @@ def test_control_year_required_rejects_zero_year_matching_baseline():
     fields = CandidateCanonicalSearchFields(
         title="t", authors=["a"], publication_year=0
     )
-    control = resolve_retrieval_policy(CURRENT_FUZZY_RETRIEVAL_POLICY)
+    control = resolve_retrieval_policy(RetrievalPolicyName.CURRENT_FUZZY_V1)
     assert control.is_input_searchable(fields) is False
     assert control.is_input_searchable(fields) == fields.is_searchable
 
 
-def test_resolve_unknown_policy_raises():
-    with pytest.raises(DeduplicationValueError) as exc:
-        resolve_retrieval_policy("does_not_exist")
-    assert "does_not_exist" in str(exc.value)
-    assert CURRENT_FUZZY_RETRIEVAL_POLICY in str(exc.value)
+def test_policy_name_enum_membership():
+    """The value strings are pinned; unknown names are rejected at the boundary."""
+    assert (
+        RetrievalPolicyName("current_fuzzy_v1") is RetrievalPolicyName.CURRENT_FUZZY_V1
+    )
+    with pytest.raises(ValueError, match="does_not_exist"):
+        RetrievalPolicyName("does_not_exist")
 
 
-def test_current_fuzzy_v1_is_registered():
-    assert CURRENT_FUZZY_RETRIEVAL_POLICY in RETRIEVAL_POLICIES
+def test_every_policy_name_is_registered():
+    """Registry completeness: resolve never misses a member, so the lookup is total."""
+    for name in RetrievalPolicyName:
+        assert resolve_retrieval_policy(name).name is name
 
 
 def test_policy_is_immutable():
-    policy = resolve_retrieval_policy(CURRENT_FUZZY_RETRIEVAL_POLICY)
+    policy = resolve_retrieval_policy(RetrievalPolicyName.CURRENT_FUZZY_V1)
     with pytest.raises(ValidationError):
         policy.union_identifiers = False
 
@@ -88,5 +100,5 @@ def test_policy_is_immutable():
 def test_registry_is_read_only():
     with pytest.raises(TypeError):
         RETRIEVAL_POLICIES["injected"] = resolve_retrieval_policy(
-            CURRENT_FUZZY_RETRIEVAL_POLICY
+            RetrievalPolicyName.CURRENT_FUZZY_V1
         )

--- a/tests/unit/domain/references/models/test_retrieval_policy.py
+++ b/tests/unit/domain/references/models/test_retrieval_policy.py
@@ -58,6 +58,16 @@ def test_is_input_searchable_requires_title_and_authors():
     assert policy.is_input_searchable(fields) is False
 
 
+def test_control_year_required_rejects_zero_year_matching_baseline():
+    """A zero publication_year is 'no year': the control stays baseline-equivalent."""
+    fields = CandidateCanonicalSearchFields(
+        title="t", authors=["a"], publication_year=0
+    )
+    control = resolve_retrieval_policy(CURRENT_FUZZY_RETRIEVAL_POLICY)
+    assert control.is_input_searchable(fields) is False
+    assert control.is_input_searchable(fields) == fields.is_searchable
+
+
 def test_resolve_unknown_policy_raises():
     with pytest.raises(DeduplicationValueError) as exc:
         resolve_retrieval_policy("does_not_exist")

--- a/tests/unit/domain/references/test_candidate_query_builder.py
+++ b/tests/unit/domain/references/test_candidate_query_builder.py
@@ -1,51 +1,101 @@
 # ruff: noqa: SLF001
-"""Tests for the candidate query builder's year-clause seam.
-
-Tests exercise the repository's private query-builder helpers directly.
-"""
+"""Tests for service query construction and Elasticsearch translation."""
 
 from unittest.mock import MagicMock
+from uuid import UUID
+
+import pytest
 
 from app.core.config import DedupCandidateScoringConfig
-from app.domain.references.models.models import CandidateCanonicalSearchFields
-from app.domain.references.models.retrieval_policy import YearStrategy
+from app.core.exceptions import DeduplicationValueError
+from app.domain.references.models.models import (
+    CandidateCanonicalSearchFields,
+    DuplicateDetermination,
+    RetrievalPolicyName,
+)
+from app.domain.references.models.retrieval_policy import resolve_retrieval_policy
 from app.domain.references.repository import ReferenceESRepository
+from app.domain.references.services.deduplication_service import (
+    build_candidate_canonical_search_query,
+)
+
+
+def _query(
+    fields: CandidateCanonicalSearchFields,
+    policy_name: RetrievalPolicyName,
+    *,
+    reference_id: UUID | None = None,
+):
+    return build_candidate_canonical_search_query(
+        fields,
+        scoring_config=DedupCandidateScoringConfig(),
+        policy=resolve_retrieval_policy(policy_name),
+        reference_id=reference_id,
+    )
 
 
 def test_hard_window_builds_pm1_year_range():
-    clauses = ReferenceESRepository._year_filter_clauses(2000, YearStrategy.HARD_WINDOW)
-    assert len(clauses) == 1
-    assert clauses[0].to_dict()["range"]["publication_year"] == {
-        "gte": 1999,
-        "lte": 2001,
-    }
+    fields = CandidateCanonicalSearchFields(
+        title="Shared Title", authors=["Smith"], publication_year=2000
+    )
+    query = _query(fields, RetrievalPolicyName.CURRENT_FUZZY_V1)
+    assert query.publication_year_range == (1999, 2001)
 
 
 def test_no_filter_yields_no_year_clause():
-    assert (
-        ReferenceESRepository._year_filter_clauses(2000, YearStrategy.NO_FILTER) == []
+    fields = CandidateCanonicalSearchFields(
+        title="Shared Title", authors=["Smith"], publication_year=2000
     )
+    query = _query(fields, RetrievalPolicyName.NO_YEAR_FILTER_V1)
+    assert query.publication_year_range is None
 
 
 def test_hard_window_without_year_yields_no_clause():
-    assert (
-        ReferenceESRepository._year_filter_clauses(None, YearStrategy.HARD_WINDOW) == []
+    fields = CandidateCanonicalSearchFields(title="Shared Title", authors=["Smith"])
+    query = _query(fields, RetrievalPolicyName.CURRENT_FUZZY_V1)
+    assert query.publication_year_range is None
+
+
+def test_hard_window_with_year_zero_yields_no_clause():
+    fields = CandidateCanonicalSearchFields(
+        title="Shared Title", authors=["Smith"], publication_year=0
     )
+    query = _query(fields, RetrievalPolicyName.CURRENT_FUZZY_V1)
+    assert query.publication_year_range is None
+
+
+def test_builder_rejects_missing_title():
+    fields = CandidateCanonicalSearchFields(authors=["Smith"], publication_year=2000)
+
+    with pytest.raises(DeduplicationValueError, match="requires a title"):
+        _query(fields, RetrievalPolicyName.CURRENT_FUZZY_V1)
+
+
+def test_service_builds_complete_query_regime():
+    fields = CandidateCanonicalSearchFields(
+        title="Shared Title", authors=["G Smith"], publication_year=2000
+    )
+    query = _query(fields, RetrievalPolicyName.CURRENT_FUZZY_V1)
+    assert query.title == "Shared Title"
+    assert query.title_fuzziness == "AUTO"
+    assert query.title_boost == 2.0
+    assert query.title_minimum_should_match == "50%"
+    assert query.author_terms == ("Smith",)
+    assert query.author_tie_breaker == 0.1
+    assert query.duplicate_determination.value == "canonical"
 
 
 def test_build_candidate_query_canonical_unconditional():
     """Canonical filter present for every strategy; only the year range varies."""
-    repo = ReferenceESRepository(client=MagicMock())
     fields = CandidateCanonicalSearchFields(
         title="Shared Title", authors=["Smith"], publication_year=2000
     )
-    for strategy in (YearStrategy.HARD_WINDOW, YearStrategy.NO_FILTER):
-        query = repo._build_candidate_query(
-            fields,
-            scoring_config=DedupCandidateScoringConfig(),
-            year_strategy=strategy,
-            reference_id=None,
-        )
+    repo = ReferenceESRepository(client=MagicMock())
+    for policy_name in (
+        RetrievalPolicyName.CURRENT_FUZZY_V1,
+        RetrievalPolicyName.NO_YEAR_FILTER_V1,
+    ):
+        query = repo._to_es_candidate_query(_query(fields, policy_name))
         filter_dicts = [clause.to_dict() for clause in query.filter]
         assert any(
             "term" in fd and "duplicate_determination" in fd["term"]
@@ -54,4 +104,54 @@ def test_build_candidate_query_canonical_unconditional():
         has_year_range = any(
             "range" in fd and "publication_year" in fd["range"] for fd in filter_dicts
         )
-        assert has_year_range is (strategy is YearStrategy.HARD_WINDOW)
+        assert has_year_range is (policy_name is RetrievalPolicyName.CURRENT_FUZZY_V1)
+
+
+def test_es_translation_preserves_baseline_query_semantics():
+    reference_id = UUID("00000000-0000-0000-0000-000000000001")
+    fields = CandidateCanonicalSearchFields(
+        title="Shared Title", authors=["G Smith"], publication_year=2000
+    )
+    query = _query(
+        fields,
+        RetrievalPolicyName.CURRENT_FUZZY_V1,
+        reference_id=reference_id,
+    )
+
+    assert ReferenceESRepository._to_es_candidate_query(query).to_dict() == {
+        "bool": {
+            "must": [
+                {
+                    "match": {
+                        "title": {
+                            "query": "Shared Title",
+                            "fuzziness": "AUTO",
+                            "boost": 2.0,
+                            "operator": "or",
+                            "minimum_should_match": "50%",
+                        }
+                    }
+                }
+            ],
+            "should": [
+                {
+                    "dis_max": {
+                        "queries": [{"match": {"authors": "Smith"}}],
+                        "tie_breaker": 0.1,
+                    }
+                }
+            ],
+            "filter": [
+                {
+                    "range": {
+                        "publication_year": {
+                            "gte": 1999,
+                            "lte": 2001,
+                        }
+                    }
+                },
+                {"term": {"duplicate_determination": DuplicateDetermination.CANONICAL}},
+            ],
+            "must_not": [{"ids": {"values": [reference_id]}}],
+        }
+    }

--- a/tests/unit/domain/references/test_candidate_query_builder.py
+++ b/tests/unit/domain/references/test_candidate_query_builder.py
@@ -1,0 +1,57 @@
+# ruff: noqa: SLF001
+"""Tests for the candidate query builder's year-clause seam.
+
+Tests exercise the repository's private query-builder helpers directly.
+"""
+
+from unittest.mock import MagicMock
+
+from app.core.config import DedupCandidateScoringConfig
+from app.domain.references.models.models import CandidateCanonicalSearchFields
+from app.domain.references.models.retrieval_policy import YearStrategy
+from app.domain.references.repository import ReferenceESRepository
+
+
+def test_hard_window_builds_pm1_year_range():
+    clauses = ReferenceESRepository._year_filter_clauses(2000, YearStrategy.HARD_WINDOW)
+    assert len(clauses) == 1
+    assert clauses[0].to_dict()["range"]["publication_year"] == {
+        "gte": 1999,
+        "lte": 2001,
+    }
+
+
+def test_no_filter_yields_no_year_clause():
+    assert (
+        ReferenceESRepository._year_filter_clauses(2000, YearStrategy.NO_FILTER) == []
+    )
+
+
+def test_hard_window_without_year_yields_no_clause():
+    assert (
+        ReferenceESRepository._year_filter_clauses(None, YearStrategy.HARD_WINDOW) == []
+    )
+
+
+def test_build_candidate_query_canonical_unconditional():
+    """Canonical filter present for every strategy; only the year range varies."""
+    repo = ReferenceESRepository(client=MagicMock())
+    fields = CandidateCanonicalSearchFields(
+        title="Shared Title", authors=["Smith"], publication_year=2000
+    )
+    for strategy in (YearStrategy.HARD_WINDOW, YearStrategy.NO_FILTER):
+        query = repo._build_candidate_query(
+            fields,
+            scoring_config=DedupCandidateScoringConfig(),
+            year_strategy=strategy,
+            reference_id=None,
+        )
+        filter_dicts = [clause.to_dict() for clause in query.filter]
+        assert any(
+            "term" in fd and "duplicate_determination" in fd["term"]
+            for fd in filter_dicts
+        )
+        has_year_range = any(
+            "range" in fd and "publication_year" in fd["range"] for fd in filter_dicts
+        )
+        assert has_year_range is (strategy is YearStrategy.HARD_WINDOW)


### PR DESCRIPTION
## Summary

Adds a named, server-side candidate-retrieval policy registry to the candidate-selection API (`POST /v1/references/deduplication/candidates/`, introduced in #818). A request selects a policy by name, and the policy fixes the policy-controlled retrieval axes (year strategy, identifier union, and input searchability) under one stable, versioned name, so recall@K stays comparable across evaluation runs. Shared query shape and scoring config are unchanged, and k stays request-scoped. New policies are added only through a focused experiment cycle; an existing name's semantics never change.

## What ships

Three policies, registered in a read-only mapping:

- `current_fuzzy_v1` (default, control): reproduces the existing baseline exactly. Hard ±1 year window, identifier union on, requires title, authors, and publication year.
- `no_year_filter_v1`: drops the year filter on the query side but still requires a publication year as input.
- `no_year_filter_year_optional_v1`: drops the year filter and makes the publication year optional as input, so references with no year become searchable.

The `include_identifier_matches` request toggle is folded into the policy as `union_identifiers` and removed from the request and result. This breaks the request contract, but the field is not in the SDK or consumed outside internal evaluation, and the endpoint already carried the pre-existing `@experimental` marker (documented as subject to change) from #818; a test pins that a client still sending the field now gets a 422. The nomination path is untouched.

## Implementation notes

- Policies are immutable (`frozen=True`) and exposed through a `MappingProxyType`, so a name's semantics cannot be mutated at runtime. An unknown policy name raises `DeduplicationValueError`, which the route surfaces as HTTP 422 listing the valid names.
- Input searchability is policy-relative and split from the query-side year strategy. The control policy's year-presence check uses `bool(publication_year)`, so a `0` (or JSON `false`, which pydantic coerces to `0`) counts as absent, keeping the control exactly equivalent to the pre-existing baseline gate `all((publication_year, authors, title))` rather than running an ES query the baseline never ran.
- The two axes are independent: `year_strategy` governs the query (hard window vs no filter), while `requires_publication_year` governs the input gate. That is why `no_year_filter_v1` can drop the filter yet still require a year as input, while `no_year_filter_year_optional_v1` relaxes both.

## Validation performed

- Unit, integration, and end-to-end suites green for the candidate-selection area (52 tests across the changed files); mypy and pre-commit clean.
- Live-validated against a local DR stack (host-native app, Elasticsearch `reference_v1` at 28,299 docs, Postgres at 30,195 references). Eight cases over the live endpoint:
  - Control policy with `publication_year` of `0` and of JSON `false` both returned `searchable: false` and ran no Elasticsearch query, matching the baseline gate.
  - `no_year_filter_year_optional_v1` admitted a no-year input (searchable, query ran); `no_year_filter_v1` left the same input unsearchable.
  - An unknown policy returned 422 listing the valid policies.
  - A control pair with identical title and authors and a deliberately far year (1990 against a 2006 reference) flipped the target from excluded under the ±1 window to included once the year filter was dropped, confirming the year strategy actually drives the query rather than being ignored.

Part of #819. This delivers the policy mechanism and the API surface; the issue's downstream evaluation deliverables (depth sweep, stratified recall@K report, production-policy recommendation) land separately, so this does not close it.
