### PR TITLE
feat(dedup): add soft_year_decay candidate-retrieval policy

### DIFF
--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -836,9 +836,9 @@ class RetrievalPolicyName(StrEnum):
     exponential proximity bonus adds at most 10% to the title/author score.
     Requires publication year as input."""
     SOFT_YEAR_DECAY_NONFUZZY_PROBE_V1 = "soft_year_decay_nonfuzzy_probe_v1"
-    """Evaluation-only probe: soft_year_decay_v1 with a non-fuzzy (zero
-    edit-distance) title match, to measure the recall cost of dropping fuzzy
-    title expansion. Not for production nomination."""
+    """Evaluation-only probe: soft_year_decay_v1 with zero edit-distance title
+    matching. Used to measure the recall and latency impact of disabling fuzzy
+    title matching for this query shape. Not for production nomination."""
 
 
 class CandidateIdentifier(GenericExternalIdentifier):
@@ -926,9 +926,9 @@ class CandidateSelectionRequest(BaseModel):
         default=True,
         description=(
             "Compute the exact Elasticsearch total-hit count for reporting. Set "
-            "false for the production-throughput proxy: the total becomes a lower "
-            "bound and the query skips the full count, which is expensive on broad "
-            "(e.g. no-year-filter) queries."
+            "false for the production-throughput proxy: Elasticsearch may return a "
+            "lower-bound total and can avoid exact full-count work, which is "
+            "especially relevant on broad no-year-filter queries."
         ),
     )
 

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -925,10 +925,11 @@ class CandidateSelectionRequest(BaseModel):
     track_total_hits: bool = Field(
         default=True,
         description=(
-            "Compute the exact Elasticsearch total-hit count for reporting. Set "
-            "false for the production-throughput proxy: Elasticsearch may return a "
-            "lower-bound total and can avoid exact full-count work, which is "
-            "especially relevant on broad no-year-filter queries."
+            "Compute the exact Elasticsearch total-hit count. Defaults to true: "
+            "exact totals reveal the true candidate-pool size that the "
+            "Elasticsearch 10k default caps, which is useful for evaluation. Set "
+            "false for the Elasticsearch default (a lower-bound total), matching "
+            "the production nomination path."
         ),
     )
 

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -835,6 +835,10 @@ class RetrievalPolicyName(StrEnum):
     """Bounded soft year decay: no hard year filter; a native Elasticsearch
     exponential proximity bonus adds at most 10% to the title/author score.
     Requires publication year as input."""
+    SOFT_YEAR_DECAY_NONFUZZY_PROBE_V1 = "soft_year_decay_nonfuzzy_probe_v1"
+    """Evaluation-only probe: soft_year_decay_v1 with a non-fuzzy (zero
+    edit-distance) title match, to measure the recall cost of dropping fuzzy
+    title expansion. Not for production nomination."""
 
 
 class CandidateIdentifier(GenericExternalIdentifier):

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -831,6 +831,10 @@ class RetrievalPolicyName(StrEnum):
     as input."""
     NO_YEAR_FILTER_YEAR_OPTIONAL_V1 = "no_year_filter_year_optional_v1"
     """Drops the year filter and makes publication year optional as input."""
+    SOFT_YEAR_DECAY_V1 = "soft_year_decay_v1"
+    """Bounded soft year decay: no hard year filter; a native Elasticsearch
+    exponential proximity bonus adds at most 10% to the title/author score.
+    Requires publication year as input."""
 
 
 class CandidateIdentifier(GenericExternalIdentifier):

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -674,6 +674,28 @@ class CandidateCanonicalSearchFields(ProjectedBaseModel):
         return all((self.publication_year, self.authors, self.title))
 
 
+class YearDecayConfig(BaseModel):
+    """Immutable, versioned publication-year decay parameters (no query origin)."""
+
+    model_config = ConfigDict(frozen=True)
+
+    offset: int = Field(default=1, ge=0)
+    scale: int = Field(default=9, gt=0)
+    decay: float = Field(default=0.5, gt=0, lt=1)
+    weight: float = Field(default=0.10, ge=0)
+
+
+class YearDecay(YearDecayConfig):
+    """Resolved decay spec carried on a candidate query; origin is required."""
+
+    origin: int
+
+    @property
+    def max_boost(self) -> float:
+        """Cap on the summed function score; stays pinned to the bonus weight."""
+        return 1.0 + self.weight
+
+
 class CandidateCanonicalSearchQuery(BaseModel):
     """Service-owned candidate query specification for Elasticsearch translation."""
 
@@ -687,6 +709,7 @@ class CandidateCanonicalSearchQuery(BaseModel):
     author_terms: tuple[str, ...]
     author_tie_breaker: float
     publication_year_range: tuple[int, int] | None
+    publication_year_decay: YearDecay | None = None
     duplicate_determination: DuplicateDetermination
     excluded_reference_id: UUID | None
 

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -925,11 +925,8 @@ class CandidateSelectionRequest(BaseModel):
     track_total_hits: bool = Field(
         default=True,
         description=(
-            "Compute the exact Elasticsearch total-hit count. Defaults to true: "
-            "exact totals reveal the true candidate-pool size that the "
-            "Elasticsearch 10k default caps, which is useful for evaluation. Set "
-            "false for the Elasticsearch default (a lower-bound total), matching "
-            "the production nomination path."
+            "Exact total-hit count (true, past the ES 10k cap) or the Elasticsearch "
+            "default lower bound (false, as on the nomination path)."
         ),
     )
 

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -922,6 +922,15 @@ class CandidateSelectionRequest(BaseModel):
         default=True,
         description="Include hydrated bibliographic fields on each candidate.",
     )
+    track_total_hits: bool = Field(
+        default=True,
+        description=(
+            "Compute the exact Elasticsearch total-hit count for reporting. Set "
+            "false for the production-throughput proxy: the total becomes a lower "
+            "bound and the query skips the full count, which is expensive on broad "
+            "(e.g. no-year-filter) queries."
+        ),
+    )
 
 
 class CandidateElasticsearchRoute(BaseModel):

--- a/app/domain/references/models/retrieval_policy.py
+++ b/app/domain/references/models/retrieval_policy.py
@@ -24,9 +24,8 @@ class YearStrategy(Enum):
     """
     How a policy treats the publication-year signal.
 
-    Extension seam: HARD_WINDOW keeps the hard ±1 filter, NO_FILTER drops the
-    year clause, SOFT_DECAY drops the hard filter and instead applies a bounded
-    year-proximity bonus.
+    HARD_WINDOW keeps the hard ±1 filter, NO_FILTER drops the year clause, and
+    SOFT_DECAY drops the hard filter while applying a bounded year-proximity bonus.
     """
 
     HARD_WINDOW = "hard_window"

--- a/app/domain/references/models/retrieval_policy.py
+++ b/app/domain/references/models/retrieval_policy.py
@@ -9,7 +9,7 @@ focused experiment cycle; a policy name's semantics never change.
 from collections.abc import Mapping
 from enum import Enum
 from types import MappingProxyType
-from typing import Self
+from typing import Literal, Self
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
@@ -44,6 +44,7 @@ class RetrievalPolicy(BaseModel):
     year_strategy: YearStrategy
     requires_publication_year: bool = True
     year_decay: YearDecayConfig | None = None
+    title_fuzziness: Literal["AUTO", "0"] = "AUTO"
 
     @model_validator(mode="after")
     def _validate_year_decay_matches_strategy(self) -> Self:
@@ -92,6 +93,13 @@ RETRIEVAL_POLICIES: Mapping[RetrievalPolicyName, RetrievalPolicy] = MappingProxy
                 union_identifiers=True,
                 year_strategy=YearStrategy.SOFT_DECAY,
                 year_decay=YearDecayConfig(),
+            ),
+            RetrievalPolicy(
+                name=RetrievalPolicyName.SOFT_YEAR_DECAY_NONFUZZY_PROBE_V1,
+                union_identifiers=True,
+                year_strategy=YearStrategy.SOFT_DECAY,
+                year_decay=YearDecayConfig(),
+                title_fuzziness="0",
             ),
         )
     }

--- a/app/domain/references/models/retrieval_policy.py
+++ b/app/domain/references/models/retrieval_policy.py
@@ -9,12 +9,14 @@ focused experiment cycle; a policy name's semantics never change.
 from collections.abc import Mapping
 from enum import Enum
 from types import MappingProxyType
+from typing import Self
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from app.domain.references.models.models import (
     CandidateCanonicalSearchFields,
     RetrievalPolicyName,
+    YearDecayConfig,
 )
 
 
@@ -23,12 +25,13 @@ class YearStrategy(Enum):
     How a policy treats the publication-year signal.
 
     Extension seam: HARD_WINDOW keeps the hard ±1 filter, NO_FILTER drops the
-    year clause. A soft year-distance decay strategy (SOFT_DECAY) is added here
-    once we have grounding on its weights/policy.
+    year clause, SOFT_DECAY drops the hard filter and instead applies a bounded
+    year-proximity bonus.
     """
 
     HARD_WINDOW = "hard_window"
     NO_FILTER = "no_filter"
+    SOFT_DECAY = "soft_decay"
 
 
 class RetrievalPolicy(BaseModel):
@@ -40,6 +43,17 @@ class RetrievalPolicy(BaseModel):
     union_identifiers: bool
     year_strategy: YearStrategy
     requires_publication_year: bool = True
+    year_decay: YearDecayConfig | None = None
+
+    @model_validator(mode="after")
+    def _validate_year_decay_matches_strategy(self) -> Self:
+        """year_decay is present iff the strategy is SOFT_DECAY."""
+        if (self.year_decay is not None) != (
+            self.year_strategy is YearStrategy.SOFT_DECAY
+        ):
+            msg = "year_decay must be set iff year_strategy is SOFT_DECAY."
+            raise ValueError(msg)
+        return self
 
     def is_input_searchable(
         self, search_fields: CandidateCanonicalSearchFields
@@ -72,6 +86,12 @@ RETRIEVAL_POLICIES: Mapping[RetrievalPolicyName, RetrievalPolicy] = MappingProxy
                 union_identifiers=True,
                 year_strategy=YearStrategy.NO_FILTER,
                 requires_publication_year=False,
+            ),
+            RetrievalPolicy(
+                name=RetrievalPolicyName.SOFT_YEAR_DECAY_V1,
+                union_identifiers=True,
+                year_strategy=YearStrategy.SOFT_DECAY,
+                year_decay=YearDecayConfig(),
             ),
         )
     }

--- a/app/domain/references/models/retrieval_policy.py
+++ b/app/domain/references/models/retrieval_policy.py
@@ -21,16 +21,14 @@ from app.domain.references.models.models import (
 
 
 class YearStrategy(Enum):
-    """
-    How a policy treats the publication-year signal.
-
-    HARD_WINDOW keeps the hard ±1 filter, NO_FILTER drops the year clause, and
-    SOFT_DECAY drops the hard filter while applying a bounded year-proximity bonus.
-    """
+    """How a policy treats the publication-year signal."""
 
     HARD_WINDOW = "hard_window"
+    """Keep the hard ±1 publication-year filter."""
     NO_FILTER = "no_filter"
+    """Drop the year clause entirely."""
     SOFT_DECAY = "soft_decay"
+    """Drop the hard filter and apply a bounded year-proximity bonus instead."""
 
 
 class RetrievalPolicy(BaseModel):

--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -701,9 +701,8 @@ class ReferenceESRepository(
         )
         if query.publication_year_decay is None:
             return bool_query
-        # Soft year decay: keep every match (no hard year filter) but multiply in a
-        # bounded exponential year-proximity bonus. The exists guard leaves
-        # candidates with no publication_year on the base score (bonus weight 0).
+        # The exists guard keeps year-less candidates at the base score: ES scores
+        # a missing year as 1.0, which would otherwise grant them the full bonus.
         decay = query.publication_year_decay
         return Q(
             "function_score",

--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -679,7 +679,7 @@ class ReferenceESRepository(
                 duplicate_determination=query.duplicate_determination,
             )
         )
-        return Q(
+        bool_query = Q(
             "bool",
             must=[
                 Q(
@@ -698,6 +698,34 @@ class ReferenceESRepository(
             must_not=[Q("ids", values=[query.excluded_reference_id])]
             if query.excluded_reference_id
             else [],
+        )
+        if query.publication_year_decay is None:
+            return bool_query
+        # Soft year decay: keep every match (no hard year filter) but multiply in a
+        # bounded exponential year-proximity bonus. The exists guard leaves
+        # candidates with no publication_year on the base score (bonus weight 0).
+        decay = query.publication_year_decay
+        return Q(
+            "function_score",
+            query=bool_query,
+            functions=[
+                {"weight": 1.0},
+                {
+                    "filter": Q("exists", field="publication_year"),
+                    "exp": {
+                        "publication_year": {
+                            "origin": decay.origin,
+                            "offset": decay.offset,
+                            "scale": decay.scale,
+                            "decay": decay.decay,
+                        }
+                    },
+                    "weight": decay.weight,
+                },
+            ],
+            score_mode="sum",
+            boost_mode="multiply",
+            max_boost=decay.max_boost,
         )
 
     @trace_repository_method(tracer)

--- a/app/domain/references/services/deduplication_service.py
+++ b/app/domain/references/services/deduplication_service.py
@@ -128,7 +128,7 @@ def build_candidate_canonical_search_query(
 
     return CandidateCanonicalSearchQuery(
         title=search_fields.title,
-        title_fuzziness="AUTO",
+        title_fuzziness=policy.title_fuzziness,
         title_boost=2.0,
         title_operator="or",
         title_minimum_should_match="50%",

--- a/app/domain/references/services/deduplication_service.py
+++ b/app/domain/references/services/deduplication_service.py
@@ -29,6 +29,7 @@ from app.domain.references.models.models import (
     ReferenceDuplicateDecision,
     ReferenceDuplicateDeterminationResult,
     RetrievalPolicyName,
+    YearDecay,
 )
 from app.domain.references.models.projections import (
     CandidateReferenceProjection,
@@ -100,6 +101,7 @@ def build_candidate_canonical_search_query(
         msg = "Candidate retrieval requires a title."
         raise DeduplicationValueError(msg)
 
+    publication_year_decay: YearDecay | None = None
     match policy.year_strategy:
         case YearStrategy.HARD_WINDOW:
             publication_year_range = (
@@ -112,6 +114,15 @@ def build_candidate_canonical_search_query(
             )
         case YearStrategy.NO_FILTER:
             publication_year_range = None
+        case YearStrategy.SOFT_DECAY:
+            if policy.year_decay is None or not search_fields.publication_year:
+                msg = "soft_year_decay requires a decay config and a publication year."
+                raise DeduplicationValueError(msg)
+            publication_year_range = None
+            publication_year_decay = YearDecay(
+                **policy.year_decay.model_dump(),
+                origin=search_fields.publication_year,
+            )
         case _:  # pragma: no cover - exhaustiveness guard
             assert_never(policy.year_strategy)
 
@@ -127,6 +138,7 @@ def build_candidate_canonical_search_query(
         # The best-matching author dominates; additional matches add 10% each.
         author_tie_breaker=0.1,
         publication_year_range=publication_year_range,
+        publication_year_decay=publication_year_decay,
         # Prevent concurrently deduplicated references forming conflicting links.
         duplicate_determination=DuplicateDetermination.CANONICAL,
         excluded_reference_id=reference_id,

--- a/app/domain/references/services/deduplication_service.py
+++ b/app/domain/references/services/deduplication_service.py
@@ -236,9 +236,9 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
             es_result = await self.es_uow.references.search_for_candidate_canonicals(
                 query,
                 k=k,
-                # The evaluation endpoint reports the exact total; the nomination
-                # path does not, so only this caller opts into the full count.
-                track_total_hits=True,
+                # Exact total for reporting by default; callers benchmarking
+                # throughput pass false for the production-cost proxy.
+                track_total_hits=request.track_total_hits,
             )
 
         es_hits = es_result.hits if es_result else []

--- a/app/domain/references/services/deduplication_service.py
+++ b/app/domain/references/services/deduplication_service.py
@@ -236,8 +236,6 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
             es_result = await self.es_uow.references.search_for_candidate_canonicals(
                 query,
                 k=k,
-                # Exact total for reporting by default; callers benchmarking
-                # throughput pass false for the production-cost proxy.
                 track_total_hits=request.track_total_hits,
             )
 

--- a/tests/integration/test_es_references.py
+++ b/tests/integration/test_es_references.py
@@ -768,3 +768,84 @@ async def test_no_year_filter_returns_year_drifted_candidate(
     assert drifted_target.id in unfiltered_ids
     # Tiny index: removing the year gate strictly widens eligibility.
     assert unfiltered.total.value >= hard.total.value
+
+
+async def test_soft_year_decay_returns_and_reranks_year_drifted_candidate(
+    es_reference_repository: ReferenceESRepository, reference: Reference
+):
+    """SOFT_DECAY keeps the far-year duplicate (recall) but ranks the near-year duplicate above it (proximity bonus)."""
+
+    def _with_biblio(ref_id: object, year: int) -> Reference:
+        return reference.model_copy(
+            update={
+                "id": ref_id,
+                "enhancements": [
+                    enhancement.model_copy(
+                        update={
+                            "id": uuid7(),
+                            "reference_id": ref_id,
+                            "content": (
+                                enhancement.content.model_copy(
+                                    update={
+                                        "title": "Shared Drifted Title",
+                                        "authorship": [
+                                            Authorship(
+                                                display_name="Jane Smith",
+                                                position=AuthorPosition.FIRST,
+                                            )
+                                        ],
+                                        "publication_year": year,
+                                    }
+                                )
+                                if enhancement.content.enhancement_type
+                                == EnhancementType.BIBLIOGRAPHIC
+                                else enhancement.content
+                            ),
+                        }
+                    )
+                    for enhancement in (reference.enhancements or [])
+                ],
+            }
+        )
+
+    query_ref = _with_biblio(uuid7(), 2000)
+    near_target = _with_biblio(uuid7(), 2001)  # distance 1 -> full bonus
+    far_target = _with_biblio(uuid7(), 2010)  # distance 10 -> halved bonus
+
+    await es_reference_repository.add(to_indexable(query_ref))
+    await es_reference_repository.add(to_indexable(near_target))
+    await es_reference_repository.add(to_indexable(far_target))
+    await es_reference_repository._client.indices.refresh(  # noqa: SLF001
+        index=es_reference_repository._persistence_cls.Index.name  # noqa: SLF001
+    )
+
+    search_fields = (
+        ReferenceSearchFieldsProjection.get_canonical_candidate_search_fields(query_ref)
+    )
+    no_filter_query = build_candidate_canonical_search_query(
+        search_fields,
+        scoring_config=DedupCandidateScoringConfig(),
+        policy=resolve_retrieval_policy(RetrievalPolicyName.NO_YEAR_FILTER_V1),
+        reference_id=query_ref.id,
+    )
+    soft_query = build_candidate_canonical_search_query(
+        search_fields,
+        scoring_config=DedupCandidateScoringConfig(),
+        policy=resolve_retrieval_policy(RetrievalPolicyName.SOFT_YEAR_DECAY_V1),
+        reference_id=query_ref.id,
+    )
+    no_filter = await es_reference_repository.search_for_candidate_canonicals(
+        no_filter_query, k=100
+    )
+    soft = await es_reference_repository.search_for_candidate_canonicals(
+        soft_query, k=100
+    )
+
+    soft_ranks = {hit.id: rank for rank, hit in enumerate(soft.hits)}
+    # Recall: soft decay filters nothing; the far-year duplicate is still returned.
+    assert far_target.id in soft_ranks
+    assert near_target.id in soft_ranks
+    # Same matching set as no_year_filter_v1: decay only reranks.
+    assert soft.total.value == no_filter.total.value
+    # Proximity bonus: the near-year duplicate outranks the far-year one.
+    assert soft_ranks[near_target.id] < soft_ranks[far_target.id]

--- a/tests/integration/test_es_references.py
+++ b/tests/integration/test_es_references.py
@@ -776,10 +776,10 @@ async def test_no_year_filter_returns_year_drifted_candidate(
 async def test_soft_year_decay_returns_and_reranks_year_drifted_candidate(
     es_reference_repository: ReferenceESRepository, reference: Reference
 ):
-    """SOFT_DECAY keeps the far-year duplicate (recall) but ranks the near-year duplicate above it (proximity bonus)."""
+    """SOFT_DECAY preserves recall while preferring closer publication years."""
     query_ref = _reference_with_drifted_biblio(reference, uuid7(), 2000)
-    near_target = _reference_with_drifted_biblio(reference, uuid7(), 2001)  # dist 1
-    far_target = _reference_with_drifted_biblio(reference, uuid7(), 2010)  # dist 10
+    near_target = _reference_with_drifted_biblio(reference, uuid7(), 2001)
+    far_target = _reference_with_drifted_biblio(reference, uuid7(), 2010)
 
     await es_reference_repository.add(to_indexable(query_ref))
     await es_reference_repository.add(to_indexable(near_target))

--- a/tests/integration/test_es_references.py
+++ b/tests/integration/test_es_references.py
@@ -690,46 +690,49 @@ async def test_canonical_candidate_search(
     assert not results.hits
 
 
+def _reference_with_drifted_biblio(
+    reference: Reference, ref_id: object, year: int
+) -> Reference:
+    """Copy the fixture reference with a shared drifted title/author and a set year."""
+    return reference.model_copy(
+        update={
+            "id": ref_id,
+            "enhancements": [
+                enhancement.model_copy(
+                    update={
+                        "id": uuid7(),
+                        "reference_id": ref_id,
+                        "content": (
+                            enhancement.content.model_copy(
+                                update={
+                                    "title": "Shared Drifted Title",
+                                    "authorship": [
+                                        Authorship(
+                                            display_name="Jane Smith",
+                                            position=AuthorPosition.FIRST,
+                                        )
+                                    ],
+                                    "publication_year": year,
+                                }
+                            )
+                            if enhancement.content.enhancement_type
+                            == EnhancementType.BIBLIOGRAPHIC
+                            else enhancement.content
+                        ),
+                    }
+                )
+                for enhancement in (reference.enhancements or [])
+            ],
+        }
+    )
+
+
 async def test_no_year_filter_returns_year_drifted_candidate(
     es_reference_repository: ReferenceESRepository, reference: Reference
 ):
     """NO_FILTER drops the ±1 year gate: a 10-year-drifted duplicate is returned."""
-
-    def _with_biblio(ref_id: object, year: int) -> Reference:
-        return reference.model_copy(
-            update={
-                "id": ref_id,
-                "enhancements": [
-                    enhancement.model_copy(
-                        update={
-                            "id": uuid7(),
-                            "reference_id": ref_id,
-                            "content": (
-                                enhancement.content.model_copy(
-                                    update={
-                                        "title": "Shared Drifted Title",
-                                        "authorship": [
-                                            Authorship(
-                                                display_name="Jane Smith",
-                                                position=AuthorPosition.FIRST,
-                                            )
-                                        ],
-                                        "publication_year": year,
-                                    }
-                                )
-                                if enhancement.content.enhancement_type
-                                == EnhancementType.BIBLIOGRAPHIC
-                                else enhancement.content
-                            ),
-                        }
-                    )
-                    for enhancement in (reference.enhancements or [])
-                ],
-            }
-        )
-
-    query_ref = _with_biblio(uuid7(), 2000)
-    drifted_target = _with_biblio(uuid7(), 2010)
+    query_ref = _reference_with_drifted_biblio(reference, uuid7(), 2000)
+    drifted_target = _reference_with_drifted_biblio(reference, uuid7(), 2010)
 
     await es_reference_repository.add(to_indexable(query_ref))
     await es_reference_repository.add(to_indexable(drifted_target))
@@ -774,43 +777,9 @@ async def test_soft_year_decay_returns_and_reranks_year_drifted_candidate(
     es_reference_repository: ReferenceESRepository, reference: Reference
 ):
     """SOFT_DECAY keeps the far-year duplicate (recall) but ranks the near-year duplicate above it (proximity bonus)."""
-
-    def _with_biblio(ref_id: object, year: int) -> Reference:
-        return reference.model_copy(
-            update={
-                "id": ref_id,
-                "enhancements": [
-                    enhancement.model_copy(
-                        update={
-                            "id": uuid7(),
-                            "reference_id": ref_id,
-                            "content": (
-                                enhancement.content.model_copy(
-                                    update={
-                                        "title": "Shared Drifted Title",
-                                        "authorship": [
-                                            Authorship(
-                                                display_name="Jane Smith",
-                                                position=AuthorPosition.FIRST,
-                                            )
-                                        ],
-                                        "publication_year": year,
-                                    }
-                                )
-                                if enhancement.content.enhancement_type
-                                == EnhancementType.BIBLIOGRAPHIC
-                                else enhancement.content
-                            ),
-                        }
-                    )
-                    for enhancement in (reference.enhancements or [])
-                ],
-            }
-        )
-
-    query_ref = _with_biblio(uuid7(), 2000)
-    near_target = _with_biblio(uuid7(), 2001)  # distance 1 -> full bonus
-    far_target = _with_biblio(uuid7(), 2010)  # distance 10 -> halved bonus
+    query_ref = _reference_with_drifted_biblio(reference, uuid7(), 2000)
+    near_target = _reference_with_drifted_biblio(reference, uuid7(), 2001)  # dist 1
+    far_target = _reference_with_drifted_biblio(reference, uuid7(), 2010)  # dist 10
 
     await es_reference_repository.add(to_indexable(query_ref))
     await es_reference_repository.add(to_indexable(near_target))

--- a/tests/unit/domain/references/deduplication/test_candidate_selection.py
+++ b/tests/unit/domain/references/deduplication/test_candidate_selection.py
@@ -531,3 +531,35 @@ async def test_writes_no_duplicate_decision_state(build_service):
     decisions.add_bulk.assert_not_awaited()
     decisions.update_by_pk.assert_not_awaited()
     decisions.merge.assert_not_awaited()
+
+
+def test_track_total_hits_defaults_true_and_is_overridable():
+    default_request = CandidateSelectionRequest(
+        input=CandidateSelectionInput(title="t", authors=["a"], publication_year=2020),
+    )
+    assert default_request.track_total_hits is True
+    proxy_request = CandidateSelectionRequest(
+        input=CandidateSelectionInput(title="t", authors=["a"], publication_year=2020),
+        track_total_hits=False,
+    )
+    assert proxy_request.track_total_hits is False
+
+
+@pytest.mark.asyncio
+async def test_track_total_hits_forwarded_to_es_search(build_service):
+    service, es_refs, _, _ = build_service(
+        es_result=_es_result(ESScoreResult(id=uuid7(), score=4.0))
+    )
+
+    await service.get_deduplication_candidates(
+        CandidateSelectionRequest(
+            input=CandidateSelectionInput(
+                title="t", authors=["a"], publication_year=2020
+            ),
+            track_total_hits=False,
+            hydrate=False,
+        )
+    )
+
+    call = es_refs.search_for_candidate_canonicals.call_args
+    assert call.kwargs["track_total_hits"] is False

--- a/tests/unit/domain/references/models/test_retrieval_policy.py
+++ b/tests/unit/domain/references/models/test_retrieval_policy.py
@@ -140,6 +140,18 @@ def test_non_soft_decay_rejects_a_decay_config():
         )
 
 
+def test_soft_decay_policies_unsearchable_without_year():
+    """SOFT_DECAY needs a year origin, so a yearless input is not searchable."""
+    fields = CandidateCanonicalSearchFields(
+        title="t", authors=["a"], publication_year=None
+    )
+    for name in (
+        RetrievalPolicyName.SOFT_YEAR_DECAY_V1,
+        RetrievalPolicyName.SOFT_YEAR_DECAY_NONFUZZY_PROBE_V1,
+    ):
+        assert resolve_retrieval_policy(name).is_input_searchable(fields) is False
+
+
 def test_soft_year_decay_nonfuzzy_probe_v1_regime():
     policy = resolve_retrieval_policy(
         RetrievalPolicyName.SOFT_YEAR_DECAY_NONFUZZY_PROBE_V1

--- a/tests/unit/domain/references/models/test_retrieval_policy.py
+++ b/tests/unit/domain/references/models/test_retrieval_policy.py
@@ -102,3 +102,39 @@ def test_registry_is_read_only():
         RETRIEVAL_POLICIES["injected"] = resolve_retrieval_policy(
             RetrievalPolicyName.CURRENT_FUZZY_V1
         )
+
+
+def test_soft_year_decay_v1_regime():
+    from app.domain.references.models.models import YearDecayConfig
+
+    assert RetrievalPolicyName.SOFT_YEAR_DECAY_V1.value == "soft_year_decay_v1"
+    policy = resolve_retrieval_policy(RetrievalPolicyName.SOFT_YEAR_DECAY_V1)
+    assert policy.year_strategy is YearStrategy.SOFT_DECAY
+    assert policy.union_identifiers is True
+    assert policy.requires_publication_year is True
+    assert policy.year_decay == YearDecayConfig()
+
+
+def test_soft_decay_requires_a_decay_config():
+    from app.domain.references.models.retrieval_policy import RetrievalPolicy
+
+    with pytest.raises(ValidationError):
+        RetrievalPolicy(
+            name=RetrievalPolicyName.SOFT_YEAR_DECAY_V1,
+            union_identifiers=True,
+            year_strategy=YearStrategy.SOFT_DECAY,
+            year_decay=None,
+        )
+
+
+def test_non_soft_decay_rejects_a_decay_config():
+    from app.domain.references.models.models import YearDecayConfig
+    from app.domain.references.models.retrieval_policy import RetrievalPolicy
+
+    with pytest.raises(ValidationError):
+        RetrievalPolicy(
+            name=RetrievalPolicyName.CURRENT_FUZZY_V1,
+            union_identifiers=True,
+            year_strategy=YearStrategy.HARD_WINDOW,
+            year_decay=YearDecayConfig(),
+        )

--- a/tests/unit/domain/references/models/test_retrieval_policy.py
+++ b/tests/unit/domain/references/models/test_retrieval_policy.py
@@ -138,3 +138,20 @@ def test_non_soft_decay_rejects_a_decay_config():
             year_strategy=YearStrategy.HARD_WINDOW,
             year_decay=YearDecayConfig(),
         )
+
+
+def test_soft_year_decay_nonfuzzy_probe_v1_regime():
+    policy = resolve_retrieval_policy(
+        RetrievalPolicyName.SOFT_YEAR_DECAY_NONFUZZY_PROBE_V1
+    )
+    assert policy.year_strategy is YearStrategy.SOFT_DECAY
+    assert policy.requires_publication_year is True
+    assert policy.title_fuzziness == "0"
+
+
+def test_fuzzy_policies_default_to_auto_fuzziness():
+    for name in (
+        RetrievalPolicyName.CURRENT_FUZZY_V1,
+        RetrievalPolicyName.SOFT_YEAR_DECAY_V1,
+    ):
+        assert resolve_retrieval_policy(name).title_fuzziness == "AUTO"

--- a/tests/unit/domain/references/models/test_year_decay.py
+++ b/tests/unit/domain/references/models/test_year_decay.py
@@ -1,0 +1,39 @@
+"""Tests for publication-year decay models."""
+
+import pytest
+from pydantic import ValidationError
+
+from app.domain.references.models.models import (
+    YearDecay,
+    YearDecayConfig,
+)
+
+
+def test_config_defaults_match_v1_constants():
+    config = YearDecayConfig()
+    assert (config.offset, config.scale, config.decay, config.weight) == (
+        1,
+        9,
+        0.5,
+        0.10,
+    )
+
+
+def test_max_boost_is_derived_from_weight():
+    assert YearDecay(origin=2000).max_boost == pytest.approx(1.10)
+    assert YearDecay(origin=2000, weight=0.2).max_boost == pytest.approx(1.20)
+
+
+def test_year_decay_requires_origin():
+    with pytest.raises(ValidationError):
+        YearDecay()  # origin is required
+
+
+def test_decay_must_be_below_one():
+    with pytest.raises(ValidationError):
+        YearDecayConfig(decay=1.0)
+
+
+def test_config_is_frozen():
+    with pytest.raises(ValidationError):
+        YearDecayConfig().offset = 5

--- a/tests/unit/domain/references/test_candidate_query_builder.py
+++ b/tests/unit/domain/references/test_candidate_query_builder.py
@@ -249,3 +249,13 @@ def test_soft_decay_es_translation_wraps_function_score():
             "max_boost": 1.1,
         }
     }
+
+
+def test_nonfuzzy_probe_disables_title_fuzziness():
+    fields = CandidateCanonicalSearchFields(
+        title="Shared Title", authors=["Smith"], publication_year=2000
+    )
+    fuzzy = _query(fields, RetrievalPolicyName.SOFT_YEAR_DECAY_V1)
+    nonfuzzy = _query(fields, RetrievalPolicyName.SOFT_YEAR_DECAY_NONFUZZY_PROBE_V1)
+    assert fuzzy.title_fuzziness == "AUTO"
+    assert nonfuzzy.title_fuzziness == "0"

--- a/tests/unit/domain/references/test_candidate_query_builder.py
+++ b/tests/unit/domain/references/test_candidate_query_builder.py
@@ -179,3 +179,73 @@ def test_soft_decay_without_year_raises():
     fields = CandidateCanonicalSearchFields(title="Shared Title", authors=["Smith"])
     with pytest.raises(DeduplicationValueError, match="publication year"):
         _query(fields, RetrievalPolicyName.SOFT_YEAR_DECAY_V1)
+
+
+def test_soft_decay_es_translation_wraps_function_score():
+    reference_id = UUID("00000000-0000-0000-0000-000000000001")
+    fields = CandidateCanonicalSearchFields(
+        title="Shared Title", authors=["G Smith"], publication_year=2000
+    )
+    query = _query(
+        fields,
+        RetrievalPolicyName.SOFT_YEAR_DECAY_V1,
+        reference_id=reference_id,
+    )
+
+    assert ReferenceESRepository._to_es_candidate_query(query).to_dict() == {
+        "function_score": {
+            "query": {
+                "bool": {
+                    "must": [
+                        {
+                            "match": {
+                                "title": {
+                                    "query": "Shared Title",
+                                    "fuzziness": "AUTO",
+                                    "boost": 2.0,
+                                    "operator": "or",
+                                    "minimum_should_match": "50%",
+                                }
+                            }
+                        }
+                    ],
+                    "should": [
+                        {
+                            "dis_max": {
+                                "queries": [{"match": {"authors": "Smith"}}],
+                                "tie_breaker": 0.1,
+                            }
+                        }
+                    ],
+                    "filter": [
+                        {
+                            "term": {
+                                "duplicate_determination": (
+                                    DuplicateDetermination.CANONICAL
+                                )
+                            }
+                        }
+                    ],
+                    "must_not": [{"ids": {"values": [reference_id]}}],
+                }
+            },
+            "functions": [
+                {"weight": 1.0},
+                {
+                    "filter": {"exists": {"field": "publication_year"}},
+                    "exp": {
+                        "publication_year": {
+                            "origin": 2000,
+                            "offset": 1,
+                            "scale": 9,
+                            "decay": 0.5,
+                        }
+                    },
+                    "weight": 0.1,
+                },
+            ],
+            "score_mode": "sum",
+            "boost_mode": "multiply",
+            "max_boost": 1.1,
+        }
+    }

--- a/tests/unit/domain/references/test_candidate_query_builder.py
+++ b/tests/unit/domain/references/test_candidate_query_builder.py
@@ -155,3 +155,27 @@ def test_es_translation_preserves_baseline_query_semantics():
             "must_not": [{"ids": {"values": [reference_id]}}],
         }
     }
+
+
+def test_soft_decay_builds_decay_spec_and_no_range():
+    fields = CandidateCanonicalSearchFields(
+        title="Shared Title", authors=["Smith"], publication_year=2000
+    )
+    query = _query(fields, RetrievalPolicyName.SOFT_YEAR_DECAY_V1)
+    assert query.publication_year_range is None
+    decay = query.publication_year_decay
+    assert decay is not None
+    assert (decay.origin, decay.offset, decay.scale, decay.decay, decay.weight) == (
+        2000,
+        1,
+        9,
+        0.5,
+        0.10,
+    )
+    assert decay.max_boost == pytest.approx(1.10)
+
+
+def test_soft_decay_without_year_raises():
+    fields = CandidateCanonicalSearchFields(title="Shared Title", authors=["Smith"])
+    with pytest.raises(DeduplicationValueError, match="publication year"):
+        _query(fields, RetrievalPolicyName.SOFT_YEAR_DECAY_V1)


### PR DESCRIPTION
## Summary

Adds one new versioned candidate-retrieval policy and the single Elasticsearch
translation feature it needs: a bounded publication-year proximity bonus. This lets
soft publication-year decay be evaluated through the existing Candidate Selection API
without touching the production nomination path.

New policies, exposed by name through `POST /v1/references/deduplication/candidates/`
(evaluator-facing only):

- `soft_year_decay_v1` — drops the hard ±1 publication-year filter and instead
  multiplies in a bounded native Elasticsearch exponential year-proximity bonus (at
  most +10%, halving around ten years). Year becomes corroboration, not a gate:
  nothing is excluded, near-year candidates just rank above far-year ones.
- `soft_year_decay_nonfuzzy_probe_v1` — evaluation-only probe: the same decay with a
  zero-edit-distance (non-fuzzy) title match, to measure the recall and latency impact
  of disabling fuzzy title matching for this query shape.

How it is layered:

- Immutable, versioned decay parameters (`YearDecayConfig`) live on the policy. The
  service query builder resolves them into a query-carried `YearDecay` (adding the
  per-query origin); the repository translates a decay-bearing query into an ES
  `function_score` wrapping the otherwise-unchanged `bool`. The repository only
  translates a resolved query object; the policy behaviour is chosen in the service.
- Title fuzziness moves from a hardcoded builder literal to a policy attribute so the
  probe can set it. Behaviour-preserving for every existing policy (all default
  `AUTO`).

## Benchmark support: track_total_hits (default-preserving)

Also adds `track_total_hits` as a per-request option on the candidate-selection
endpoint. The default stays `true`, so existing responses keep exact totals, which
reveal the true candidate-pool size past the Elasticsearch 10k default cap (useful
for evaluation, and measured latency-neutral on staging: p50 ~268ms vs ~260ms). A
benchmark sets it to `false` for the Elasticsearch default lower-bound total,
matching the production nomination path. This is configurable for benchmark
comparability, default-preserving, and changes no production behaviour.

## Not changed

- Default candidate-selection policy remains `current_fuzzy_v1`.
- The production nomination path is unchanged: `nominate_candidate_canonicals` still
  uses `current_fuzzy_v1` and leaves `track_total_hits` off.
- Scoring config and duplicate-decision actuation are unchanged; the endpoint stays
  read-only and writes no decision or candidate state.
- No persisted-model or migration changes. Domain models and the ES query only; the
  retrieval policy is not part of the SDK.

## Validation performed

- Typecheck clean (`pyright`) on the changed modules; full references unit suite green.
- ES integration arm proves `soft_year_decay_v1` accepts the `function_score` DSL,
  preserves the no-filter matching set (the ten-year-drifted duplicate is still
  returned), and ranks the near-year duplicate above the far-year one.
- Live-validated the endpoint against local DR by capturing the emitted query per
  policy via search slowlog: `soft_year_decay_v1` emits the `function_score` with the
  `exists: publication_year` guard and no range filter; `current_fuzzy_v1` (control)
  keeps the `range publication_year` filter and emits no `function_score`; the
  non-fuzzy probe emits `fuzziness:"0"`. The multipliers observed against real
  Elasticsearch matched the spec (missing-year 1.00, near-year 1.10, ten-year 1.05).
- Confirmed the searchability gate blocks a yearless `soft_year_decay_v1` input from
  the ES route, and an unknown policy returns HTTP 422 at request validation.
- Live-validated `track_total_hits`: `false` omits the count from the emitted query
  (Elasticsearch default lower bound); default `true` emits the exact full count.

## Follow-ups

- Weight/curve calibration, the recall/precision sweep, and the fuzzy-vs-non-fuzzy
  comparison run in the evaluation harness. These policies are exposed by name only
  and are not wired into the nomination default.