### PR TITLE
Add db-level idempotency guard for pending enhancements

### DIFF
--- a/app/domain/references/models/sql.py
+++ b/app/domain/references/models/sql.py
@@ -801,14 +801,14 @@ class PendingEnhancement(GenericSQLPersistence[DomainPendingEnhancement]):
         "EnhancementRequest", back_populates="pending_enhancements"
     )
 
-    original_uniqueness_index = Index(
-        "uq_pending_enhancement_request_reference_original",
+    non_retry_uniqueness_index = Index(
+        "uq_pending_enhancement_request_reference_non_retry",
         "enhancement_request_id",
         "reference_id",
         unique=True,
         postgresql_where=text("retry_of IS NULL"),
     )
-    """At most one original (non-retry) pending enhancement per
+    """At most one non-retry pending enhancement per
     (enhancement_request_id, reference_id). Relied upon for idempotent enhancement
     requests."""
 
@@ -834,7 +834,7 @@ class PendingEnhancement(GenericSQLPersistence[DomainPendingEnhancement]):
             "ix_pending_enhancement_robot_enhancement_batch_id",
             "robot_enhancement_batch_id",
         ),
-        original_uniqueness_index,
+        non_retry_uniqueness_index,
     )
 
     @classmethod

--- a/app/domain/references/models/sql.py
+++ b/app/domain/references/models/sql.py
@@ -15,6 +15,7 @@ from sqlalchemy import (
     Integer,
     String,
     UniqueConstraint,
+    text,
 )
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy.exc import MissingGreenlet
@@ -800,6 +801,17 @@ class PendingEnhancement(GenericSQLPersistence[DomainPendingEnhancement]):
         "EnhancementRequest", back_populates="pending_enhancements"
     )
 
+    original_uniqueness_index = Index(
+        "uq_pending_enhancement_request_reference_original",
+        "enhancement_request_id",
+        "reference_id",
+        unique=True,
+        postgresql_where=text("retry_of IS NULL"),
+    )
+    """At most one original (non-retry) pending enhancement per
+    (enhancement_request_id, reference_id). Relied upon for idempotent enhancement
+    requests."""
+
     __table_args__ = (
         Index(
             "ix_pending_enhancement_enhancement_request_id_status",
@@ -822,6 +834,7 @@ class PendingEnhancement(GenericSQLPersistence[DomainPendingEnhancement]):
             "ix_pending_enhancement_robot_enhancement_batch_id",
             "robot_enhancement_batch_id",
         ),
+        original_uniqueness_index,
     )
 
     @classmethod

--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -2,7 +2,7 @@
 
 import datetime
 from abc import ABC
-from collections.abc import AsyncGenerator, Mapping, Sequence
+from collections.abc import AsyncGenerator, Collection, Mapping, Sequence
 from typing import Any, ClassVar, Literal
 from uuid import UUID
 
@@ -22,6 +22,7 @@ from sqlalchemy import (
     select,
     update,
 )
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -40,6 +41,7 @@ from app.domain.references.models.models import (
     CrossFacetAxis,
     CrossFacetCell,
     DuplicateDetermination,
+    EnhancementRequestSearchStatus,
     FacetType,
     GenericExternalIdentifier,
     LinkedDataConceptFilter,
@@ -123,6 +125,9 @@ from app.persistence.sql.repository import GenericAsyncSqlRepository
 
 settings = get_settings()
 tracer = trace.get_tracer(__name__)
+
+# asyncpg caps bind parameters per statement at a signed 16-bit maximum
+_MAX_BIND_PARAMS_PER_STATEMENT = 2**15 - 1
 
 
 class ReferenceRepositoryBase(
@@ -939,6 +944,34 @@ class EnhancementRequestSQLRepository(
         results = await self._session.execute(query)
         return {PendingEnhancementStatus(row[0]): row[1] for row in results.all()}
 
+    @trace_repository_method(tracer)
+    async def claim_search_request(self, enhancement_request_id: UUID) -> bool:
+        """
+        Atomically move a search request into ``SEARCHING``.
+
+        Accepts a request that is ``PENDING`` (first run) or already
+        ``SEARCHING`` (a redelivered task resumes instead of no-opping).
+
+        Returns ``False`` if the request is terminal (``COMPLETED``/``FAILED``) or
+        missing.
+        """
+        stmt = (
+            update(SQLEnhancementRequest)
+            .where(
+                SQLEnhancementRequest.id == enhancement_request_id,
+                SQLEnhancementRequest.search_status.in_(
+                    [
+                        EnhancementRequestSearchStatus.PENDING,
+                        EnhancementRequestSearchStatus.SEARCHING,
+                    ]
+                ),
+            )
+            .values(search_status=EnhancementRequestSearchStatus.SEARCHING)
+        )
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        return bool(result.rowcount)
+
     async def get_by_pk(
         self,
         pk: UUID,
@@ -1261,6 +1294,44 @@ class PendingEnhancementSQLRepository(
                 entity.status.guard_transition(new_status, entity.id)
 
         return await super().bulk_update_by_filter(filter_conditions, **kwargs)
+
+    @trace_repository_method(tracer)
+    async def add_bulk_ignore_conflicts(
+        self, records: Collection[DomainPendingEnhancement]
+    ) -> int:
+        """
+        Insert pending enhancements, skipping ones that already exist.
+
+        A row is skipped when it collides with an existing *original* (non-retry)
+        pending enhancement for the same ``(enhancement_request_id,
+        reference_id)``.
+
+        Returns the number of rows actually inserted.
+        """
+        records = list(records)
+        if not records:
+            return 0
+
+        rows = [
+            SQLPendingEnhancement.from_domain(record).to_write_values()
+            for record in records
+        ]
+
+        chunk_size = max(1, _MAX_BIND_PARAMS_PER_STATEMENT // len(rows[0]))
+        inserted = 0
+        for start in range(0, len(rows), chunk_size):
+            stmt = (
+                pg_insert(SQLPendingEnhancement)
+                .values(rows[start : start + chunk_size])
+                .on_conflict_do_nothing(
+                    constraint=SQLPendingEnhancement.original_uniqueness_index
+                )
+            )
+            result = await self._session.execute(stmt)
+            inserted += result.rowcount or 0
+
+        await self._session.flush()
+        return inserted
 
     @trace_repository_method(tracer)
     async def find_available_for_robot(

--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -1331,7 +1331,7 @@ class PendingEnhancementSQLRepository(
                 pg_insert(SQLPendingEnhancement)
                 .values(rows[start : start + chunk_size])
                 .on_conflict_do_nothing(
-                    constraint=SQLPendingEnhancement.original_uniqueness_index
+                    constraint=SQLPendingEnhancement.non_retry_uniqueness_index
                 )
             )
             result = await self._session.execute(stmt)

--- a/app/domain/references/service.py
+++ b/app/domain/references/service.py
@@ -700,8 +700,12 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
         reference_ids: Iterable[UUID],
         enhancement_request_id: UUID | None = None,
         source: str | None = None,
-    ) -> list[PendingEnhancement]:
-        """Create a batch enhancement request."""
+    ) -> None:
+        """
+        Create pending enhancements for the given references.
+
+        Idempotent over ``(enhancement_request_id, reference_id)``.
+        """
         pending_enhancements_to_create = [
             PendingEnhancement(
                 reference_id=ref_id,
@@ -713,11 +717,9 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
         ]
 
         if pending_enhancements_to_create:
-            return await self.sql_uow.pending_enhancements.add_bulk(
+            await self.sql_uow.pending_enhancements.add_bulk_ignore_conflicts(
                 pending_enhancements_to_create
             )
-
-        return []
 
     @sql_unit_of_work
     async def create_pending_enhancements(
@@ -726,9 +728,9 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
         reference_ids: Iterable[UUID],
         enhancement_request_id: UUID | None = None,
         source: str | None = None,
-    ) -> list[PendingEnhancement]:
-        """Create pending enhancements."""
-        return await self._create_pending_enhancements(
+    ) -> None:
+        """Create pending enhancements in their own transaction."""
+        await self._create_pending_enhancements(
             robot_id=robot_id,
             reference_ids=reference_ids,
             enhancement_request_id=enhancement_request_id,

--- a/app/domain/references/services/enhancement_service.py
+++ b/app/domain/references/services/enhancement_service.py
@@ -659,15 +659,18 @@ class EnhancementService(GenericService[ReferenceAntiCorruptionService]):
     async def claim_search_enhancement_request(
         self, enhancement_request_id: UUID
     ) -> EnhancementRequest | None:
-        """Atomically move PENDING -> SEARCHING; ``None`` if not claimable."""
-        updated = await self.sql_uow.enhancement_requests.bulk_update_by_filter(
-            filter_conditions={
-                "id": enhancement_request_id,
-                "search_status": EnhancementRequestSearchStatus.PENDING,
-            },
-            search_status=EnhancementRequestSearchStatus.SEARCHING,
+        """
+        Claim a search request for scanning; ``None`` if not claimable.
+
+        Accepts a request that is ``PENDING`` or already ``SEARCHING`` so a task
+        redelivered after a crashed run resumes instead of no-opping. Returns
+        ``None`` only when the request is terminal (``COMPLETED``/``FAILED``) or
+        missing.
+        """
+        claimed = await self.sql_uow.enhancement_requests.claim_search_request(
+            enhancement_request_id
         )
-        if updated == 0:
+        if not claimed:
             return None
         return await self.sql_uow.enhancement_requests.get_by_pk(enhancement_request_id)
 

--- a/app/migrations/versions/9b2f1c4d7e83_add_pending_enhancement_request_reference_unique_index.py
+++ b/app/migrations/versions/9b2f1c4d7e83_add_pending_enhancement_request_reference_unique_index.py
@@ -1,0 +1,56 @@
+"""
+add partial unique index on pending enhancement (request, reference)
+
+Revision ID: 9b2f1c4d7e83
+Revises: 73a049948581
+Create Date: 2026-07-27 03:00:00.000000+00:00
+
+"""
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '9b2f1c4d7e83'
+down_revision: Union[str, None] = '73a049948581'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_INDEX_NAME = 'uq_pending_enhancement_request_reference_original'
+
+
+def upgrade() -> None:
+    duplicate_groups = op.get_bind().execute(
+        sa.text(
+            """
+            SELECT count(*) FROM (
+                SELECT 1
+                FROM pending_enhancement
+                WHERE retry_of IS NULL AND enhancement_request_id IS NOT NULL
+                GROUP BY enhancement_request_id, reference_id
+                HAVING count(*) > 1
+            ) duplicates
+            """
+        )
+    ).scalar_one()
+    if duplicate_groups:
+        msg = (
+            f"Cannot create {_INDEX_NAME}: {duplicate_groups} "
+            "(enhancement_request_id, reference_id) group(s) already have "
+            "multiple original pending enhancements."
+        )
+        raise RuntimeError(msg)
+
+    op.create_index(
+        _INDEX_NAME,
+        'pending_enhancement',
+        ['enhancement_request_id', 'reference_id'],
+        unique=True,
+        postgresql_where=sa.text('retry_of IS NULL'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(_INDEX_NAME, table_name='pending_enhancement')

--- a/app/migrations/versions/9b2f1c4d7e83_add_pending_enhancement_request_reference_unique_index.py
+++ b/app/migrations/versions/9b2f1c4d7e83_add_pending_enhancement_request_reference_unique_index.py
@@ -18,7 +18,7 @@ down_revision: Union[str, None] = '73a049948581'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-_INDEX_NAME = 'uq_pending_enhancement_request_reference_original'
+_INDEX_NAME = 'uq_pending_enhancement_request_reference_non_retry'
 
 
 def upgrade() -> None:

--- a/app/persistence/sql/persistence.py
+++ b/app/persistence/sql/persistence.py
@@ -3,12 +3,12 @@
 import datetime
 from abc import abstractmethod
 from enum import StrEnum, auto
-from typing import Generic, Self
+from typing import Any, Generic, Self
 from uuid import UUID, uuid7
 
 from pydantic import BaseModel, Field
 from sqlalchemy import UUID as SQL_UUID
-from sqlalchemy import DateTime
+from sqlalchemy import DateTime, inspect
 from sqlalchemy.ext.asyncio import AsyncAttrs
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
@@ -58,6 +58,21 @@ class GenericSQLPersistence(
         self, preload: list[GenericSQLPreloadableType] | None = None
     ) -> GenericDomainModelType:
         """Create a domain model from this persistence model."""
+
+    def to_write_values(self) -> dict[str, Any]:
+        """
+        Return this instance's assigned column values for a Core write.
+
+        Only columns explicitly set on the instance are included; unset columns
+        (e.g. ``created_at``/``updated_at``) are omitted so their column defaults
+        (or ``onupdate``) apply, mirroring an ORM flush.
+        """
+        assigned = self.__dict__
+        return {
+            column.key: assigned[column.key]
+            for column in inspect(type(self)).column_attrs
+            if column.key in assigned
+        }
 
 
 class RelationshipLoadType(StrEnum):

--- a/libs/sdk/src/destiny_sdk/robots.py
+++ b/libs/sdk/src/destiny_sdk/robots.py
@@ -3,7 +3,7 @@
 from enum import StrEnum, auto
 from typing import Annotated, Any
 
-from pydantic import BaseModel, ConfigDict, Field, HttpUrl
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator
 
 from destiny_sdk.core import UUID, _JsonlFileInputMixIn
 from destiny_sdk.enhancements import Enhancement
@@ -217,6 +217,15 @@ class _EnhancementRequestBase(BaseModel):
 
 class EnhancementRequestIn(_EnhancementRequestBase):
     """The model for requesting multiple enhancements on specific references."""
+
+    @field_validator("reference_ids")
+    @classmethod
+    def _reject_duplicate_reference_ids(cls, value: list[UUID]) -> list[UUID]:
+        """Reject duplicate ids so a request maps to a distinct set of references."""
+        if len(value) != len(set(value)):
+            msg = "reference_ids must not contain duplicate ids."
+            raise ValueError(msg)
+        return value
 
 
 class EnhancementRequestRead(_EnhancementRequestBase):

--- a/libs/sdk/tests/unit/test_robots.py
+++ b/libs/sdk/tests/unit/test_robots.py
@@ -25,3 +25,20 @@ def test_robot_models_reject_any_extra_fields():
             owner="Styx",
             client_secret="I'm not allowed in this model",
         )
+
+
+def test_enhancement_request_in_rejects_duplicate_reference_ids():
+    ref_id = uuid7()
+    with pytest.raises(ValidationError):
+        destiny_sdk.robots.EnhancementRequestIn(
+            robot_id=uuid7(),
+            reference_ids=[ref_id, ref_id],
+        )
+
+
+def test_enhancement_request_in_allows_distinct_reference_ids():
+    request = destiny_sdk.robots.EnhancementRequestIn(
+        robot_id=uuid7(),
+        reference_ids=[uuid7(), uuid7()],
+    )
+    assert len(request.reference_ids) == 2

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -222,3 +222,63 @@ async def test_migrate_41a69_to_1a717(db_at_migration: str) -> None:
         assert row.enhancement_type == EnhancementType.ABSTRACT
 
     await engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("migration_id", ["73a049948581"])
+async def test_pending_enhancement_unique_index_fails_fast_on_duplicates(
+    db_at_migration: str,
+) -> None:
+    """The (request, reference) unique-index migration refuses pre-existing dupes."""
+    db_url = db_at_migration
+    engine = create_async_engine(db_url, future=True)
+    now = datetime.datetime.now(datetime.UTC)
+    ref_id, rob_id, req_id = str(uuid7()), str(uuid7()), str(uuid7())
+
+    async with engine.begin() as conn:
+        await conn.execute(
+            sa.text(
+                "INSERT INTO reference (id, visibility, created_at, updated_at) "
+                "VALUES (:id, 'public', :now, :now)"
+            ),
+            {"id": ref_id, "now": now},
+        )
+        await conn.execute(
+            sa.text(
+                "INSERT INTO robot (id, name, description, owner, client_secret, "
+                "created_at, updated_at) "
+                "VALUES (:id, 'R', 'd', 'o@e.com', 's', :now, :now)"
+            ),
+            {"id": rob_id, "now": now},
+        )
+        await conn.execute(
+            sa.text(
+                "INSERT INTO enhancement_request (id, reference_ids, robot_id, "
+                "request_status, created_at, updated_at) "
+                "VALUES (:id, '{}'::uuid[], :robot_id, 'received', :now, :now)"
+            ),
+            {"id": req_id, "robot_id": rob_id, "now": now},
+        )
+        # Two original (retry_of NULL) pending enhancements for the same
+        # (request, reference): exactly what the new index forbids.
+        for _ in range(2):
+            await conn.execute(
+                sa.text(
+                    "INSERT INTO pending_enhancement (id, reference_id, robot_id, "
+                    "enhancement_request_id, status, expires_at, created_at, "
+                    "updated_at) "
+                    "VALUES (:id, :ref, :rob, :req, 'pending', :now, :now, :now)"
+                ),
+                {
+                    "id": str(uuid7()),
+                    "ref": ref_id,
+                    "rob": rob_id,
+                    "req": req_id,
+                    "now": now,
+                },
+            )
+
+    with pytest.raises(RuntimeError, match="multiple original pending enhancements"):
+        await run_migration(db_url, "9b2f1c4d7e83")
+
+    await engine.dispose()

--- a/tests/integration/test_sql_models.py
+++ b/tests/integration/test_sql_models.py
@@ -28,11 +28,13 @@ from app.domain.references.models.models import (
     DuplicateDetermination,
     Enhancement,
     EnhancementRequest,
+    EnhancementRequestSearchStatus,
     EnhancementRequestStatus,
     PendingEnhancement,
     PendingEnhancementStatus,
     Reference,
     ReferenceDuplicateDecision,
+    SearchQuery,
 )
 from app.domain.references.models.sql import (
     Enhancement as SQLEnhancement,
@@ -48,6 +50,7 @@ from app.domain.references.models.sql import (
 )
 from app.domain.references.repository import (
     EnhancementRequestSQLRepository,
+    PendingEnhancementSQLRepository,
     ReferenceDuplicateDecisionSQLRepository,
     ReferenceSQLRepository,
 )
@@ -372,13 +375,15 @@ async def test_enhancement_request_status_projection(
     expected_status: EnhancementRequestStatus | None,
 ):
     """Test EnhancementRequest status projection logic."""
-    # Create a reference first
-    reference = SQLReference.from_domain(
-        Reference(
-            id=uuid7(),
-        )
-    )
-    session.add(reference)
+    # A request holds at most one original pending enhancement per reference,
+    # so give each pending enhancement its own reference. The status projection
+    # aggregates over the request's pending enhancements regardless of which
+    # reference they belong to.
+    references = [
+        SQLReference.from_domain(Reference(id=uuid7())) for _ in pending_statuses
+    ]
+    for reference in references:
+        session.add(reference)
 
     # Create a robot first (required for foreign key constraint)
     robot_id = uuid7()
@@ -398,7 +403,7 @@ async def test_enhancement_request_status_projection(
     enhancement_request = SQLEnhancementRequest.from_domain(
         EnhancementRequest(
             id=request_id,
-            reference_ids=[reference.id],
+            reference_ids=[reference.id for reference in references],
             robot_id=robot_id,
             request_status=EnhancementRequestStatus.RECEIVED,
         )
@@ -406,7 +411,7 @@ async def test_enhancement_request_status_projection(
     session.add(enhancement_request)
 
     # Create pending enhancements with different statuses
-    for status in pending_statuses:
+    for reference, status in zip(references, pending_statuses, strict=True):
         pending_enhancement = SQLPendingEnhancement.from_domain(
             PendingEnhancement(
                 id=uuid7(),
@@ -518,3 +523,147 @@ async def test_multiple_import_batch_status_projection(
         ImportBatchStatus.PARTIALLY_FAILED,
         ImportBatchStatus.STARTED,
     }
+
+
+async def test_add_bulk_ignore_conflicts_deduplicates_originals_and_exempts_retries(
+    session: AsyncSession,
+):
+    """
+    The partial unique index dedupes original pending enhancements.
+
+    Uniqueness is enforced per (enhancement_request_id, reference_id) for
+    originals, so re-running a search collection creates no duplicates; retries
+    (retry_of set) are exempt.
+    """
+    reference = SQLReference.from_domain(Reference(id=uuid7()))
+    session.add(reference)
+    robot_id = uuid7()
+    session.add(
+        SQLRobot.from_domain(
+            Robot(
+                id=robot_id,
+                name="Test Robot",
+                description="A test robot",
+                owner="test@example.com",
+                client_secret="test-secret",
+            )
+        )
+    )
+    request_id = uuid7()
+    session.add(
+        SQLEnhancementRequest.from_domain(
+            EnhancementRequest(
+                id=request_id,
+                reference_ids=[reference.id],
+                robot_id=robot_id,
+                request_status=EnhancementRequestStatus.RECEIVED,
+            )
+        )
+    )
+    await session.flush()
+    await session.commit()
+
+    repo = PendingEnhancementSQLRepository(session)
+    expires_at = datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(hours=1)
+
+    original = PendingEnhancement(
+        reference_id=reference.id,
+        robot_id=robot_id,
+        enhancement_request_id=request_id,
+        expires_at=expires_at,
+    )
+    assert await repo.add_bulk_ignore_conflicts([original]) == 1
+
+    # A re-run inserting the same (request, reference) original is skipped.
+    duplicate = PendingEnhancement(
+        reference_id=reference.id,
+        robot_id=robot_id,
+        enhancement_request_id=request_id,
+        expires_at=expires_at,
+    )
+    assert await repo.add_bulk_ignore_conflicts([duplicate]) == 0
+
+    # A retry for the same (request, reference) is exempt from the index.
+    retry = PendingEnhancement(
+        reference_id=reference.id,
+        robot_id=robot_id,
+        enhancement_request_id=request_id,
+        retry_of=original.id,
+        expires_at=expires_at,
+    )
+    assert await repo.add_bulk_ignore_conflicts([retry]) == 1
+
+    await session.commit()
+    count = (
+        await session.execute(
+            text(
+                "SELECT count(*) FROM pending_enhancement "
+                "WHERE enhancement_request_id = :rid"
+            ),
+            {"rid": request_id},
+        )
+    ).scalar_one()
+    assert count == 2
+
+    # The Core insert bypasses the ORM's flush-time defaults, so confirm the
+    # non-nullable timestamps were stamped rather than left NULL.
+    missing_timestamps = (
+        await session.execute(
+            text(
+                "SELECT count(*) FROM pending_enhancement "
+                "WHERE enhancement_request_id = :rid "
+                "AND (created_at IS NULL OR updated_at IS NULL)"
+            ),
+            {"rid": request_id},
+        )
+    ).scalar_one()
+    assert missing_timestamps == 0
+
+
+async def test_claim_search_request_reentrant_and_respects_terminal(
+    session: AsyncSession,
+):
+    """claim_search_request re-enters from SEARCHING but refuses terminal states."""
+    robot_id = uuid7()
+    session.add(
+        SQLRobot.from_domain(
+            Robot(
+                id=robot_id,
+                name="Test Robot",
+                description="A test robot",
+                owner="test@example.com",
+                client_secret="test-secret",
+            )
+        )
+    )
+    request_id = uuid7()
+    session.add(
+        SQLEnhancementRequest.from_domain(
+            EnhancementRequest(
+                id=request_id,
+                reference_ids=[],
+                robot_id=robot_id,
+                search=SearchQuery(query_string="climate"),
+                search_status=EnhancementRequestSearchStatus.PENDING,
+            )
+        )
+    )
+    await session.flush()
+    await session.commit()
+
+    repo = EnhancementRequestSQLRepository(session)
+
+    # First claim: PENDING -> SEARCHING.
+    assert await repo.claim_search_request(request_id) is True
+    assert (
+        await repo.get_by_pk(request_id)
+    ).search_status == EnhancementRequestSearchStatus.SEARCHING
+
+    # Re-entry: a task redelivered after a crash may reclaim a SEARCHING request.
+    assert await repo.claim_search_request(request_id) is True
+
+    # Terminal states are not claimable.
+    await repo.update_by_pk(
+        request_id, search_status=EnhancementRequestSearchStatus.COMPLETED
+    )
+    assert await repo.claim_search_request(request_id) is False

--- a/tests/routers/test_references.py
+++ b/tests/routers/test_references.py
@@ -295,6 +295,18 @@ async def test_request_batch_enhancement_happy_path(
     await broker.wait_all()
 
 
+async def test_request_batch_enhancement_rejects_duplicate_reference_ids(
+    client: AsyncClient,
+) -> None:
+    """Duplicate reference_ids in a batch request are rejected before the handler."""
+    ref_id = str(uuid7())
+    response = await client.post(
+        "/v1/enhancement-requests/",
+        json={"reference_ids": [ref_id, ref_id], "robot_id": str(uuid7())},
+    )
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+
 async def test_request_search_enhancement_dry_run(
     app: FastAPI, client: AsyncClient
 ) -> None:

--- a/tests/unit/domain/conftest.py
+++ b/tests/unit/domain/conftest.py
@@ -11,6 +11,7 @@ from app.domain.imports.models.models import (
     ImportResult,
 )
 from app.domain.references.models.models import (
+    EnhancementRequestSearchStatus,
     PendingEnhancement,
     PendingEnhancementStatus,
 )
@@ -214,6 +215,51 @@ class FakeRepository:
                     setattr(record, key, value)
                 updated_count += 1
         return updated_count
+
+    async def add_bulk_ignore_conflicts(
+        self, records: list[DummyDomainSQLModel]
+    ) -> int:
+        """Insert records, skipping originals that collide on (request, ref).
+
+        Emulates the partial unique index on
+        ``(enhancement_request_id, reference_id) WHERE retry_of IS NULL``:
+        rows with a NULL request or a set ``retry_of`` are never skipped.
+        """
+
+        def key(record: DummyDomainSQLModel) -> tuple[object, object]:
+            return (
+                getattr(record, "enhancement_request_id", None),
+                getattr(record, "reference_id", None),
+            )
+
+        def is_constrained_original(record: DummyDomainSQLModel) -> bool:
+            return (
+                getattr(record, "enhancement_request_id", None) is not None
+                and getattr(record, "retry_of", None) is None
+            )
+
+        existing = {
+            key(r) for r in self.repository.values() if is_constrained_original(r)
+        }
+        inserted = 0
+        for record in records:
+            if is_constrained_original(record) and key(record) in existing:
+                continue
+            self.repository[record.id] = record
+            existing.add(key(record))
+            inserted += 1
+        return inserted
+
+    async def claim_search_request(self, enhancement_request_id: UUID) -> bool:
+        """Move a PENDING/SEARCHING request to SEARCHING; False if terminal."""
+        record = self.repository.get(enhancement_request_id)
+        if record is None or getattr(record, "search_status", None) not in (
+            EnhancementRequestSearchStatus.PENDING,
+            EnhancementRequestSearchStatus.SEARCHING,
+        ):
+            return False
+        setattr(record, "search_status", EnhancementRequestSearchStatus.SEARCHING)  # noqa: B010
+        return True
 
 
 def link_fake_repos(

--- a/tests/unit/domain/references/test_service.py
+++ b/tests/unit/domain/references/test_service.py
@@ -1401,11 +1401,13 @@ async def test_collect_pending_enhancements_from_search_records_zero_matches(
 
 
 @pytest.mark.asyncio
-async def test_collect_search_enhancement_request_skips_when_not_pending(
+async def test_collect_search_enhancement_request_skips_when_terminal(
     fake_repository, fake_uow
 ):
+    # A COMPLETED (or FAILED) request is terminal: a stray redelivery must
+    # no-op rather than re-scan and re-request enhancements.
     request = SearchEnhancementRequestFactory.build(
-        search_status=EnhancementRequestSearchStatus.SEARCHING
+        search_status=EnhancementRequestSearchStatus.COMPLETED
     )
     fake_requests = fake_repository(init_entries=[request])
     fake_pending = fake_repository()
@@ -1423,8 +1425,54 @@ async def test_collect_search_enhancement_request_skips_when_not_pending(
     assert await fake_pending.get_all() == []
     assert (
         fake_requests.get_first_record().search_status
-        == EnhancementRequestSearchStatus.SEARCHING
+        == EnhancementRequestSearchStatus.COMPLETED
     )
+
+
+@pytest.mark.asyncio
+async def test_collect_pending_enhancements_from_search_resumes_when_searching(
+    fake_repository, fake_uow
+):
+    # A request left in SEARCHING by a worker that died mid-scan must be
+    # re-runnable: the redelivered task resumes, and references already
+    # collected by the prior partial run are not duplicated.
+    request = SearchEnhancementRequestFactory.build(
+        search_status=EnhancementRequestSearchStatus.SEARCHING
+    )
+    matched_ids = [uuid7(), uuid7(), uuid7()]
+    already_collected = PendingEnhancement(
+        reference_id=matched_ids[0],
+        robot_id=request.robot_id,
+        enhancement_request_id=request.id,
+    )
+    fake_requests = fake_repository(init_entries=[request])
+    fake_pending = fake_repository(init_entries=[already_collected])
+    uow = fake_uow(
+        enhancement_requests=fake_requests, pending_enhancements=fake_pending
+    )
+    service = ReferenceService(
+        ReferenceAntiCorruptionService(fake_repository()), uow, fake_uow()
+    )
+    search_service = _search_service_yielding(
+        [
+            ESSearchResult(
+                hits=[ESHit(id=mid) for mid in matched_ids],
+                total=ESSearchTotal(value=3, relation="eq"),
+                page=1,
+            )
+        ]
+    )
+
+    with patch.object(service, "_search_service", search_service):
+        await service.collect_pending_enhancements_from_search(request.id)
+
+    pending = await fake_pending.get_all()
+    # Exactly one pending enhancement per matched reference: the pre-existing
+    # one for matched_ids[0] is not duplicated.
+    assert len(pending) == len(matched_ids)
+    assert {pe.reference_id for pe in pending} == set(matched_ids)
+    stored = fake_requests.get_first_record()
+    assert stored.search_status == EnhancementRequestSearchStatus.COMPLETED
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fast follow of #838 to ensure every search enhancement request reaches a terminal state.

Main case this handles is a worker going down mid-task, which would leave the task in a `searching` state, which would then be ignored when the task is redelivered. Now, redelivered tasks in that state are picked up again and idempotently (if naively) finish requesting the enhancements.

It does this by adding a unique index (`enhancement_request_id`, `reference_id`) where not a retry, and ignoring conflicts. I've checked prod and staging, no existing rows violate this constraint, and the migration contains a fast-fail if one materialises before we run it.

This also covers the existing id-list endpoint. Rather than letting duplicate ids there silently dedupe at the DB, that endpoint now returns a 422.