### PR TITLE
Fix tracing code broken by starlette version bump

### DIFF
--- a/app/api/root.py
+++ b/app/api/root.py
@@ -4,7 +4,7 @@ import pathlib
 from collections.abc import Callable
 from contextlib import AbstractAsyncContextManager
 
-from fastapi import APIRouter, FastAPI, Request
+from fastapi import APIRouter, Depends, FastAPI, Request
 from fastapi.middleware import Middleware
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.docs import get_redoc_html
@@ -32,7 +32,7 @@ from app.core.exceptions import (
     SDKToDomainError,
     VocabularyFetchError,
 )
-from app.core.telemetry.fastapi import FastAPITracingMiddleware
+from app.core.telemetry.fastapi import FastAPITracingMiddleware, trace_path_params
 from app.core.telemetry.logger import get_logger
 from app.domain.imports.routes import router as import_router_v1
 from app.domain.references.routes import (
@@ -51,7 +51,9 @@ logger = get_logger(__name__)
 
 def create_v1_router() -> APIRouter:
     """Create the v1 API router with all domain-specific routers."""
-    api_v1 = APIRouter(prefix="/v1", tags=["v1"])
+    api_v1 = APIRouter(
+        prefix="/v1", tags=["v1"], dependencies=[Depends(trace_path_params)]
+    )
     api_v1.include_router(import_router_v1)
     api_v1.include_router(enhancement_request_router_v1)
     api_v1.include_router(robot_enhancement_batch_router_v1)

--- a/app/core/telemetry/fastapi.py
+++ b/app/core/telemetry/fastapi.py
@@ -6,7 +6,6 @@ from fastapi import Request, Response
 from opentelemetry import trace
 from starlette.applications import Starlette
 from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.routing import Match
 from structlog.contextvars import (
     bind_contextvars,
     bound_contextvars,
@@ -63,21 +62,10 @@ class FastAPITracingMiddleware(BaseHTTPMiddleware):
             contextvars |= request.query_params.keys()
             bind_contextvars(**request.query_params)
 
-        # Can't access path parameters directly in middleware.
-        # This is what starlette does internally.
-        # https://github.com/fastapi/fastapi/issues/861
-        # https://github.com/encode/starlette/blob/5c43dde0ec0917673bb280bcd7ab0c37b78061b7/starlette/routing.py#L544
-        routes = request.app.router.routes
-        for route in routes:
-            match, scope = route.matches(request)
-            if match == Match.FULL:
-                if current_span.is_recording():
-                    for key, value in scope["path_params"].items():
-                        current_span.set_attribute(
-                            f"{Attributes.HTTP_REQUEST_PATH_PARAMS}.{key}", str(value)
-                        )
-                contextvars |= scope["path_params"].keys()
-                bind_contextvars(**scope["path_params"])
+        # Path parameters are NOT available here: Starlette runs routing after
+        # the middleware stack, so request.path_params is still empty at this
+        # point. They are attached instead via the trace_path_params dependency
+        # below, which runs after routing but before the route handler.
 
         try:
             result = await call_next(request)
@@ -87,6 +75,32 @@ class FastAPITracingMiddleware(BaseHTTPMiddleware):
         else:
             unbind_contextvars(*contextvars)
             return result
+
+
+async def trace_path_params(request: Request) -> AsyncGenerator[None, None]:
+    """
+    Attach request path parameters to the current span and log context.
+
+    This is a FastAPI dependency rather than middleware logic because Starlette
+    resolves routing after the middleware stack runs, so ``request.path_params``
+    is only populated by the time dependencies execute (still ahead of the route
+    handler, so bound context vars enrich the handler's logs too).
+
+    Args:
+        request: The incoming request.
+
+    Yields:
+        None, after binding path parameters to the span and log context.
+
+    """
+    current_span = trace.get_current_span()
+    if current_span.is_recording():
+        for key, value in request.path_params.items():
+            current_span.set_attribute(
+                f"{Attributes.HTTP_REQUEST_PATH_PARAMS}.{key}", str(value)
+            )
+    with bound_contextvars(**request.path_params):
+        yield
 
 
 class PayloadAttributeTracer:

--- a/app/core/telemetry/fastapi.py
+++ b/app/core/telemetry/fastapi.py
@@ -81,11 +81,6 @@ async def trace_path_params(request: Request) -> AsyncGenerator[None, None]:
     """
     Attach request path parameters to the current span and log context.
 
-    This is a FastAPI dependency rather than middleware logic because Starlette
-    resolves routing after the middleware stack runs, so ``request.path_params``
-    is only populated by the time dependencies execute (still ahead of the route
-    handler, so bound context vars enrich the handler's logs too).
-
     Args:
         request: The incoming request.
 

--- a/tests/core/telemetry/test_fastapi.py
+++ b/tests/core/telemetry/test_fastapi.py
@@ -2,14 +2,14 @@
 
 from typing import Annotated
 
-from fastapi import FastAPI, Path
+from fastapi import APIRouter, Depends, FastAPI, Path
 from fastapi.testclient import TestClient
 from opentelemetry import trace
-from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from app.core.telemetry.fastapi import FastAPITracingMiddleware
+from app.core.telemetry.fastapi import FastAPITracingMiddleware, trace_path_params
 
 
 def setup_tracing():
@@ -26,38 +26,63 @@ def setup_tracing():
     return tracer, memory_exporter
 
 
-def test_tracing_middleware():
-    """Test the TracingMiddleware with a simple FastAPI app."""
+def _find_span(memory_exporter: InMemorySpanExporter, name: str) -> ReadableSpan | None:
+    for span in memory_exporter.get_finished_spans():
+        if span.name == name:
+            return span
+    return None
+
+
+def test_middleware_traces_query_params():
+    """Test that query params can be traced using the middleware."""
     tracer, memory_exporter = setup_tracing()
 
     app = FastAPI()
     app.add_middleware(FastAPITracingMiddleware)
 
-    @app.get("/test/{item_id}/")
+    router = APIRouter()
+
+    @router.get("/test/{item_id}")
     async def test_endpoint(
         item_id: Annotated[str, Path(...)], query_param: str = "default"
     ) -> dict[str, str]:
         return {"item_id": item_id, "query_param": query_param}
 
+    app.include_router(router)
     client = TestClient(app)
 
     with tracer.start_as_current_span("test_request"):
         client.get("/test/123?query_param=test_value&another_param=another_value")
 
-    # Get the spans from the in-memory exporter
-    spans = memory_exporter.get_finished_spans()
-
-    # Find our test span
-    test_span = None
-    for span in spans:
-        if span.name == "test_request":
-            test_span = span
-            break
-
+    test_span = _find_span(memory_exporter, "test_request")
     assert test_span is not None, "Test span not found"
 
-    # Verify the attributes were set by the middleware
     attributes = test_span.attributes
     assert attributes["http.request.query.query_param"] == "test_value"
     assert attributes["http.request.query.another_param"] == "another_value"
+
+
+def test_path_params_traced_via_dependency():
+    """# Test that path params can be traced using the dependency on the router."""
+    tracer, memory_exporter = setup_tracing()
+
+    app = FastAPI()
+    app.add_middleware(FastAPITracingMiddleware)
+
+    router = APIRouter(dependencies=[Depends(trace_path_params)])
+
+    @router.get("/test/{item_id}")
+    async def test_endpoint(item_id: Annotated[str, Path(...)]) -> dict[str, str]:
+        return {"item_id": item_id}
+
+    app.include_router(router)
+    client = TestClient(app)
+
+    with tracer.start_as_current_span("test_request"):
+        client.get("/test/123")
+
+    test_span = _find_span(memory_exporter, "test_request")
+    assert test_span is not None, "Test span not found"
+
+    attributes = test_span.attributes
     assert attributes["http.request.path.item_id"] == "123"


### PR DESCRIPTION
When we bumped the starlette version with FastAPI, it broke the tracing middleware we were using to get the path params. The reason we had to jump through hoops is because starlette does routing *after* middleware which meant we had to essentially reach in and do some routing ourselves to get the path params.

What we now do instead is do the routing as part of a FastAPI dependency which occurs after routing is done (hooray!).

The relevant tests have also been fixed so we'll catch this kind of issue in the future.