### PR TITLE
Add container app env cpu guardrail

### DIFF
--- a/infra/app/guards.tf
+++ b/infra/app/guards.tf
@@ -1,0 +1,79 @@
+/** Plan-time guardrails. */
+
+# --- Guardrail: Container App Environment Consumption CPU budget ---
+# Every app and job here shares one Consumption workload profile, capped at a
+# fixed number of *requested* CPU cores (not used ones). This asserts the worst-case
+# deploy draw stays under the quota.
+locals {
+  # The Consumption profile's requested-CPU ceiling.
+  consumption_core_quota = 100
+
+  # A rolling deploy runs old and new revisions concurrently, so the scalable
+  # apps can transiently request up to 2x their steady-state cores.
+  rollout_factor = 2
+
+  # The UI app's replicas/CPU live in the remote container-app module and aren't
+  # exposed as root variables; reserve a rollout-inclusive allowance.
+  ui_reserved_cores = 4
+
+  scalable_app_cores = (
+    var.app_max_replicas * var.container_app_cpu +
+    var.tasks_max_replicas * var.container_app_tasks_cpu
+  )
+
+  # Worst case: every container app job runs at once. A job's draw is its
+  # parallelism (concurrent replicas per execution) x per-replica CPU.
+  scheduled_job_cores = length(azurerm_container_app_job.scheduled_jobs) > 0 ? sum([
+    for job in azurerm_container_app_job.scheduled_jobs :
+    job.schedule_trigger_config[0].parallelism * job.template[0].container[0].cpu
+  ]) : 0
+
+  job_cores = (
+    azurerm_container_app_job.database_migrator.manual_trigger_config[0].parallelism *
+    azurerm_container_app_job.database_migrator.template[0].container[0].cpu
+    +
+    azurerm_container_app_job.es_index_migrator.manual_trigger_config[0].parallelism *
+    azurerm_container_app_job.es_index_migrator.template[0].container[0].cpu
+    +
+    local.scheduled_job_cores
+  )
+
+  worst_case_deploy_cores = (
+    local.rollout_factor * local.scalable_app_cores +
+    local.job_cores +
+    local.ui_reserved_cores
+  )
+}
+
+# --- Registry ---
+# Each entry is a precondition spec: a condition that must hold, and the message
+# shown when it doesn't.
+locals {
+  guardrails = {
+    consumption_cpu_budget = {
+      condition = local.worst_case_deploy_cores <= local.consumption_core_quota
+      error_message = format(
+        "Worst-case deploy draw is %g cores (%dx scalable apps = %g, jobs = %g, UI reserve = %g) but the Consumption quota is %d. Lower tasks_max_replicas / app_max_replicas or per-replica CPU.",
+        local.worst_case_deploy_cores,
+        local.rollout_factor,
+        local.rollout_factor * local.scalable_app_cores,
+        local.job_cores,
+        local.ui_reserved_cores,
+        local.consumption_core_quota,
+      )
+    }
+  }
+}
+
+# --- Enforcement ---
+# One precondition per registered guardrail
+resource "terraform_data" "guardrail" {
+  for_each = local.guardrails
+
+  lifecycle {
+    precondition {
+      condition     = each.value.condition
+      error_message = each.value.error_message
+    }
+  }
+}

--- a/infra/app/terraform.tf
+++ b/infra/app/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.4"
 
   cloud {
     organization = "destiny-evidence"


### PR DESCRIPTION
Mitigating change for the incident seen in https://covidence.slack.com/archives/C0810ARPCRG/p1785207268941949 by adding a guardrail to ensure that terraform variables can't be configured in a way that exceeds our container app env CPU quota.

Speculative TF plan deliberately failing to show the current misconfiguration that led to the above. I will drop the number of tasks replicas to 40 in production (update: done).

<img width="1301" height="178" alt="image" src="https://github.com/user-attachments/assets/8cf6a5c5-43e7-4653-a0d3-5daa4320b672" />
