### PR TITLE
Add match/dispatch telemetry to robot automation percolation

### DIFF
--- a/app/core/telemetry/attributes.py
+++ b/app/core/telemetry/attributes.py
@@ -97,7 +97,7 @@ class Attributes(StrEnum):
     # Robot automation detection (percolation)
     PERCOLATION_DOCUMENT_COUNT = "app.percolation.document_count"
     PERCOLATION_MATCH_COUNT = "app.percolation.match_count"
-    ROBOT_AUTOMATION_MATCHED_COUNT = "app.robot_automation.matched_count"
+    ROBOT_AUTOMATION_MATCH_COUNT = "app.robot_automation.match_count"
     ROBOT_AUTOMATION_PENDING_ENHANCEMENT_COUNT = (
         "app.robot_automation.pending_enhancement_count"
     )

--- a/app/core/telemetry/attributes.py
+++ b/app/core/telemetry/attributes.py
@@ -94,6 +94,14 @@ class Attributes(StrEnum):
     SEARCH_EXPORT_ID = "app.search_export.id"
     REFERENCE_EXPORT_ID = "app.reference_export.id"
 
+    # Robot automation detection (percolation)
+    PERCOLATION_DOCUMENT_COUNT = "app.percolation.document_count"
+    PERCOLATION_MATCH_COUNT = "app.percolation.match_count"
+    ROBOT_AUTOMATION_MATCHED_COUNT = "app.robot_automation.matched_count"
+    ROBOT_AUTOMATION_PENDING_ENHANCEMENT_COUNT = (
+        "app.robot_automation.pending_enhancement_count"
+    )
+
     # Other
     FILE_LINE_NO = "app.file.line_number"
 

--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -26,6 +26,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.core.config import get_settings
+from app.core.telemetry.attributes import Attributes, trace_attribute
 from app.core.telemetry.repository import (
     trace_repository_generator,
     trace_repository_method,
@@ -1039,6 +1040,12 @@ class RobotAutomationESRepository(
                     reference_ids={reference.id for reference in matches},
                 )
             )
+
+        trace_attribute(Attributes.PERCOLATION_DOCUMENT_COUNT, len(documents))
+        trace_attribute(
+            Attributes.PERCOLATION_MATCH_COUNT,
+            len(robot_automation_percolation_results),
+        )
 
         return robot_automation_percolation_results
 

--- a/app/domain/references/service.py
+++ b/app/domain/references/service.py
@@ -1396,9 +1396,7 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
             reference=reference,
             enhancement_ids=enhancement_ids,
         )
-        trace_attribute(
-            Attributes.ROBOT_AUTOMATION_MATCHED_COUNT, len(robot_automations)
-        )
+        trace_attribute(Attributes.ROBOT_AUTOMATION_MATCH_COUNT, len(robot_automations))
         pending_enhancement_count = 0
         for robot_automation in robot_automations:
             if robot_automation.robot_id == skip_robot_id:
@@ -1423,7 +1421,7 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
         if robot_automations:
             logger.info(
                 "Dispatched robot automations.",
-                matched_count=len(robot_automations),
+                match_count=len(robot_automations),
                 pending_enhancement_count=pending_enhancement_count,
                 source=source_str,
             )

--- a/app/domain/references/service.py
+++ b/app/domain/references/service.py
@@ -1396,6 +1396,10 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
             reference=reference,
             enhancement_ids=enhancement_ids,
         )
+        trace_attribute(
+            Attributes.ROBOT_AUTOMATION_MATCHED_COUNT, len(robot_automations)
+        )
+        pending_enhancement_count = 0
         for robot_automation in robot_automations:
             if robot_automation.robot_id == skip_robot_id:
                 logger.warning(
@@ -1408,6 +1412,19 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
             await self._create_pending_enhancements(
                 robot_id=robot_automation.robot_id,
                 reference_ids=robot_automation.reference_ids,
+                source=source_str,
+            )
+            pending_enhancement_count += len(robot_automation.reference_ids)
+
+        trace_attribute(
+            Attributes.ROBOT_AUTOMATION_PENDING_ENHANCEMENT_COUNT,
+            pending_enhancement_count,
+        )
+        if robot_automations:
+            logger.info(
+                "Dispatched robot automations.",
+                matched_count=len(robot_automations),
+                pending_enhancement_count=pending_enhancement_count,
                 source=source_str,
             )
 


### PR DESCRIPTION
Adds telemetry to show whether percolation produces any matches once re-enabled — today that's only inferable from downstream SQL spans.

- percolate span: `app.percolation.document_count`, `app.percolation.match_count`
- detect-and-dispatch span: `app.robot_automation.matched_count`, `app.robot_automation.pending_enhancement_count`, plus an INFO log gated to non-empty matches

No behaviour change. Relates to #670.