### PR TITLE
Unbounded search

### DIFF
--- a/app/core/telemetry/repository.py
+++ b/app/core/telemetry/repository.py
@@ -1,10 +1,12 @@
 """Functions for tracing repository functionality."""
 
 import functools
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable
+from contextlib import AbstractContextManager
 from typing import TYPE_CHECKING, ParamSpec, TypeVar, cast
 
 from opentelemetry import trace
+from opentelemetry.trace import Span
 
 from app.core.telemetry.attributes import Attributes
 
@@ -12,46 +14,69 @@ if TYPE_CHECKING:
     from app.persistence.repository import GenericAsyncRepository
 
 T = TypeVar("T")
+Y = TypeVar("Y")
 P = ParamSpec("P")
+
+
+def _span_context(
+    tracer: trace.Tracer,
+    func: Callable[..., object],
+    args: tuple[object, ...],
+) -> AbstractContextManager[Span]:
+    """Build the span for a repository method from its name and its repository."""
+    repository = cast("GenericAsyncRepository", args[0])
+    method_parts = func.__name__.split("_")
+    repository_implementation = repository._persistence_cls.__name__  # noqa: SLF001
+    verb = method_parts[0]
+    span_name = f"{repository.system}: {verb.capitalize()} {repository_implementation}"
+    if len(method_parts) > 1:
+        span_name = f"{span_name}.{'_'.join(method_parts[1:])}"
+    return tracer.start_as_current_span(
+        span_name,
+        attributes={
+            Attributes.CODE_FUNCTION_NAME: func.__qualname__,
+            Attributes.DB_COLLECTION_NAME: repository_implementation,
+            Attributes.DB_OPERATION_NAME: verb,
+            Attributes.DB_SYSTEM_NAME: repository.system,
+        },
+    )
 
 
 def trace_repository_method(
     tracer: trace.Tracer,
 ) -> Callable[[Callable[P, Awaitable[T]]], Callable[P, Awaitable[T]]]:
-    """Decorate a repository method with a given tracer."""
+    """Decorate an async repository method with a given tracer."""
 
     def decorator(func: Callable[P, Awaitable[T]]) -> Callable[P, Awaitable[T]]:
-        """Decorate repository methods with standard telemetry tracing attributes."""
-
         @functools.wraps(func)
         async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
-            repository = cast("GenericAsyncRepository", args[0])
-
-            method_parts = func.__name__.split("_")
-            repository_implementation = repository._persistence_cls.__name__  # noqa: SLF001
-
-            verb = method_parts[0]
-
-            span_name = (
-                f"{repository.system}: {verb.capitalize()} "
-                f"{repository_implementation}"
-            )
-
-            if len(method_parts) > 1:
-                details = "_".join(method_parts[1:])
-                span_name = f"{span_name}.{details}"
-
-            # Start the span and execute the original function
-            with tracer.start_as_current_span(
-                span_name,
-                attributes={
-                    Attributes.CODE_FUNCTION_NAME: func.__qualname__,
-                    Attributes.DB_COLLECTION_NAME: repository_implementation,
-                    Attributes.DB_OPERATION_NAME: verb,
-                    Attributes.DB_SYSTEM_NAME: repository.system,
-                },
-            ):
+            with _span_context(tracer, func, args):
                 return await func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def trace_repository_generator(
+    tracer: trace.Tracer,
+) -> Callable[
+    [Callable[P, AsyncGenerator[Y, None]]], Callable[P, AsyncGenerator[Y, None]]
+]:
+    """Trace an async-generator repository method, spanning the full iteration."""
+
+    def decorator(
+        func: Callable[P, AsyncGenerator[Y, None]],
+    ) -> Callable[P, AsyncGenerator[Y, None]]:
+        @functools.wraps(func)
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> AsyncGenerator[Y, None]:
+            agen = func(*args, **kwargs)
+            with _span_context(tracer, func, args):
+                try:
+                    async for item in agen:
+                        yield item
+                finally:
+                    await agen.aclose()
 
         return wrapper
 

--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -410,7 +410,12 @@ class ReferenceESRepository(
         limit: int | None = None,
         page_size: int = 500,
     ) -> AsyncGenerator[ESSearchResult, None]:
-        """Scan references matching ``query`` in pages."""
+        """
+        Scan references matching ``query`` in pages.
+
+        ``scan_with_query_string`` appends the ``id`` tiebreaker, so unlike
+        :meth:`search` this method doesn't add one itself.
+        """
         sort_keys: list[str | dict[str, Any]] = list(sort) if sort else ["_score"]
         async for page in self.scan_with_query_string(
             query.query_string,

--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -2,7 +2,7 @@
 
 import datetime
 from abc import ABC
-from collections.abc import Mapping, Sequence
+from collections.abc import AsyncGenerator, Mapping, Sequence
 from typing import Any, ClassVar, Literal
 from uuid import UUID
 
@@ -26,7 +26,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
 from app.core.config import DedupCandidateScoringConfig, get_settings
-from app.core.telemetry.repository import trace_repository_method
+from app.core.telemetry.repository import (
+    trace_repository_generator,
+    trace_repository_method,
+)
 from app.domain.references.models.es import (
     ReferenceDocument,
     RobotAutomationPercolationDocument,
@@ -399,6 +402,27 @@ class ReferenceESRepository(
             filter_clauses=self._build_filter_clauses(query),
             parse_document=False,
         )
+
+    @trace_repository_generator(tracer)
+    async def scan(
+        self,
+        query: SearchQuery,
+        sort: list[str] | None = None,
+        limit: int | None = None,
+        page_size: int = 500,
+    ) -> AsyncGenerator[ESSearchResult, None]:
+        """Scan references matching ``query`` in pages."""
+        sort_keys: list[str | dict[str, Any]] = list(sort) if sort else ["_score"]
+        async for page in self.scan_with_query_string(
+            query.query_string,
+            fields=self.default_search_fields,
+            limit=limit,
+            page_size=page_size,
+            sort=sort_keys,
+            filter_clauses=self._build_filter_clauses(query),
+            parse_document=False,
+        ):
+            yield page
 
     @trace_repository_method(tracer)
     async def aggregate_facets(

--- a/app/domain/references/services/search_service.py
+++ b/app/domain/references/services/search_service.py
@@ -1,6 +1,6 @@
 """Service for searching references."""
 
-from collections.abc import Iterable, Sequence
+from collections.abc import AsyncGenerator, Iterable, Sequence
 from typing import ClassVar
 
 from opentelemetry import trace
@@ -78,6 +78,16 @@ class SearchService(GenericService[ReferenceAntiCorruptionService]):
             page_size=page_size,
             sort=sort,
         )
+
+    async def scan(
+        self,
+        query: SearchQuery,
+        sort: list[str] | None = None,
+        limit: int | None = None,
+    ) -> AsyncGenerator[ESSearchResult, None]:
+        """Scan all references matching ``query``, paging beyond the result window."""
+        async for page in self.es_uow.references.scan(query, sort=sort, limit=limit):
+            yield page
 
     async def aggregate_facets(
         self,

--- a/app/persistence/es/repository.py
+++ b/app/persistence/es/repository.py
@@ -2,7 +2,8 @@
 
 import json
 from abc import ABC
-from collections.abc import AsyncGenerator, Sequence
+from collections.abc import AsyncGenerator, AsyncIterator, Sequence
+from contextlib import asynccontextmanager
 from typing import Any, Generic, Never
 from uuid import UUID
 
@@ -21,7 +22,10 @@ from app.core.exceptions import (
     ESQueryError,
 )
 from app.core.telemetry.attributes import Attributes, trace_attribute
-from app.core.telemetry.repository import trace_repository_method
+from app.core.telemetry.repository import (
+    trace_repository_generator,
+    trace_repository_method,
+)
 from app.persistence.es.generics import GenericESPersistenceType
 from app.persistence.es.persistence import (
     ESFacetBucket,
@@ -33,6 +37,8 @@ from app.persistence.generics import GenericDomainModelType
 from app.persistence.repository import GenericAsyncRepository
 
 tracer = trace.get_tracer(__name__)
+
+ES_MAX_PAGE_SIZE = 10_000
 
 
 class GenericAsyncESRepository(
@@ -192,22 +198,32 @@ class GenericAsyncESRepository(
         :rtype: ESSearchResult
         """
         return ESSearchResult(
-            hits=[
-                ESHit(
-                    id=hit.meta.id,
-                    score=hit.meta.score,
-                    document=self._persistence_cls.from_hit(hit).to_domain()
-                    if parse_document
-                    else None,
-                )
-                for hit in response.hits
-            ],
-            # ES DSL typing on response.hits is incorrect
-            total=ESSearchTotal(
-                value=response.hits.total.value,  # type: ignore[attr-defined]
-                relation=response.hits.total.relation,  # type: ignore[attr-defined]
-            ),
+            hits=self._parse_hits(response, parse_document=parse_document),
+            total=self._extract_total(response),
             page=page,
+        )
+
+    def _parse_hits(
+        self, response: Response[Hit], *, parse_document: bool = False
+    ) -> list[ESHit]:
+        """Parse the hits of a search response into domain-facing ``ESHit``s."""
+        return [
+            ESHit(
+                id=hit.meta.id,
+                score=hit.meta.score,
+                document=self._persistence_cls.from_hit(hit).to_domain()
+                if parse_document
+                else None,
+            )
+            for hit in response.hits
+        ]
+
+    def _extract_total(self, response: Response[Hit]) -> ESSearchTotal:
+        """Read the total hit count from a response that tracked totals."""
+        # ES DSL typing on response.hits is incorrect
+        return ESSearchTotal(
+            value=response.hits.total.value,  # type: ignore[attr-defined]
+            relation=response.hits.total.relation,  # type: ignore[attr-defined]
         )
 
     @trace_repository_method(tracer)
@@ -258,6 +274,140 @@ class GenericAsyncESRepository(
             search = search.source(includes=[])
         response = await self._execute_search(search)
         return self._parse_search_result(response, page, parse_document=parse_document)
+
+    @asynccontextmanager
+    async def _point_in_time(self, keep_alive: str) -> AsyncIterator[str]:
+        """Open a point-in-time and guarantee it is closed."""
+        pit = await self._client.open_point_in_time(
+            index=self._persistence_cls.Index.name, keep_alive=keep_alive
+        )
+        pit_id = pit["id"]
+        try:
+            yield pit_id
+        finally:
+            await self._client.close_point_in_time(id=pit_id)
+
+    @trace_repository_generator(tracer)
+    async def scan_with_query_string(  # noqa: PLR0913
+        self,
+        query: str,
+        page_size: int = 500,
+        limit: int | None = None,
+        fields: Sequence[str] | None = None,
+        sort: list[str | dict[str, Any]] | None = None,
+        filter_clauses: Sequence[Query] | None = None,
+        *,
+        parse_document: bool = False,
+        keep_alive: str = "10m",
+    ) -> AsyncGenerator[ESSearchResult, None]:
+        """
+        Iterate over matching records in pages, unbounded by the result window.
+
+        This uses a point-in-time (PIT) page indefinitely, yielding one
+        :class:`ESSearchResult` per page. The result set is a consistent snapshot taken
+        when the PIT opens.
+
+        :param query: The query string to search with.
+        :type query: str
+        :param page_size: Records per page, i.e. the batch size per ES round-trip.
+            Must be in ``[1, ES_MAX_PAGE_SIZE]``.
+        :type page_size: int
+        :param limit: Stop after yielding this many hits in total. ``None`` scans the
+            whole result set.
+        :type limit: int | None
+        :param fields: The fields to search within. If None, searches all fields
+            (unless the query specifies otherwise).
+        :type fields: Sequence[str] | None
+        :param sort: The sorting criteria. Entries may be field-name strings or full
+            ES sort dicts. If not provided, a tiebreaker is appended to guarantee a
+            total order for paging.
+        :type sort: list[str | dict[str, Any]] | None
+        :param filter_clauses: Structured DSL clauses ANDed with the query string
+            under ``bool.filter`` (non-scoring).
+        :type filter_clauses: Sequence[Query] | None
+        :param parse_document: Whether to retrieve the documents and include them in
+            the hits as domain models.
+        :type parse_document: bool
+        :param keep_alive: PIT time-to-live, renewed on each page request.
+        :type keep_alive: str
+        :return: An async generator yielding one search result per page.
+        :rtype: AsyncGenerator[ESSearchResult, None]
+        """
+        if not 1 <= page_size <= ES_MAX_PAGE_SIZE:
+            msg = f"page_size must be in [1, {ES_MAX_PAGE_SIZE}], got {page_size}."
+            raise ESError(msg)
+        if limit is not None and limit < 1:
+            msg = f"limit must be a positive integer, got {limit}."
+            raise ESError(msg)
+
+        sort_keys = self._scan_sort_keys(sort)
+
+        async with self._point_in_time(keep_alive) as pit_id:
+            # The index is bound to the PIT, so it is not set on the search.
+            search = (
+                AsyncSearch(using=self._client)
+                .extra(pit={"id": pit_id, "keep_alive": keep_alive})
+                .extra(track_total_hits=True)
+                .query(self._compose_query(query, fields, filter_clauses))
+                .sort(*sort_keys)
+            )
+            if not parse_document:
+                search = search.source(includes=[])
+
+            emitted = 0
+            page = 1
+            cached_total: ESSearchTotal | None = None
+            while True:
+                remaining = None if limit is None else limit - emitted
+                current_size = (
+                    page_size if remaining is None else min(page_size, remaining)
+                )
+                search = search.extra(size=current_size)
+                response = await self._execute_search(search)
+
+                if cached_total is None:
+                    cached_total = self._extract_total(response)
+                    # Total is fixed at PIT open; stop recomputing it per page.
+                    search = search.extra(track_total_hits=False)
+
+                hits = self._parse_hits(response, parse_document=parse_document)
+                if not hits:
+                    break
+
+                yield ESSearchResult(hits=hits, total=cached_total, page=page)
+                emitted += len(hits)
+
+                if limit is not None and emitted >= limit:
+                    break
+                if len(hits) < current_size:
+                    break
+
+                search = search.extra(search_after=response.hits[-1].meta.sort)
+                page += 1
+
+    @staticmethod
+    def _sort_key_field(key: str | dict[str, Any]) -> str:
+        """Return the field name a sort entry sorts on (str or single-key dict)."""
+        if isinstance(key, dict):
+            return next(iter(key), "")
+        return key.lstrip("-+")
+
+    def _scan_sort_keys(
+        self, sort: list[str | dict[str, Any]] | None
+    ) -> list[str | dict[str, Any]]:
+        """
+        Append a total-order tiebreaker to the caller's sort keys.
+
+        Prefer the document ``id`` where it exists, otherwise fall back to
+        ``_shard_doc``, ES's PIT-only built-in tiebreaker.
+        """
+        keys = list(sort) if sort else []
+        if "id" in self._persistence_cls._doc_type.mapping:  # noqa: SLF001
+            if not any(self._sort_key_field(key) == "id" for key in keys):
+                keys.append({"id": {"order": "desc"}})
+        elif not any(self._sort_key_field(key) == "_shard_doc" for key in keys):
+            keys.append("_shard_doc")
+        return keys
 
     @trace_repository_method(tracer)
     async def aggregate_terms(

--- a/app/persistence/es/repository.py
+++ b/app/persistence/es/repository.py
@@ -2,7 +2,7 @@
 
 import json
 from abc import ABC
-from collections.abc import AsyncGenerator, AsyncIterator, Sequence
+from collections.abc import AsyncGenerator, Sequence
 from contextlib import asynccontextmanager
 from typing import Any, Generic, Never
 from uuid import UUID
@@ -276,7 +276,7 @@ class GenericAsyncESRepository(
         return self._parse_search_result(response, page, parse_document=parse_document)
 
     @asynccontextmanager
-    async def _point_in_time(self, keep_alive: str) -> AsyncIterator[str]:
+    async def _point_in_time(self, keep_alive: str) -> AsyncGenerator[str, None]:
         """Open a point-in-time and guarantee it is closed."""
         pit = await self._client.open_point_in_time(
             index=self._persistence_cls.Index.name, keep_alive=keep_alive

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -726,3 +726,38 @@ async def test_search_tolerates_index_without_id_mapping(
 
     assert result.total.value == 5
     assert len(result.hits) == 5
+
+
+async def test_scan_pages_all_matches(es_client: AsyncElasticsearch) -> None:
+    """scan() yields every match once across pages, with an exact total."""
+    references = [
+        ReferenceFactory.build(
+            enhancements=[
+                EnhancementFactory.build(
+                    content=BibliographicMetadataEnhancementFactory.build(
+                        title="scantoken", publication_year=2020
+                    )
+                )
+            ]
+        )
+        for _ in range(25)
+    ]
+    repository = await _wipe_and_index(es_client, references)
+    query = SearchQuery(query_string="title:scantoken")
+
+    pages = [page async for page in repository.scan(query, page_size=10)]
+
+    assert [page.page for page in pages] == [1, 2, 3]
+    assert all(page.total.value == 25 for page in pages)
+    assert all(page.total.relation == "eq" for page in pages)
+    returned = [hit.id for page in pages for hit in page.hits]
+    assert len(returned) == 25
+    assert set(returned) == {reference.id for reference in references}
+
+    # A limit trims the total emitted, even across page boundaries.
+    limited = [
+        hit.id
+        async for page in repository.scan(query, page_size=10, limit=15)
+        for hit in page.hits
+    ]
+    assert len(limited) == 15

--- a/tests/persistence_models.py
+++ b/tests/persistence_models.py
@@ -1,10 +1,11 @@
 """Simple domain and persistence models for testing repositories."""
 
 from typing import Literal, Self
+from uuid import UUID
 
 import sqlalchemy as sa
 from elasticsearch import AsyncElasticsearch
-from elasticsearch.dsl import Integer, Text, mapped_field
+from elasticsearch.dsl import Integer, Keyword, Text, mapped_field
 from sqlalchemy import String
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Mapped, mapped_column
@@ -67,6 +68,7 @@ class SimpleSQLRepository(
 class SimpleDoc(GenericESPersistence):
     """Simple test document with basic fields."""
 
+    id: UUID = mapped_field(Keyword(required=True))
     title: str = mapped_field(Text())
     year: int = mapped_field(Integer())
     content: str = mapped_field(Text())
@@ -90,6 +92,7 @@ class SimpleDoc(GenericESPersistence):
         """Create from simple domain dict."""
         return cls(
             meta={"id": domain_model.id},  # type: ignore[call-arg]
+            id=domain_model.id,
             title=domain_model.title,
             year=domain_model.year,
             content=domain_model.content,

--- a/tests/unit/persistence/es/test_repository.py
+++ b/tests/unit/persistence/es/test_repository.py
@@ -1,12 +1,14 @@
 """Unit tests for Elasticsearch repository query string search functionality."""
 
+from typing import Any
 from uuid import uuid7
 
 import pytest
 from elasticsearch import AsyncElasticsearch
+from elasticsearch.dsl import Text, mapped_field
 from elasticsearch.helpers import async_bulk
 
-from app.core.exceptions import ESQueryError
+from app.core.exceptions import ESError, ESQueryError
 from app.domain.references.models.es import ReferenceDocument
 from app.domain.references.models.models import Visibility
 from app.domain.references.repository import ReferenceESRepository
@@ -14,7 +16,8 @@ from app.domain.references.services.world_bank_regions import (
     SOUTH_ASIA,
     SUB_SAHARAN_AFRICA,
 )
-from app.persistence.es.repository import GenericAsyncESRepository
+from app.persistence.es.persistence import GenericESPersistence
+from app.persistence.es.repository import ES_MAX_PAGE_SIZE, GenericAsyncESRepository
 from tests.persistence_models import SimpleDoc, SimpleDomainModel
 
 
@@ -349,6 +352,269 @@ async def test_query_string_search_with_document(
     assert results.hits[0].document.title == "test document"
     assert results.hits[0].document.year == 2023
     assert results.hits[0].document.content == "This is sample content for testing"
+
+
+def build_simple_docs(count: int, *, title: str, year: int = 2000) -> list[SimpleDoc]:
+    """Build ``count`` indexable SimpleDocs sharing a title (and year)."""
+    docs = []
+    for _ in range(count):
+        doc_id = uuid7()
+        docs.append(
+            SimpleDoc(
+                meta={"id": doc_id},
+                id=doc_id,
+                title=title,
+                year=year,
+                content="content",
+            )
+        )
+    return docs
+
+
+async def bulk_index(repository: SimpleRepository, docs: list[SimpleDoc]) -> None:
+    """Bulk-index docs and refresh so they are immediately searchable."""
+    await async_bulk(
+        repository._client,  # noqa: SLF001
+        [doc.to_dict(include_meta=True) for doc in docs],
+        index=SimpleDoc.Index.name,
+    )
+    await repository._client.indices.refresh(  # noqa: SLF001
+        index=SimpleDoc.Index.name
+    )
+
+
+def test_scan_sort_keys_prefers_mapped_id(simple_repository: SimpleRepository):
+    """When the index maps ``id``, it is appended as the tiebreaker."""
+    assert simple_repository._scan_sort_keys(["_score"]) == [  # noqa: SLF001
+        "_score",
+        {"id": {"order": "desc"}},
+    ]
+
+
+def test_scan_sort_keys_does_not_duplicate_id(simple_repository: SimpleRepository):
+    """A caller already sorting on ``id`` is not given a second id key."""
+    assert simple_repository._scan_sort_keys([{"id": {"order": "asc"}}]) == [  # noqa: SLF001
+        {"id": {"order": "asc"}}
+    ]
+
+
+def test_scan_sort_keys_falls_back_to_shard_doc(es_client: AsyncElasticsearch):
+    """Without a mapped ``id``, ``_shard_doc`` is used as the tiebreaker."""
+
+    class NoIdDoc(GenericESPersistence):
+        title: str = mapped_field(Text())
+
+        class Index:
+            name = "test_no_id"
+
+        def to_domain(self) -> SimpleDomainModel:
+            return SimpleDomainModel(title=self.title)
+
+        @classmethod
+        def from_domain(cls, domain_model: SimpleDomainModel) -> "NoIdDoc":
+            return cls(title=domain_model.title)
+
+    repository = GenericAsyncESRepository(es_client, SimpleDomainModel, NoIdDoc)
+    assert repository._scan_sort_keys(["_score"]) == ["_score", "_shard_doc"]  # noqa: SLF001
+
+
+async def test_scan_paginates_all_results(simple_repository: SimpleRepository):
+    """Scan yields every match exactly once across incrementing pages."""
+    docs = build_simple_docs(55, title="scan")
+    await bulk_index(simple_repository, docs)
+
+    pages = [
+        page
+        async for page in simple_repository.scan_with_query_string(
+            "title:scan", page_size=20
+        )
+    ]
+
+    assert [page.page for page in pages] == [1, 2, 3]
+    # Total is exact (track_total_hits) and identical on every page.
+    assert all(page.total.value == 55 for page in pages)
+    assert all(page.total.relation == "eq" for page in pages)
+
+    returned = [hit.id for page in pages for hit in page.hits]
+    assert len(returned) == 55
+    assert {str(rid) for rid in returned} == {str(doc.id) for doc in docs}
+
+
+async def test_scan_tiebreaker_orders_fully_tied_sort(
+    simple_repository: SimpleRepository,
+):
+    """A sort whose values are all equal still pages without skips or dupes."""
+    docs = build_simple_docs(45, title="tied", year=2000)
+    await bulk_index(simple_repository, docs)
+
+    returned = [
+        hit.id
+        async for page in simple_repository.scan_with_query_string(
+            "title:tied", page_size=10, sort=["year"]
+        )
+        for hit in page.hits
+    ]
+
+    assert len(returned) == 45
+    assert {str(rid) for rid in returned} == {str(doc.id) for doc in docs}
+
+
+async def test_scan_limit_trims_final_page(simple_repository: SimpleRepository):
+    """A limit that is not a page multiple trims the final page exactly."""
+    await bulk_index(simple_repository, build_simple_docs(55, title="scan"))
+
+    pages = [
+        page
+        async for page in simple_repository.scan_with_query_string(
+            "title:scan", page_size=20, limit=25
+        )
+    ]
+
+    assert [len(page.hits) for page in pages] == [20, 5]
+    assert sum(len(page.hits) for page in pages) == 25
+
+
+async def test_scan_limit_exceeding_total_returns_all(
+    simple_repository: SimpleRepository,
+):
+    """A limit larger than the result set returns everything and stops."""
+    await bulk_index(simple_repository, build_simple_docs(10, title="scan"))
+
+    returned = [
+        hit
+        async for page in simple_repository.scan_with_query_string(
+            "title:scan", page_size=20, limit=1000
+        )
+        for hit in page.hits
+    ]
+
+    assert len(returned) == 10
+
+
+async def test_scan_exceeds_result_window(simple_repository: SimpleRepository):
+    """Scan pages past ES's 10,000 from+size result window."""
+    count = ES_MAX_PAGE_SIZE + 50
+    await bulk_index(simple_repository, build_simple_docs(count, title="big"))
+
+    pages = [
+        page
+        async for page in simple_repository.scan_with_query_string(
+            "title:big", page_size=ES_MAX_PAGE_SIZE
+        )
+    ]
+
+    assert [len(page.hits) for page in pages] == [ES_MAX_PAGE_SIZE, 50]
+    assert pages[0].total.value == count
+    assert pages[0].total.relation == "eq"
+
+
+async def test_scan_parse_document(simple_repository: SimpleRepository):
+    """parse_document=True hydrates domain models on scanned hits."""
+    await bulk_index(simple_repository, build_simple_docs(3, title="hydrate"))
+
+    pages = [
+        page
+        async for page in simple_repository.scan_with_query_string(
+            "title:hydrate", parse_document=True
+        )
+    ]
+
+    hits = [hit for page in pages for hit in page.hits]
+    assert len(hits) == 3
+    assert all(isinstance(hit.document, SimpleDomainModel) for hit in hits)
+    assert all(
+        hit.document.title == "hydrate"
+        for hit in hits
+        if isinstance(hit.document, SimpleDomainModel)
+    )
+
+
+@pytest.mark.parametrize("page_size", [0, -1, ES_MAX_PAGE_SIZE + 1])
+async def test_scan_rejects_invalid_page_size(
+    simple_repository: SimpleRepository, page_size: int
+):
+    """page_size must sit within [1, ES_MAX_PAGE_SIZE]."""
+    with pytest.raises(ESError):
+        await anext(
+            simple_repository.scan_with_query_string("title:scan", page_size=page_size)
+        )
+
+
+async def test_scan_rejects_invalid_limit(simple_repository: SimpleRepository):
+    """A non-positive limit is rejected."""
+    with pytest.raises(ESError):
+        await anext(simple_repository.scan_with_query_string("title:scan", limit=0))
+
+
+async def test_scan_closes_pit_on_early_exit(
+    simple_repository: SimpleRepository,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Abandoning the scan mid-iteration still closes the PIT."""
+    await bulk_index(simple_repository, build_simple_docs(30, title="scan"))
+
+    close_calls: list[dict] = []
+    original_close = simple_repository._client.close_point_in_time  # noqa: SLF001
+
+    async def spy_close(**kwargs: Any) -> Any:
+        close_calls.append(kwargs)
+        return await original_close(**kwargs)
+
+    monkeypatch.setattr(
+        simple_repository._client,  # noqa: SLF001
+        "close_point_in_time",
+        spy_close,
+    )
+
+    scan = simple_repository.scan_with_query_string("title:scan", page_size=10)
+    await anext(scan)
+    await scan.aclose()
+
+    assert len(close_calls) == 1
+
+
+async def test_scan_closes_pit_on_error(
+    simple_repository: SimpleRepository,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """An error mid-scan still closes the PIT (the DSL CM trap)."""
+    await bulk_index(simple_repository, build_simple_docs(30, title="scan"))
+
+    close_calls: list[dict] = []
+    original_close = simple_repository._client.close_point_in_time  # noqa: SLF001
+
+    async def spy_close(**kwargs: Any) -> Any:
+        close_calls.append(kwargs)
+        return await original_close(**kwargs)
+
+    monkeypatch.setattr(
+        simple_repository._client,  # noqa: SLF001
+        "close_point_in_time",
+        spy_close,
+    )
+
+    call_count = {"n": 0}
+    original_execute = simple_repository._execute_search  # noqa: SLF001
+
+    async def failing_execute(search: Any) -> Any:
+        call_count["n"] += 1
+        if call_count["n"] == 2:
+            msg = "boom"
+            raise RuntimeError(msg)
+        return await original_execute(search)
+
+    monkeypatch.setattr(simple_repository, "_execute_search", failing_execute)
+
+    async def drain() -> None:
+        async for _ in simple_repository.scan_with_query_string(
+            "title:scan", page_size=10
+        ):
+            pass
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await drain()
+
+    assert len(close_calls) == 1
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes #661 

Adds `scan` generators to the generic ES repository and reference search service.

These take a PIT snapshot and iterate over it using `search_after`, yielding pages of `page_size` until the optional `limit` is reached. There's no upper bound to the number of documents that can be retrieved.