### PR TITLE
Search enhancement request niggles

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -114,8 +114,12 @@ class ESConfig(BaseModel):
 
     # Other configuration
     timeout_seconds: int = 30
-    retry_on_timeout: bool = True
     max_retries: int = 5
+
+    @property
+    def retry_on_timeout(self) -> bool:
+        """Return True if timed out requests should be retried."""
+        return bool(self.max_retries)
 
     @property
     def uses_api_key(self) -> bool:

--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -1324,7 +1324,11 @@ class PendingEnhancementSQLRepository(
             for record in records
         ]
 
-        chunk_size = max(1, _MAX_BIND_PARAMS_PER_STATEMENT // len(rows[0]))
+        chunk_size = max(
+            1,
+            _MAX_BIND_PARAMS_PER_STATEMENT
+            // len(SQLPendingEnhancement.__table__.columns),
+        )
         inserted = 0
         for start in range(0, len(rows), chunk_size):
             stmt = (

--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -127,9 +127,6 @@ from app.persistence.sql.repository import GenericAsyncSqlRepository
 settings = get_settings()
 tracer = trace.get_tracer(__name__)
 
-# asyncpg caps bind parameters per statement at a signed 16-bit maximum
-_MAX_BIND_PARAMS_PER_STATEMENT = 2**15 - 1
-
 
 class ReferenceRepositoryBase(
     GenericAsyncRepository[DomainReference, GenericPersistenceType],
@@ -1324,22 +1321,15 @@ class PendingEnhancementSQLRepository(
             for record in records
         ]
 
-        chunk_size = max(
-            1,
-            _MAX_BIND_PARAMS_PER_STATEMENT
-            // len(SQLPendingEnhancement.__table__.columns),
-        )
-        inserted = 0
-        for start in range(0, len(rows), chunk_size):
-            stmt = (
-                pg_insert(SQLPendingEnhancement)
-                .values(rows[start : start + chunk_size])
-                .on_conflict_do_nothing(
-                    constraint=SQLPendingEnhancement.non_retry_uniqueness_index
-                )
+        stmt = (
+            pg_insert(SQLPendingEnhancement)
+            .on_conflict_do_nothing(
+                constraint=SQLPendingEnhancement.non_retry_uniqueness_index
             )
-            result = await self._session.execute(stmt)
-            inserted += result.rowcount or 0
+            .returning(SQLPendingEnhancement.id)
+        )
+        result = await self._session.execute(stmt, rows)
+        inserted = len(result.all())
 
         await self._session.flush()
         return inserted

--- a/app/domain/references/service.py
+++ b/app/domain/references/service.py
@@ -1,5 +1,6 @@
 """The service for interacting with and managing references."""
 
+import contextlib
 import datetime
 from collections import defaultdict
 from collections.abc import Collection, Iterable, Sequence
@@ -90,6 +91,7 @@ from app.persistence.es.uow import AsyncESUnitOfWork
 from app.persistence.es.uow import unit_of_work as es_unit_of_work
 from app.persistence.sql.uow import AsyncSqlUnitOfWork
 from app.persistence.sql.uow import unit_of_work as sql_unit_of_work
+from app.utils.aio import prefetch
 from app.utils.lists import list_chunker
 from app.utils.time_and_date import apply_positive_timedelta
 
@@ -774,21 +776,28 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
         search = enhancement_request.search
         total_count_recorded = False
         try:
-            async for page in self._search_service.scan(
-                search,
-                score=False,
-                page_size=settings.search_enhancement_scan_page_size,
-            ):
-                if not total_count_recorded:
-                    await self._enhancement_service.record_search_match_total(
-                        enhancement_request_id, page.total.value
+            # Prefetched so the next ES page is retrieved while the current page
+            # is being processed.
+            async with contextlib.aclosing(
+                prefetch(
+                    self._search_service.scan(
+                        search,
+                        score=False,
+                        page_size=settings.search_enhancement_scan_page_size,
                     )
-                    total_count_recorded = True
-                await self.create_pending_enhancements(
-                    robot_id=enhancement_request.robot_id,
-                    reference_ids=[hit.id for hit in page.hits],
-                    enhancement_request_id=enhancement_request_id,
                 )
+            ) as pages:
+                async for page in pages:
+                    if not total_count_recorded:
+                        await self._enhancement_service.record_search_match_total(
+                            enhancement_request_id, page.total.value
+                        )
+                        total_count_recorded = True
+                    await self.create_pending_enhancements(
+                        robot_id=enhancement_request.robot_id,
+                        reference_ids=[hit.id for hit in page.hits],
+                        enhancement_request_id=enhancement_request_id,
+                    )
             if not total_count_recorded:
                 await self._enhancement_service.record_search_match_total(
                     enhancement_request_id, 0

--- a/app/utils/aio.py
+++ b/app/utils/aio.py
@@ -29,7 +29,9 @@ async def prefetch(source: AsyncGenerator[T, None]) -> AsyncGenerator[T, None]:
             async with contextlib.aclosing(source) as stream:
                 async for item in stream:
                     await queue.put(item)
-        except Exception as exc:  # noqa: BLE001 - re-raised in the consumer
+        except asyncio.CancelledError:
+            raise
+        except BaseException as exc:  # noqa: BLE001 - re-raised in the consumer
             await queue.put(exc)
         else:
             await queue.put(_DONE)
@@ -45,5 +47,9 @@ async def prefetch(source: AsyncGenerator[T, None]) -> AsyncGenerator[T, None]:
             yield item
     finally:
         producer.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
+        try:
             await producer
+        except asyncio.CancelledError:
+            consumer = asyncio.current_task()
+            if consumer is not None and consumer.cancelling():
+                raise

--- a/app/utils/aio.py
+++ b/app/utils/aio.py
@@ -3,9 +3,11 @@
 import asyncio
 import contextlib
 from collections.abc import AsyncGenerator
-from typing import TypeVar
+from typing import Any, Final, TypeVar
 
 T = TypeVar("T")
+
+_DONE: Final = object()
 
 
 async def prefetch(source: AsyncGenerator[T, None]) -> AsyncGenerator[T, None]:
@@ -18,17 +20,28 @@ async def prefetch(source: AsyncGenerator[T, None]) -> AsyncGenerator[T, None]:
     Callers that may stop iterating early - via ``break``, or an exception in
     the loop body - must wrap this in :func:`contextlib.aclosing`.
     """
-    upcoming = asyncio.ensure_future(anext(source))
+    queue: asyncio.Queue[Any] = asyncio.Queue(maxsize=1)
+
+    async def _produce() -> None:
+        try:
+            async with contextlib.aclosing(source) as stream:
+                async for item in stream:
+                    await queue.put(item)
+        except Exception as exc:  # noqa: BLE001 - re-raised in the consumer
+            await queue.put(exc)
+        else:
+            await queue.put(_DONE)
+
+    producer = asyncio.create_task(_produce())
     try:
         while True:
-            try:
-                item = await upcoming
-            except StopAsyncIteration:
+            item = await queue.get()
+            if item is _DONE:
                 return
-            upcoming = asyncio.ensure_future(anext(source))
+            if isinstance(item, BaseException):
+                raise item
             yield item
     finally:
-        upcoming.cancel()
-        with contextlib.suppress(asyncio.CancelledError, StopAsyncIteration):
-            await upcoming
-        await source.aclose()
+        producer.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await producer

--- a/app/utils/aio.py
+++ b/app/utils/aio.py
@@ -15,7 +15,9 @@ async def prefetch(source: AsyncGenerator[T, None]) -> AsyncGenerator[T, None]:
     Yield from ``source`` with the next item already in flight.
 
     Overlaps a slow producer with a slow consumer: fetching item n+1 starts
-    before the caller has finished with item n.
+    before the caller has finished with item n. A slow consumer leaves the
+    source up to two items ahead - one queued, one fetched and waiting to be
+    queued - so three items can be alive at once.
 
     Callers that may stop iterating early - via ``break``, or an exception in
     the loop body - must wrap this in :func:`contextlib.aclosing`.

--- a/app/utils/aio.py
+++ b/app/utils/aio.py
@@ -1,0 +1,34 @@
+"""Utility functions for async iteration."""
+
+import asyncio
+import contextlib
+from collections.abc import AsyncGenerator
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+async def prefetch(source: AsyncGenerator[T, None]) -> AsyncGenerator[T, None]:
+    """
+    Yield from ``source`` with the next item already in flight.
+
+    Overlaps a slow producer with a slow consumer: fetching item n+1 starts
+    before the caller has finished with item n.
+
+    Callers that may stop iterating early - via ``break``, or an exception in
+    the loop body - must wrap this in :func:`contextlib.aclosing`.
+    """
+    upcoming = asyncio.ensure_future(anext(source))
+    try:
+        while True:
+            try:
+                item = await upcoming
+            except StopAsyncIteration:
+                return
+            upcoming = asyncio.ensure_future(anext(source))
+            yield item
+    finally:
+        upcoming.cancel()
+        with contextlib.suppress(asyncio.CancelledError, StopAsyncIteration):
+            await upcoming
+        await source.aclose()

--- a/cli/request_enhancements_for_search.py
+++ b/cli/request_enhancements_for_search.py
@@ -62,6 +62,7 @@ def request_enhancements(  # noqa: PLR0913
             robot_id=robot_id,
             search_query=query,
             source=source,
+            timeout=60,
             dry_run=True,
         )
         print(

--- a/infra/app/main.tf
+++ b/infra/app/main.tf
@@ -177,8 +177,10 @@ locals {
     {
       name = "es-config"
       value = jsonencode({
-        cloud_id = ec_deployment.cluster.elasticsearch.cloud_id
-        api_key  = elasticstack_elasticsearch_security_api_key.app.encoded
+        cloud_id        = ec_deployment.cluster.elasticsearch.cloud_id
+        api_key         = elasticstack_elasticsearch_security_api_key.app.encoded
+        timeout_seconds = var.es_timeout_seconds
+        max_retries     = var.es_max_retries
       })
     },
     {
@@ -759,8 +761,10 @@ resource "azurerm_container_app_job" "es_index_migrator" {
   secret {
     name = "es-config"
     value = jsonencode({
-      cloud_id = ec_deployment.cluster.elasticsearch.cloud_id
-      api_key  = elasticstack_elasticsearch_security_api_key.es_index_migrator.encoded
+      cloud_id        = ec_deployment.cluster.elasticsearch.cloud_id
+      api_key         = elasticstack_elasticsearch_security_api_key.es_index_migrator.encoded
+      timeout_seconds = var.es_timeout_seconds
+      max_retries     = var.es_max_retries
     })
   }
 

--- a/infra/app/variables.tf
+++ b/infra/app/variables.tf
@@ -398,6 +398,18 @@ variable "es_aggregation_max_buckets" {
   default     = 1000
 }
 
+variable "es_timeout_seconds" {
+  description = "Request timeout for the Elasticsearch client in seconds"
+  type        = number
+  default     = 30
+}
+
+variable "es_max_retries" {
+  description = "Maximum retries per Elasticsearch request. Zero disables retries, including retry on timeout."
+  type        = number
+  default     = 5
+}
+
 variable "es_migrator_reindex_polling_interval" {
   description = "How frequently to poll the reindexing task when migrating indices"
   type        = number

--- a/tests/unit/domain/references/test_repository.py
+++ b/tests/unit/domain/references/test_repository.py
@@ -1,15 +1,22 @@
 import datetime
 import time
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid7
 
 import pytest
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import StateTransitionError
 from app.domain.references.models.models import (
     GenericExternalIdentifier,
+    PendingEnhancement,
     PendingEnhancementStatus,
 )
 from app.domain.references.models.sql import ExternalIdentifier as SQLExternalIdentifier
+from app.domain.references.models.sql import (
+    PendingEnhancement as SQLPendingEnhancement,
+)
 from app.domain.references.models.sql import Reference as SQLReference
 from app.domain.references.repository import (
     PendingEnhancementSQLRepository,
@@ -342,3 +349,33 @@ class TestPendingEnhancementSQLRepository:
         updated_pe2 = await repo.get_by_pk(pe2.id)
         assert updated_pe1.status == PendingEnhancementStatus.PROCESSING
         assert updated_pe2.status == PendingEnhancementStatus.PROCESSING
+
+    async def test_add_bulk_ignore_conflicts_chunks_within_bind_param_limit(self):
+        """Each chunked insert stays under asyncpg's bind parameter ceiling."""
+        mock_session = AsyncMock(spec=AsyncSession)
+        mock_session.execute.return_value = MagicMock(rowcount=1)
+        repo = PendingEnhancementSQLRepository(mock_session)
+
+        records = [
+            PendingEnhancement(
+                reference_id=uuid7(),
+                robot_id=uuid7(),
+                enhancement_request_id=uuid7(),
+                expires_at=utc_now() + datetime.timedelta(hours=1),
+            )
+            for _ in range(7000)
+        ]
+
+        await repo.add_bulk_ignore_conflicts(records)
+
+        statements = [call.args[0] for call in mock_session.execute.await_args_list]
+        assert len(statements) > 1, "expected the insert to be chunked"
+
+        bound = 0
+        for statement in statements:
+            params = len(statement.compile(dialect=postgresql.dialect()).params)
+            assert params <= 2**15 - 1
+            bound += params
+
+        # Every row binds every column, including the ones left to their defaults.
+        assert bound == len(records) * len(SQLPendingEnhancement.__table__.columns)

--- a/tests/unit/domain/references/test_repository.py
+++ b/tests/unit/domain/references/test_repository.py
@@ -350,10 +350,18 @@ class TestPendingEnhancementSQLRepository:
         assert updated_pe1.status == PendingEnhancementStatus.PROCESSING
         assert updated_pe2.status == PendingEnhancementStatus.PROCESSING
 
-    async def test_add_bulk_ignore_conflicts_chunks_within_bind_param_limit(self):
-        """Each chunked insert stays under asyncpg's bind parameter ceiling."""
+    async def test_add_bulk_ignore_conflicts_passes_rows_as_executemany_params(self):
+        """
+        Rows go as executemany parameters rather than inlined VALUES.
+
+        Inlining would recompile a statement per call - the dominant cost at
+        these sizes - and reintroduce asyncpg's 32767 bind parameter ceiling.
+        """
+        n_records = 7000
         mock_session = AsyncMock(spec=AsyncSession)
-        mock_session.execute.return_value = MagicMock(rowcount=1)
+        mock_session.execute.return_value = MagicMock(
+            all=MagicMock(return_value=[object()] * n_records)
+        )
         repo = PendingEnhancementSQLRepository(mock_session)
 
         records = [
@@ -363,19 +371,17 @@ class TestPendingEnhancementSQLRepository:
                 enhancement_request_id=uuid7(),
                 expires_at=utc_now() + datetime.timedelta(hours=1),
             )
-            for _ in range(7000)
+            for _ in range(n_records)
         ]
 
-        await repo.add_bulk_ignore_conflicts(records)
+        inserted = await repo.add_bulk_ignore_conflicts(records)
 
-        statements = [call.args[0] for call in mock_session.execute.await_args_list]
-        assert len(statements) > 1, "expected the insert to be chunked"
+        assert inserted == n_records
+        mock_session.execute.assert_awaited_once()
+        statement, params = mock_session.execute.await_args.args
+        assert len(params) == n_records
 
-        bound = 0
-        for statement in statements:
-            params = len(statement.compile(dialect=postgresql.dialect()).params)
-            assert params <= 2**15 - 1
-            bound += params
-
-        # Every row binds every column, including the ones left to their defaults.
-        assert bound == len(records) * len(SQLPendingEnhancement.__table__.columns)
+        # One row's worth of placeholders however many rows are inserted, so the
+        # bind parameter ceiling is unreachable.
+        compiled = statement.compile(dialect=postgresql.dialect())
+        assert len(compiled.params) == len(SQLPendingEnhancement.__table__.columns)

--- a/tests/unit/test_aio.py
+++ b/tests/unit/test_aio.py
@@ -84,17 +84,24 @@ async def test_prefetch_overlaps_producer_and_consumer():
 
 
 @pytest.mark.asyncio
-async def test_prefetch_reads_at_most_one_ahead():
+async def test_prefetch_lookahead_is_bounded_at_two():
+    """
+    A slow consumer leaves the source two items ahead, and no further.
+
+    One item waits in the queue while the producer holds a second, blocked on
+    putting it.
+    """
     produced: list[int] = []
     seen: list[int] = []
+    lookaheads: list[int] = []
 
-    async for item in prefetch(_slow_source(6, 0, produced)):
-        await asyncio.sleep(0)
+    async for item in prefetch(_slow_source(8, 0.001, produced)):
+        await asyncio.sleep(0.01)
         seen.append(item)
-        # Only the immediate successor may have been fetched.
-        assert len(produced) <= len(seen) + 1
+        lookaheads.append(len(produced) - len(seen))
 
-    assert seen == [0, 1, 2, 3, 4, 5]
+    assert seen == [0, 1, 2, 3, 4, 5, 6, 7]
+    assert max(lookaheads) == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_aio.py
+++ b/tests/unit/test_aio.py
@@ -1,0 +1,103 @@
+import asyncio
+import contextlib
+
+import pytest
+
+from app.utils.aio import prefetch
+
+
+async def _slow_source(n, delay, produced=None):
+    for i in range(n):
+        await asyncio.sleep(delay)
+        if produced is not None:
+            produced.append(i)
+        yield i
+
+
+async def _closeable(closed):
+    try:
+        for i in range(100):
+            yield i
+    finally:
+        closed.set()
+
+
+@pytest.mark.asyncio
+async def test_prefetch_preserves_order_and_completes():
+    assert [item async for item in prefetch(_slow_source(5, 0))] == [0, 1, 2, 3, 4]
+
+
+@pytest.mark.asyncio
+async def test_prefetch_overlaps_producer_and_consumer():
+    """Serial iteration costs n*(produce+consume); prefetched, the two overlap."""
+    delay = 0.02
+    n = 5
+
+    start = asyncio.get_running_loop().time()
+    async for _ in prefetch(_slow_source(n, delay)):
+        await asyncio.sleep(delay)
+    elapsed = asyncio.get_running_loop().time() - start
+
+    serial = 2 * n * delay
+    assert elapsed < serial * 0.8
+
+
+@pytest.mark.asyncio
+async def test_prefetch_reads_at_most_one_ahead():
+    produced: list[int] = []
+    seen: list[int] = []
+
+    async for item in prefetch(_slow_source(6, 0, produced)):
+        await asyncio.sleep(0)
+        seen.append(item)
+        # Only the immediate successor may have been fetched.
+        assert len(produced) <= len(seen) + 1
+
+    assert seen == [0, 1, 2, 3, 4, 5]
+
+
+@pytest.mark.asyncio
+async def test_prefetch_propagates_source_error():
+    async def _failing():
+        yield 0
+        msg = "boom"
+        raise ValueError(msg)
+
+    seen = []
+
+    async def _drain():
+        async for item in prefetch(_failing()):
+            seen.append(item)  # noqa: PERF401 - must survive the raise
+
+    with pytest.raises(ValueError, match="boom"):
+        await _drain()
+
+    assert seen == [0]
+
+
+@pytest.mark.asyncio
+async def test_prefetch_closes_source_on_early_break():
+    closed = asyncio.Event()
+
+    async with contextlib.aclosing(prefetch(_closeable(closed))) as pages:
+        async for item in pages:
+            if item == 2:
+                break
+
+    assert closed.is_set()
+
+
+@pytest.mark.asyncio
+async def test_prefetch_closes_source_when_consumer_raises():
+    closed = asyncio.Event()
+
+    async def _fail_in_body():
+        async with contextlib.aclosing(prefetch(_closeable(closed))) as pages:
+            async for _ in pages:
+                msg = "consumer failed"
+                raise RuntimeError(msg)
+
+    with pytest.raises(RuntimeError, match="consumer failed"):
+        await _fail_in_body()
+
+    assert closed.is_set()

--- a/tests/unit/test_aio.py
+++ b/tests/unit/test_aio.py
@@ -105,6 +105,86 @@ async def test_prefetch_lookahead_is_bounded_at_two():
 
 
 @pytest.mark.asyncio
+async def test_prefetch_propagates_cancellation_of_the_consumer():
+    consuming = asyncio.Event()
+
+    async def _consume():
+        async with contextlib.aclosing(prefetch(_slow_source(100, 0.01))) as items:
+            async for _ in items:
+                consuming.set()
+                await asyncio.sleep(10)
+
+    task = asyncio.create_task(_consume())
+    await consuming.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_prefetch_propagates_cancellation_arriving_during_cleanup():
+    """
+    Awaiting the producer must not absorb a cancellation of the consumer.
+
+    Tearing the producer down is expected to raise CancelledError, but that
+    same await is a delivery point for the consumer's own cancellation. If it
+    is swallowed, a worker asked to stop carries on to the next statement.
+    """
+    closing = asyncio.Event()
+
+    async def _slow_to_close():
+        try:
+            for i in range(100):
+                yield i
+        finally:
+            closing.set()
+            await asyncio.sleep(0.2)
+
+    async def _consume():
+        async with contextlib.aclosing(prefetch(_slow_to_close())) as items:
+            async for item in items:
+                if item == 0:
+                    break
+
+    task = asyncio.create_task(_consume())
+    await closing.wait()
+    await asyncio.sleep(0)  # let the consumer reach `await producer`
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert task.cancelled()
+
+
+class _Fatal(BaseException):
+    """Stands in for SystemExit/KeyboardInterrupt without tripping pytest."""
+
+
+@pytest.mark.asyncio
+async def test_prefetch_propagates_base_exception_from_source():
+    """A BaseException reaches the consumer instead of stranding it."""
+
+    async def _fatal():
+        yield 0
+        raise _Fatal
+
+    async def _drain():
+        async for _ in prefetch(_fatal()):
+            pass
+
+    # It must arrive promptly. A stranded consumer also surfaces _Fatal, but
+    # only once something else cancels it and the finally re-raises it off the
+    # dead producer - in production, nothing would.
+    start = asyncio.get_running_loop().time()
+    with pytest.raises(_Fatal):
+        await asyncio.wait_for(_drain(), timeout=2)
+
+    assert asyncio.get_running_loop().time() - start < 0.5
+
+
+@pytest.mark.asyncio
 async def test_prefetch_propagates_source_error():
     async def _failing():
         yield 0

--- a/tests/unit/test_aio.py
+++ b/tests/unit/test_aio.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import contextvars
 
 import pytest
 
@@ -20,6 +21,46 @@ async def _closeable(closed):
             yield i
     finally:
         closed.set()
+
+
+@pytest.mark.asyncio
+async def test_prefetch_advances_source_in_one_context():
+    """The source must be resumed from a single task."""
+    var = contextvars.ContextVar("probe", default=0)
+
+    async def _instrumented():
+        token = var.set(1)
+        try:
+            for i in range(5):
+                yield i
+        finally:
+            var.reset(token)
+
+    assert [item async for item in prefetch(_instrumented())] == [0, 1, 2, 3, 4]
+
+
+@pytest.mark.asyncio
+async def test_prefetch_closes_source_in_one_context_on_early_break():
+    """The same holds when the close happens while the fetch is being cancelled."""
+    var = contextvars.ContextVar("probe", default=0)
+    closed = asyncio.Event()
+
+    async def _instrumented():
+        token = var.set(1)
+        try:
+            for i in range(100):
+                await asyncio.sleep(0)
+                yield i
+        finally:
+            var.reset(token)
+            closed.set()
+
+    async with contextlib.aclosing(prefetch(_instrumented())) as items:
+        async for item in items:
+            if item == 2:
+                break
+
+    assert closed.is_set()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
A couple of niggles noticed when running in staging:
- CLI dry runs should have a longer timeout to allow for counting
- Plumb in elasticsearch timeout/retry config so we can adjust it in production
- Performance improvements:
  - Remove overthought code for the bulk conflict-do-nothing execute - let SQLAlchemy handle it. `execute()` with `rows=` proved _much_ faster than `.values()`. Each page went from 6s to <1s to insert in staging.
  - Overlap ES reads with SQL inserts. 10-50% performance increase, depending on the search query.

Staging run post-fixes: https://ui.honeycomb.io/destiny-evidence/environments/staging/datasets/destiny-repository-task-staging/result/ncNMEyyxxRL/trace/dDoFgRiR7zh?fields[]=s_name&fields[]=s_serviceName&span=0ac752c69d7c7f8b
Main redeployed to staging.