### PR TITLE
feat(dedup): add year-optional soft-decay retrieval policy

### DIFF
--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -835,6 +835,9 @@ class RetrievalPolicyName(StrEnum):
     """Bounded soft year decay: no hard year filter; a native Elasticsearch
     exponential proximity bonus adds at most 10% to the title/author score.
     Requires publication year as input."""
+    SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1 = "soft_year_decay_year_optional_v1"
+    """soft_year_decay_v1 but publication year is optional as input; yearless
+    records search on title/authors with no decay bonus."""
     SOFT_YEAR_DECAY_NONFUZZY_PROBE_V1 = "soft_year_decay_nonfuzzy_probe_v1"
     """Evaluation-only probe: soft_year_decay_v1 with zero edit-distance title
     matching. Used to measure the recall and latency impact of disabling fuzzy

--- a/app/domain/references/models/retrieval_policy.py
+++ b/app/domain/references/models/retrieval_policy.py
@@ -92,6 +92,13 @@ RETRIEVAL_POLICIES: Mapping[RetrievalPolicyName, RetrievalPolicy] = MappingProxy
                 year_decay=YearDecayConfig(),
             ),
             RetrievalPolicy(
+                name=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+                union_identifiers=True,
+                year_strategy=YearStrategy.SOFT_DECAY,
+                year_decay=YearDecayConfig(),
+                requires_publication_year=False,
+            ),
+            RetrievalPolicy(
                 name=RetrievalPolicyName.SOFT_YEAR_DECAY_NONFUZZY_PROBE_V1,
                 union_identifiers=True,
                 year_strategy=YearStrategy.SOFT_DECAY,

--- a/app/domain/references/services/deduplication_service.py
+++ b/app/domain/references/services/deduplication_service.py
@@ -115,13 +115,19 @@ def build_candidate_canonical_search_query(
         case YearStrategy.NO_FILTER:
             publication_year_range = None
         case YearStrategy.SOFT_DECAY:
-            if policy.year_decay is None or not search_fields.publication_year:
-                msg = "soft_year_decay requires a decay config and a publication year."
+            if policy.year_decay is None:
+                msg = "soft_year_decay requires a decay config."
                 raise DeduplicationValueError(msg)
             publication_year_range = None
-            publication_year_decay = YearDecay(
-                **policy.year_decay.model_dump(),
-                origin=search_fields.publication_year,
+            # No year means no decay origin; a year-optional input then scores on
+            # title and authors alone (eligibility is owned by is_input_searchable).
+            publication_year_decay = (
+                YearDecay(
+                    **policy.year_decay.model_dump(),
+                    origin=search_fields.publication_year,
+                )
+                if search_fields.publication_year
+                else None
             )
         case _:  # pragma: no cover - exhaustiveness guard
             assert_never(policy.year_strategy)

--- a/tests/unit/domain/references/models/test_retrieval_policy.py
+++ b/tests/unit/domain/references/models/test_retrieval_policy.py
@@ -152,6 +152,31 @@ def test_soft_decay_policies_unsearchable_without_year():
         assert resolve_retrieval_policy(name).is_input_searchable(fields) is False
 
 
+def test_soft_year_decay_year_optional_v1_regime():
+    from app.domain.references.models.models import YearDecayConfig
+
+    policy = resolve_retrieval_policy(
+        RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1
+    )
+    assert policy.year_strategy is YearStrategy.SOFT_DECAY
+    assert policy.union_identifiers is True
+    assert policy.requires_publication_year is False
+    assert policy.year_decay == YearDecayConfig()
+
+
+def test_soft_year_decay_year_optional_admits_missing_year():
+    """The year-optional decay policy searches yearless inputs; its siblings do not."""
+    fields = CandidateCanonicalSearchFields(
+        title="t", authors=["a"], publication_year=None
+    )
+    year_optional = resolve_retrieval_policy(
+        RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1
+    )
+    year_required = resolve_retrieval_policy(RetrievalPolicyName.SOFT_YEAR_DECAY_V1)
+    assert year_optional.is_input_searchable(fields) is True
+    assert year_required.is_input_searchable(fields) is False
+
+
 def test_soft_year_decay_nonfuzzy_probe_v1_regime():
     policy = resolve_retrieval_policy(
         RetrievalPolicyName.SOFT_YEAR_DECAY_NONFUZZY_PROBE_V1

--- a/tests/unit/domain/references/test_candidate_query_builder.py
+++ b/tests/unit/domain/references/test_candidate_query_builder.py
@@ -175,10 +175,25 @@ def test_soft_decay_builds_decay_spec_and_no_range():
     assert decay.max_boost == pytest.approx(1.10)
 
 
-def test_soft_decay_without_year_raises():
-    fields = CandidateCanonicalSearchFields(title="Shared Title", authors=["Smith"])
-    with pytest.raises(DeduplicationValueError, match="publication year"):
-        _query(fields, RetrievalPolicyName.SOFT_YEAR_DECAY_V1)
+@pytest.mark.parametrize("year", [None, 0])
+def test_soft_decay_year_optional_without_year_builds_no_decay(year):
+    """Year-optional decay: a yearless input searches with no decay bonus, no raise."""
+    fields = CandidateCanonicalSearchFields(
+        title="Shared Title", authors=["Smith"], publication_year=year
+    )
+    query = _query(fields, RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1)
+    assert query.publication_year_range is None
+    assert query.publication_year_decay is None
+
+
+def test_soft_decay_year_optional_with_year_builds_decay():
+    """A year present still yields the decay spec under the year-optional policy."""
+    fields = CandidateCanonicalSearchFields(
+        title="Shared Title", authors=["Smith"], publication_year=2000
+    )
+    query = _query(fields, RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1)
+    assert query.publication_year_decay is not None
+    assert query.publication_year_decay.origin == 2000
 
 
 def test_soft_decay_es_translation_wraps_function_score():


### PR DESCRIPTION
## What & why

Adds `soft_year_decay_year_optional_v1`, a soft-decay candidate-retrieval policy that admits references lacking a publication year. It mirrors `soft_year_decay_v1` but sets `requires_publication_year=False`, so a title+author input with no year is still searchable. This unblocks running soft-decay retrieval on the year-optional cohort (and the non-fuzzy capacity run) in the recall evaluation, which previously could not search yearless references under a soft-decay policy.

## The change

- **New policy** (`retrieval_policy.py`, `models.py`): `soft_year_decay_year_optional_v1` with `year_strategy=SOFT_DECAY`, `year_decay=YearDecayConfig()`, `requires_publication_year=False`.
- **Builder guard fix** (`deduplication_service.py`): the SOFT_DECAY branch no longer raises on a missing publication year. With no year there is no decay origin, so the query falls back to title/author scoring (a plain `bool`, no `function_score`); a year still yields the `function_score` decay bonus. The one remaining raise covers only the policy-config invariant (a SOFT_DECAY policy must carry `year_decay`).
- Eligibility stays owned by `is_input_searchable`: year-required soft-decay policies continue to reject yearless inputs upstream, so the removed builder raise was an unreachable backstop for that path, not a live guard.

## Not changed

Scoped to the year-optional policy. No change to `soft_year_decay_v1`, the non-fuzzy probe, the decay math, the ES translation, or the auto-nomination path (which hardcodes `current_fuzzy_v1`).

## Validation performed

- mypy (the enforced type gate), ruff, ruff-format, and vulture clean on all changed files.
- Unit tests: policy registry, searchability gate, and builder translation (year present / None / 0) all green; full unit suite 970 passed, 1 skipped.
- Live validation against a local destiny-repository instance at the query-construction + searchability-gate level. Yearless input under the year-optional policy is searchable and emits a plain `bool` (no `function_score`, no year clause); the same input under `soft_year_decay_v1` is not searchable and emits no ES query (negative control, 2 emitted queries for 3 calls); a year-present input emits the `function_score` decay with `origin` set to the input year. New policy confirmed live in the OpenAPI enum.

Part of #819.