### PR TITLE
Support relevance as a search parameter

### DIFF
--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -284,6 +284,9 @@ class ReferenceESRepository(
     }
     """Mapping from a facet type to the ES field its counts are aggregated on."""
 
+    _RELEVANCE_SORT_KEY: ClassVar[str] = "relevance"
+    """Public sort token for ES's built-in ``_score``; the default sort."""
+
     def __init__(self, client: AsyncElasticsearch) -> None:
         """Initialize the repository with the Elasticsearch client."""
         super().__init__(
@@ -377,6 +380,19 @@ class ReferenceESRepository(
             )
         return clauses
 
+    def _normalize_sort_key(self, key: str) -> str | dict[str, Any]:
+        """
+        Translate `relevance` to ES `_score`.
+
+        ``relevance`` is a public API search key that maps to
+        ES's built-in ``_score``. Unlike mapped fields, its default direction is
+        best-first (descending).
+        """
+        if key.lstrip("-+") == self._RELEVANCE_SORT_KEY:
+            order = "asc" if key.startswith("-") else "desc"
+            return {"_score": {"order": order}}
+        return key
+
     @trace_repository_method(tracer)
     async def search(
         self,
@@ -392,12 +408,13 @@ class ReferenceESRepository(
         tiebreaker: dict[str, Any] = {
             "id": {"order": "desc", "unmapped_type": "keyword"}
         }
+        sort_keys = [self._normalize_sort_key(key) for key in (sort or ["relevance"])]
         return await self.search_with_query_string(
             query.query_string,
             fields=self.default_search_fields,
             page=page,
             page_size=page_size,
-            sort=[*sort, tiebreaker] if sort else ["_score", tiebreaker],
+            sort=[*sort_keys, tiebreaker],
             filter_clauses=self._build_filter_clauses(query),
             parse_document=False,
         )
@@ -416,7 +433,9 @@ class ReferenceESRepository(
         ``scan_with_query_string`` appends the ``id`` tiebreaker, so unlike
         :meth:`search` this method doesn't add one itself.
         """
-        sort_keys: list[str | dict[str, Any]] = list(sort) if sort else ["_score"]
+        sort_keys: list[str | dict[str, Any]] = [
+            self._normalize_sort_key(key) for key in (sort or ["relevance"])
+        ]
         async for page in self.scan_with_query_string(
             query.query_string,
             fields=self.default_search_fields,

--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -408,7 +408,10 @@ class ReferenceESRepository(
         tiebreaker: dict[str, Any] = {
             "id": {"order": "desc", "unmapped_type": "keyword"}
         }
-        sort_keys = [self._normalize_sort_key(key) for key in (sort or ["relevance"])]
+        sort_keys = [
+            self._normalize_sort_key(key)
+            for key in (sort or [self._RELEVANCE_SORT_KEY])
+        ]
         return await self.search_with_query_string(
             query.query_string,
             fields=self.default_search_fields,
@@ -434,7 +437,8 @@ class ReferenceESRepository(
         :meth:`search` this method doesn't add one itself.
         """
         sort_keys: list[str | dict[str, Any]] = [
-            self._normalize_sort_key(key) for key in (sort or ["relevance"])
+            self._normalize_sort_key(key)
+            for key in (sort or [self._RELEVANCE_SORT_KEY])
         ]
         async for page in self.scan_with_query_string(
             query.query_string,

--- a/app/domain/references/routes.py
+++ b/app/domain/references/routes.py
@@ -547,7 +547,8 @@ SortParam = Annotated[
     Query(
         description="A list of fields to sort the results by. "
         "Prefix a field with `-` to sort in descending order. "
-        "If omitted, will sort by relevance score descending. "
+        "Use `relevance` to sort by search relevance score, best matches "
+        "first. This is opposite behavior to other fields which order by ascending."
         "Multiple sort fields can be provided and will be applied "
         "in the order given. Sort fields cannot be `text` fields.",
     ),

--- a/docs/procedures/search.rst
+++ b/docs/procedures/search.rst
@@ -164,22 +164,40 @@ If omitted, defaults to the first page.
 Sort
 _____________
 
-The field(s) to sort the results by. Use ``-`` prefix to sort in descending order.
-
-If not provided, defaults to ``relevance`` as scored by the search engine.
+The field(s) to sort the results by.
 
 Multiple sort fields can be provided; they will be applied in the order given.
 
+If ``sort`` is omitted, results default to ``relevance`` in descending order.
+
+Sort by mapped fields
+    Mapped fields (such as ``publication_year`` or ``inclusion_destiny``)
+    sort in **ascending** order. Prefix a field with ``-`` to sort it in **descending**
+    order instead.
+
+Sorting by relevance
+    The special ``relevance`` key sorts by the search engine's relevance score rather
+    than a mapped field. Unlike mapped fields, ``relevance`` defaults to **descending**
+    order to provide best matches first. To reverse this and return the least relevant results
+    first, prefix it as ``-relevance``.
+
+Any of the :ref:`searchable fields <search-fields>` may be sorted on, except free-text
+fields (``title``, ``abstract``, ``authors`` and ``linked_data_labels``), which cannot be
+used as sort keys.
+
 .. code-block::
 
-    # Sort by inclusion score ascending:
-    ?q=...&sort=inclusion:destiny
+    # Sort by relevance, same as no sort parameter:
+    ?q=...&sort=relevance
 
     # Sort by publication year descending:
     ?q=...&sort=-publication_year
 
     # Sort by publication year ascending, then inclusion score descending:
-    ?q=...&sort=publication_year&sort=-inclusion:destiny
+    ?q=...&sort=publication_year&sort=-inclusion_destiny
+
+    # Sort by relevance first, then break ties by newest publication year:
+    ?q=...&sort=relevance&sort=-publication_year
 
 Returns
 """""""

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -761,3 +761,47 @@ async def test_scan_pages_all_matches(es_client: AsyncElasticsearch) -> None:
         for hit in page.hits
     ]
     assert len(limited) == 15
+
+
+async def test_relevance_sort_orders_by_score_and_can_invert(
+    es_client: AsyncElasticsearch,
+) -> None:
+    """
+    ``relevance`` sorts best-first by ES ``_score``; ``-relevance`` inverts it.
+
+    All three titles contain the query token, but shorter titles score higher
+    under BM25's field-length norm, giving them a strict relevance order that
+    the id tiebreaker never has to break.
+    """
+    titles = {
+        "high": "alpha",
+        "mid": "alpha beta gamma delta epsilon",
+        "low": (
+            "alpha beta gamma delta epsilon zeta eta "
+            "theta iota kappa lambda mu nu xi omicron"
+        ),
+    }
+    references = {
+        label: ReferenceFactory.build(
+            enhancements=[
+                EnhancementFactory.build(
+                    content=BibliographicMetadataEnhancementFactory.build(title=title)
+                )
+            ]
+        )
+        for label, title in titles.items()
+    }
+    repository = await _wipe_and_index(es_client, list(references.values()))
+    query = SearchQuery(query_string="title:alpha")
+
+    async def search_ids(sort: list[str] | None) -> list[UUID]:
+        result = await repository.search(query, sort=sort)
+        return [hit.id for hit in result.hits]
+
+    best_first = [references[label].id for label in ("high", "mid", "low")]
+
+    # Explicit and omitted sort both rank best matches first.
+    assert await search_ids(["relevance"]) == best_first
+    assert await search_ids(None) == best_first
+    # -relevance inverts to worst-first.
+    assert await search_ids(["-relevance"]) == list(reversed(best_first))

--- a/tests/unit/domain/references/services/test_search_filter_clauses.py
+++ b/tests/unit/domain/references/services/test_search_filter_clauses.py
@@ -175,3 +175,36 @@ def test_build_filter_clauses_excludes_named_facet_filters():
         Range(publication_year={"gte": 2020}),
         Term(annotations="taxonomy:x/y"),
     ]
+
+
+def test_normalize_sort_key_bare_relevance_is_best_first():
+    """Bare ``relevance`` maps to ``_score`` descending (best matches first)."""
+    repository = _StubReferenceESRepository()
+    assert repository._normalize_sort_key("relevance") == {  # noqa: SLF001
+        "_score": {"order": "desc"}
+    }
+
+
+def test_normalize_sort_key_descending_relevance_is_worst_first():
+    """``-relevance`` inverts to ``_score`` ascending (worst matches first)."""
+    repository = _StubReferenceESRepository()
+    assert repository._normalize_sort_key("-relevance") == {  # noqa: SLF001
+        "_score": {"order": "asc"}
+    }
+
+
+def test_normalize_sort_key_plus_relevance_is_best_first():
+    """A leading ``+`` is stripped but does not invert the best-first default."""
+    repository = _StubReferenceESRepository()
+    assert repository._normalize_sort_key("+relevance") == {  # noqa: SLF001
+        "_score": {"order": "desc"}
+    }
+
+
+def test_normalize_sort_key_passes_mapped_fields_through_unchanged():
+    """Non-``relevance`` tokens are returned verbatim for ES to resolve."""
+    repository = _StubReferenceESRepository()
+    assert repository._normalize_sort_key("year") == "year"  # noqa: SLF001
+    assert repository._normalize_sort_key("-year") == "-year"  # noqa: SLF001
+    # A field that merely contains "relevance" is not the virtual token.
+    assert repository._normalize_sort_key("relevance_score") == "relevance_score"  # noqa: SLF001


### PR DESCRIPTION
## Context 
Resolves errors seen here https://covidence.slack.com/archives/C099F6PR8R2/p1784816418339419 with a user attempting to sort by relevance (which was previously implied to be available as a parameter by our documentation https://destiny-evidence.github.io/destiny-repository/procedures/search.html#sort).

## What's Changed

I've introduced a normalizing function to convert `relevance` to a `_score` search dict in the ReferenceESRepository. 

## Design Decision
Bare relevance defaults to a **descending order search**, as a user ordering by relevance would expect best matches to be returned first. This is opposite behaviour to document fields like publication year, which sort ascending by default. Have added some documentation within codebase to this. 