### PR TITLE
test(e2e): allow dedup collision retries to settle

### DIFF
--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -1,6 +1,8 @@
 """Utility functions for import end-to-end tests."""
 
+import asyncio
 import datetime
+import time
 from collections.abc import Callable, Mapping
 from contextlib import _AsyncGeneratorContextManager
 from uuid import UUID
@@ -107,30 +109,40 @@ async def poll_batch_status(
     return summary
 
 
-@retry(stop=stop_after_attempt(5), wait=wait_fixed(1), reraise=True)
 async def poll_duplicate_process(
     session: AsyncSession,
     reference_id: UUID,
     required_state: DuplicateDetermination | None = None,
+    *,
+    timeout_seconds: float = 20.0,
+    interval_seconds: float = 1.0,
 ) -> ReferenceDuplicateDecision:
-    """Poll the duplicate process until it is in the required state."""
-    query = select(ReferenceDuplicateDecision).where(
-        ReferenceDuplicateDecision.reference_id == reference_id,
-    )
-    if required_state:
-        query = query.where(
-            ReferenceDuplicateDecision.duplicate_determination == required_state
-        )
-    else:
-        query = query.where(ReferenceDuplicateDecision.active_decision)
-    result = await session.execute(query)
-    try:
-        decision = result.scalar_one()
-    except NoResultFound as exc:
-        msg = "Reference duplicate decision not yet in required state"
-        raise TestPollingExhaustedError(msg) from exc
+    """
+    Poll the duplicate process until it is in the required state.
 
-    return decision
+    Polls on an elapsed-time budget, not a fixed attempt count: the dedup task
+    retries the active-decision constraint collision, during which a reference
+    transiently has no active decision, and recovery can outlast a short budget.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        query = select(ReferenceDuplicateDecision).where(
+            ReferenceDuplicateDecision.reference_id == reference_id,
+        )
+        if required_state:
+            query = query.where(
+                ReferenceDuplicateDecision.duplicate_determination == required_state
+            )
+        else:
+            query = query.where(ReferenceDuplicateDecision.active_decision)
+        result = await session.execute(query)
+        try:
+            return result.scalar_one()
+        except NoResultFound as exc:
+            if time.monotonic() >= deadline:
+                msg = "Reference duplicate decision not yet in required state"
+                raise TestPollingExhaustedError(msg) from exc
+            await asyncio.sleep(interval_seconds)
 
 
 @retry(stop=stop_after_attempt(5), wait=wait_fixed(1), reraise=True)

--- a/tests/unit/test_e2e_poll_duplicate_process.py
+++ b/tests/unit/test_e2e_poll_duplicate_process.py
@@ -1,0 +1,96 @@
+"""Unit tests for the e2e ``poll_duplicate_process`` helper's polling budget.
+
+These pin the elapsed-time polling contract that keeps the deduplication e2e
+tests reliable: the dedup task retries the active-decision constraint collision,
+during which a reference transiently has no active decision, and recovery can
+outlast a fixed short attempt count.
+
+The clock and sleep are mocked so the assertions are deterministic: a flake fix
+whose own tests depended on wall-clock timing would defeat the purpose.
+"""
+
+import types
+from uuid import uuid7
+
+import pytest
+from sqlalchemy.exc import NoResultFound
+
+from tests.e2e import utils
+from tests.e2e.utils import TestPollingExhaustedError, poll_duplicate_process
+
+_MISSING = object()
+
+
+async def _noop_sleep(*_args: object, **_kwargs: object) -> None:
+    """Stand in for asyncio.sleep so polling advances without real waiting."""
+
+
+class _FakeClock:
+    """Monotonic-clock stand-in returning each scripted reading, then the last."""
+
+    def __init__(self, readings: list[float]) -> None:
+        self._readings = readings
+        self._index = 0
+
+    def __call__(self) -> float:
+        reading = self._readings[min(self._index, len(self._readings) - 1)]
+        self._index += 1
+        return reading
+
+
+class _FakeResult:
+    def __init__(self, value: object) -> None:
+        self._value = value
+
+    def scalar_one(self) -> object:
+        if self._value is _MISSING:
+            raise NoResultFound
+        return self._value
+
+
+class _FakeSession:
+    """Minimal AsyncSession stand-in yielding no row until ``appear_on_call``."""
+
+    def __init__(self, *, appear_on_call: int, value: object) -> None:
+        self._appear_on_call = appear_on_call
+        self._value = value
+        self.calls = 0
+
+    async def execute(self, _query: object) -> _FakeResult:
+        self.calls += 1
+        if self.calls >= self._appear_on_call:
+            return _FakeResult(self._value)
+        return _FakeResult(_MISSING)
+
+
+def _mock_clock_and_sleep(monkeypatch: pytest.MonkeyPatch, monotonic: object) -> None:
+    monkeypatch.setattr(utils, "asyncio", types.SimpleNamespace(sleep=_noop_sleep))
+    monkeypatch.setattr(utils, "time", types.SimpleNamespace(monotonic=monotonic))
+
+
+async def test_poll_returns_decision_that_settles_after_old_attempt_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A decision appearing past the former five-attempt budget is still returned."""
+    _mock_clock_and_sleep(monkeypatch, monotonic=lambda: 0.0)  # deadline never elapses
+    decision = object()
+    session = _FakeSession(appear_on_call=8, value=decision)
+
+    result = await poll_duplicate_process(session, uuid7(), timeout_seconds=20.0)
+
+    assert result is decision
+    assert session.calls == 8
+
+
+async def test_poll_times_out_on_elapsed_budget_not_fixed_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When no decision settles, it polls until the budget elapses, then raises."""
+    # First reading sets the deadline; the budget is then reached on the third check.
+    _mock_clock_and_sleep(monkeypatch, monotonic=_FakeClock([0.0, 0.0, 0.0, 1.0]))
+    session = _FakeSession(appear_on_call=10**9, value=object())
+
+    with pytest.raises(TestPollingExhaustedError):
+        await poll_duplicate_process(session, uuid7(), timeout_seconds=1.0)
+
+    assert session.calls == 3


### PR DESCRIPTION
## Summary

Fixes the intermittent e2e failure in `test_deduplication_shortcut_from_scratch`
(tracked in #547). It surfaced only on post-merge `main` runs under heavy Actions
load, e.g. the [failed e2e job](https://github.com/destiny-evidence/destiny-repository/actions/runs/29887841465/job/88822026167)
([run, attempt 1](https://github.com/destiny-evidence/destiny-repository/actions/runs/29887841465/attempts/1)),
while PR #835's [pre-merge e2e passed](https://github.com/destiny-evidence/destiny-repository/actions/runs/29829623842).

## Root cause

The fixture imports two references sharing a trusted identifier in one batch, so
their deduplication tasks run concurrently. Both take the identifier shortcut and
write side-effect active decisions, racing on the
`uix_reference_one_active_decision_constraint` partial unique index. The task
recovers by retrying (`process_reference_duplicate_decision`), and during that
recovery the reference transiently holds no active decision.

`poll_duplicate_process` stopped after a fixed five attempts (~4s). When the
collision-retry recovery took longer than that, the poll saw zero active
decisions and raised `TestPollingExhaustedError` (`tests/e2e/utils.py`), even
though the decision settled shortly after.

This is a test-timing issue rather than a production problem: the underlying
race (lineage in #534) is handled and self-healing. The worker log for the
failed attempt shows the retry completing its side effects, and the re-run
passed, so `main` is green. We're leaving the production path as-is, in keeping
with that self-healing behaviour and its production track record.

## Change

- `poll_duplicate_process` polls on an elapsed-time budget (default 20s) rather
  than a fixed attempt count.
- The active-decision invariant is unchanged: a decision is only active once
  terminal (`check_active_decision_is_terminal`), so `required_state=None` still
  waits for a settled decision.
- The separate `sleep(10)` workaround (delete-then-rededup transition) is
  untouched.

## Validation performed

- Added deterministic unit tests (`tests/unit/test_e2e_poll_duplicate_process.py`)
  with mocked clock and sleep, pinning both the "returns a decision that settles
  past the old attempt budget" and "raises on the elapsed-time budget" paths.
  Confirmed they fail against the former five-attempt behaviour and pass against
  the elapsed-time budget.
- `uv run pytest tests/unit/test_e2e_poll_duplicate_process.py` green (2 passed).
- `pre-commit run --files ...` clean (ruff, ruff-format, mypy, vulture).

Closes #547
Refs #534
