### PR TITLE
Sort by `_doc` when scanning with an arbitrary order, always tiebreak by `_shard_doc`

### DIFF
--- a/app/persistence/es/repository.py
+++ b/app/persistence/es/repository.py
@@ -439,6 +439,7 @@ class GenericAsyncESRepository(
         - if you're investigating reduced performance after an ES upgrade perchance,
         try going back to just ``_shard_doc``. If that works, proceed to deliver me a
         crisp high-five.
+        See also: https://github.com/elastic/elasticsearch/issues/155559.
 
         We always append ``_shard_doc`` as a tiebreaker to guarantee a total order.
         This is required even when using ``_doc`` as it is not unique.

--- a/app/persistence/es/repository.py
+++ b/app/persistence/es/repository.py
@@ -431,16 +431,22 @@ class GenericAsyncESRepository(
         self, sort: list[str | dict[str, Any]] | None
     ) -> list[str | dict[str, Any]]:
         """
-        Append a total-order tiebreaker to the caller's sort keys.
+        Order the scan for efficient deep pagination under a PIT.
 
-        Prefer the document ``id`` where it exists, otherwise fall back to
-        ``_shard_doc``, ES's PIT-only built-in tiebreaker.
+        If no sort is supplied, we lead with ``_doc``: as the primary sort it lets ES
+        prune when querying each page, providing the fastest behaviour.
+        This is in contradiction to the documentation and seems to mimic old behaviour
+        - if you're investigating reduced performance after an ES upgrade perchance,
+        try going back to just ``_shard_doc``. If that works, proceed to deliver me a
+        crisp high-five.
+
+        We always append ``_shard_doc`` as a tiebreaker to guarantee a total order.
+        This is required even when using ``_doc`` as it is not unique.
         """
         keys = list(sort) if sort else []
-        if "id" in self._persistence_cls._doc_type.mapping:  # noqa: SLF001
-            if not any(self._sort_key_field(key) == "id" for key in keys):
-                keys.append({"id": {"order": "desc"}})
-        elif not any(self._sort_key_field(key) == "_shard_doc" for key in keys):
+        if not keys:
+            return ["_doc", "_shard_doc"]
+        if not any(self._sort_key_field(key) == "_shard_doc" for key in keys):
             keys.append("_shard_doc")
         return keys
 

--- a/tests/unit/persistence/es/test_repository.py
+++ b/tests/unit/persistence/es/test_repository.py
@@ -5,7 +5,6 @@ from uuid import uuid7
 
 import pytest
 from elasticsearch import AsyncElasticsearch
-from elasticsearch.dsl import Text, mapped_field
 from elasticsearch.dsl.query import Term
 from elasticsearch.helpers import async_bulk
 
@@ -17,7 +16,6 @@ from app.domain.references.services.world_bank_regions import (
     SOUTH_ASIA,
     SUB_SAHARAN_AFRICA,
 )
-from app.persistence.es.persistence import GenericESPersistence
 from app.persistence.es.repository import ES_MAX_PAGE_SIZE, GenericAsyncESRepository
 from tests.persistence_models import SimpleDoc, SimpleDomainModel
 
@@ -384,39 +382,25 @@ async def bulk_index(repository: SimpleRepository, docs: list[SimpleDoc]) -> Non
     )
 
 
-def test_scan_sort_keys_prefers_mapped_id(simple_repository: SimpleRepository):
-    """When the index maps ``id``, it is appended as the tiebreaker."""
+def test_scan_sort_keys_defaults_to_doc_order(simple_repository: SimpleRepository):
+    """With no caller sort, lead with ``_doc`` (for early termination) then the
+    cross-shard-unique ``_shard_doc`` tiebreaker."""
+    assert simple_repository._scan_sort_keys(None) == ["_doc", "_shard_doc"]  # noqa: SLF001
+
+
+def test_scan_sort_keys_appends_shard_doc(simple_repository: SimpleRepository):
+    """The ``_shard_doc`` tiebreaker is appended after the caller's sort keys."""
     assert simple_repository._scan_sort_keys(["_score"]) == [  # noqa: SLF001
         "_score",
-        {"id": {"order": "desc"}},
+        "_shard_doc",
     ]
 
 
-def test_scan_sort_keys_does_not_duplicate_id(simple_repository: SimpleRepository):
-    """A caller already sorting on ``id`` is not given a second id key."""
-    assert simple_repository._scan_sort_keys([{"id": {"order": "asc"}}]) == [  # noqa: SLF001
-        {"id": {"order": "asc"}}
-    ]
-
-
-def test_scan_sort_keys_falls_back_to_shard_doc(es_client: AsyncElasticsearch):
-    """Without a mapped ``id``, ``_shard_doc`` is used as the tiebreaker."""
-
-    class NoIdDoc(GenericESPersistence):
-        title: str = mapped_field(Text())
-
-        class Index:
-            name = "test_no_id"
-
-        def to_domain(self) -> SimpleDomainModel:
-            return SimpleDomainModel(title=self.title)
-
-        @classmethod
-        def from_domain(cls, domain_model: SimpleDomainModel) -> "NoIdDoc":
-            return cls(title=domain_model.title)
-
-    repository = GenericAsyncESRepository(es_client, SimpleDomainModel, NoIdDoc)
-    assert repository._scan_sort_keys(["_score"]) == ["_score", "_shard_doc"]  # noqa: SLF001
+def test_scan_sort_keys_does_not_duplicate_shard_doc(
+    simple_repository: SimpleRepository,
+):
+    """A caller already sorting on ``_shard_doc`` is not given a second key."""
+    assert simple_repository._scan_sort_keys(["_shard_doc"]) == ["_shard_doc"]  # noqa: SLF001
 
 
 async def test_scan_paginates_all_results(simple_repository: SimpleRepository):


### PR DESCRIPTION
Fixes performance issues when scanning all documents for a search in an arbitrary order.

After investigation in Elasticsearch:
- `_shard_doc` does nothing special performance wise despite documentation: https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/search/sort/ShardDocSortField.java#L40C81-L40C93.
- `_doc` however does support pruning.
- However, `_doc` is unreliable as it's a per-shard ID (also per-replica but that doesn't matter in a PIT). So it's not unique, and this is bad for `search_after` as you can skip/duplicate documents. However however, we can find use for `_shard_doc`  as a tiebreaker, as it's globally unique across the PIT.
- So, sorting and search_aftering on `[_doc, _shard_doc]` does the trick.