### PR TITLE
Add restricted ability for robots to write raw enhancements

### DIFF
--- a/.github/workflows/sdk-version-bump.yml
+++ b/.github/workflows/sdk-version-bump.yml
@@ -1,0 +1,59 @@
+name: SDK Version Bump
+
+on:
+  pull_request:
+
+jobs:
+  check-sdk-version-bumped:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.9.22"
+
+      - name: Check version is bumped when SDK source changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet "$BASE_SHA...$HEAD_SHA" -- libs/sdk/src/destiny_sdk; then
+            echo "✅ No changes under libs/sdk/src/destiny_sdk, nothing to check."
+            exit 0
+          fi
+
+          echo "Changed SDK source files:"
+          git diff --name-only "$BASE_SHA...$HEAD_SHA" -- libs/sdk/src/destiny_sdk
+
+          extract_version() {
+            grep '^version = ' | sed 's/version = "\(.*\)"/\1/'
+          }
+
+          HEAD_VERSION=$(git show "$HEAD_SHA:libs/sdk/pyproject.toml" | extract_version)
+          BASE_VERSION=$(git show "$BASE_SHA:libs/sdk/pyproject.toml" | extract_version)
+
+          echo "Base version: $BASE_VERSION"
+          echo "Head version: $HEAD_VERSION"
+
+          uv run --no-project --with packaging python - "$BASE_VERSION" "$HEAD_VERSION" <<'EOF'
+          import sys
+
+          from packaging.version import Version
+
+          base, head = Version(sys.argv[1]), Version(sys.argv[2])
+          if head <= base:
+              sys.exit(
+                  f"❌ libs/sdk/src/destiny_sdk changed but the SDK version was not "
+                  f"incremented: {base} -> {head}.\n"
+                  f"Bump `version` in libs/sdk/pyproject.toml (and refresh the "
+                  f"lockfiles with `uv lock`)."
+              )
+          print(f"✅ SDK version incremented: {base} -> {head}")
+          EOF

--- a/app/core/entitlements.py
+++ b/app/core/entitlements.py
@@ -7,4 +7,5 @@ class Entitlement(StrEnum):
     """Capabilities that can be granted to an authenticated principal."""
 
     FULL_TEXT = auto()
+    RAW_ENHANCEMENT_WRITER = auto()
     ROBOT_ENTITLEMENT_WRITER = auto()

--- a/app/domain/references/models/validators.py
+++ b/app/domain/references/models/validators.py
@@ -268,6 +268,8 @@ class EnhancementResultValidator(BaseModel):
         entry_ref: int,
         expected_reference_ids: set[UUID],
         processed_reference_ids: set[UUID] | None = None,
+        *,
+        allow_raw_enhancements: bool = False,
     ) -> Self:
         """Create a EnhancementResult from a jsonl entry."""
         file_entry_validator: TypeAdapter[destiny_sdk.robots.EnhancementResultEntry] = (
@@ -302,12 +304,14 @@ class EnhancementResultValidator(BaseModel):
             )
 
         if isinstance(file_entry, destiny_sdk.enhancements.Enhancement):
-            # Do not allow raw enhancements to be created by robots
-            if file_entry.content.enhancement_type == EnhancementType.RAW:
+            if (
+                file_entry.content.enhancement_type == EnhancementType.RAW
+                and not allow_raw_enhancements
+            ):
                 return cls(
                     robot_error=destiny_sdk.robots.LinkedRobotError(
                         reference_id=file_entry.reference_id,
-                        message="Robot returned illegal raw enhancement type",
+                        message=("Robot is not entitled to return raw enhancements. "),
                     )
                 )
 

--- a/app/domain/references/models/validators.py
+++ b/app/domain/references/models/validators.py
@@ -268,6 +268,8 @@ class EnhancementResultValidator(BaseModel):
         entry_ref: int,
         expected_reference_ids: set[UUID],
         processed_reference_ids: set[UUID] | None = None,
+        *,
+        allow_raw_enhancements: bool = False,
     ) -> Self:
         """Create a EnhancementResult from a jsonl entry."""
         file_entry_validator: TypeAdapter[destiny_sdk.robots.EnhancementResultEntry] = (
@@ -302,12 +304,14 @@ class EnhancementResultValidator(BaseModel):
             )
 
         if isinstance(file_entry, destiny_sdk.enhancements.Enhancement):
-            # Do not allow raw enhancements to be created by robots
-            if file_entry.content.enhancement_type == EnhancementType.RAW:
+            if (
+                file_entry.content.enhancement_type == EnhancementType.RAW
+                and not allow_raw_enhancements
+            ):
                 return cls(
                     robot_error=destiny_sdk.robots.LinkedRobotError(
                         reference_id=file_entry.reference_id,
-                        message="Robot returned illegal raw enhancement type",
+                        message="Robot is not entitled to return raw enhancements.",
                     )
                 )
 

--- a/app/domain/references/service.py
+++ b/app/domain/references/service.py
@@ -958,6 +958,7 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
         self,
         robot_enhancement_batch: RobotEnhancementBatch,
         blob_repository: BlobRepository,
+        access_control_service: ReferenceAccessControlService,
     ) -> ProcessedResults:
         """
         Validate and import the result of a robot enhancement batch.
@@ -967,6 +968,9 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
         - adds the enhancement to the database
         - streams the validation result to the blob storage service line-by-line
         - does some final validation of missing references and updates the request
+
+        ``access_control_service`` carries the entitlements of the robot the batch
+        belongs to.
         """
         if not robot_enhancement_batch.result_file:
             msg = "Robot enhancement batch has no result file. This should not happen."
@@ -995,6 +999,7 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
                     pending_enhancements=pending_enhancements,
                     add_enhancement=self.handle_enhancement_result_entry,
                     results=results,
+                    access_control_service=access_control_service,
                 )
             ),
             path="enhancement_result",

--- a/app/domain/references/services/access_control_service.py
+++ b/app/domain/references/services/access_control_service.py
@@ -12,7 +12,7 @@ RedactedReference = NewType("RedactedReference", Reference)
 
 
 class ReferenceAccessControlService(GenericAccessControlService):
-    """Redact references for a principal's entitlements."""
+    """Apply a principal's entitlements to reference reads and writes."""
 
     def redact_reference(self, reference: Reference) -> RedactedReference:
         """Return the principal's redacted view of a reference."""
@@ -25,6 +25,11 @@ class ReferenceAccessControlService(GenericAccessControlService):
                 }
             )
         )
+
+    @property
+    def may_write_raw_enhancements(self) -> bool:
+        """Whether the principal may contribute raw enhancements to a reference."""
+        return Entitlement.RAW_ENHANCEMENT_WRITER in self._entitlements
 
     def _redact_full_text(self, enhancements: list[Enhancement]) -> list[Enhancement]:
         """Drop full-text enhancements unless the principal is entitled to them."""

--- a/app/domain/references/services/enhancement_service.py
+++ b/app/domain/references/services/enhancement_service.py
@@ -35,6 +35,9 @@ from app.domain.references.models.models import (
 from app.domain.references.models.validators import (
     EnhancementResultValidator,
 )
+from app.domain.references.services.access_control_service import (
+    ReferenceAccessControlService,
+)
 from app.domain.references.services.anti_corruption_service import (
     ReferenceAntiCorruptionService,
 )
@@ -535,12 +538,16 @@ class EnhancementService(GenericService[ReferenceAntiCorruptionService]):
             [Enhancement], Awaitable[tuple[PendingEnhancementStatus, str]]
         ],
         results: ProcessedResults,
+        access_control_service: ReferenceAccessControlService,
     ) -> AsyncGenerator[str, None]:
         """
         Validate the result of a robot enhancement batch.
 
         This generator yields validation messages which are streamed into the
         result file of the robot enhancement batch.
+
+        ``access_control_service`` carries the entitlements of the robot that
+        produced the result.
         """
         expected_reference_ids = {pe.reference_id for pe in pending_enhancements}
         successful_reference_ids: set[UUID] = set()
@@ -573,6 +580,7 @@ class EnhancementService(GenericService[ReferenceAntiCorruptionService]):
                             line_no,
                             expected_reference_ids,
                             processed_reference_ids,
+                            allow_raw_enhancements=access_control_service.may_write_raw_enhancements,
                         )
                         line_no += 1
 

--- a/app/domain/references/tasks.py
+++ b/app/domain/references/tasks.py
@@ -116,6 +116,14 @@ async def validate_and_import_robot_enhancement_batch_result(
         )
         trace_attribute(Attributes.ROBOT_ID, str(robot_enhancement_batch.robot_id))
 
+        robot_service = await get_robot_service(RobotAntiCorruptionService(), sql_uow)
+        robot = await robot_service.get_robot_standalone(
+            robot_enhancement_batch.robot_id
+        )
+        access_control_service = ReferenceAccessControlService(
+            entitlements=robot.entitlements
+        )
+
         try:
             with bound_contextvars(
                 robot_id=str(robot_enhancement_batch.robot_id),
@@ -124,6 +132,7 @@ async def validate_and_import_robot_enhancement_batch_result(
                 results = await reference_service.validate_and_import_robot_enhancement_batch_result(  # noqa: E501
                     robot_enhancement_batch,
                     blob_repository,
+                    access_control_service=access_control_service,
                 )
         except Exception as exc:
             logger.exception(

--- a/libs/sdk/pyproject.toml
+++ b/libs/sdk/pyproject.toml
@@ -36,7 +36,7 @@ license = "Apache-2.0"
 name = "destiny_sdk"
 readme = "README.md"
 requires-python = ">=3.12, <4"
-version = "0.14.0"
+version = "0.14.1"
 
 [project.optional-dependencies]
 labs = []

--- a/libs/sdk/src/destiny_sdk/enhancements.py
+++ b/libs/sdk/src/destiny_sdk/enhancements.py
@@ -604,8 +604,8 @@ class RawEnhancement(BaseModel):
 
     Data in these enhancements is intended for future conversion into structured form.
 
-    This enhancement accepts any fields passed in to `data`. These enhancements cannot
-    be created by robots.
+    This enhancement accepts any fields passed in to `data`. These enhancements can
+    only be created by robots granted the ``raw_enhancement_writer`` entitlement.
     """
 
     enhancement_type: Literal[EnhancementType.RAW] = EnhancementType.RAW

--- a/libs/sdk/src/destiny_sdk/robots.py
+++ b/libs/sdk/src/destiny_sdk/robots.py
@@ -401,6 +401,9 @@ class RobotEntitlement(StrEnum):
     FULL_TEXT = auto()
     """The robot is entitled to read full texts in order to derive enhancements."""
 
+    RAW_ENHANCEMENT_WRITER = auto()
+    """The robot is entitled to return raw enhancements."""
+
 
 class _RobotBase(BaseModel):
     """

--- a/libs/sdk/uv.lock
+++ b/libs/sdk/uv.lock
@@ -254,7 +254,7 @@ wheels = [
 
 [[package]]
 name = "destiny-sdk"
-version = "0.14.0"
+version = "0.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },

--- a/tests/unit/domain/references/services/test_access_control_service.py
+++ b/tests/unit/domain/references/services/test_access_control_service.py
@@ -46,6 +46,18 @@ def test_redact_strips_full_text_when_principal_lacks_entitlement():
     assert redacted.enhancements[0].content.enhancement_type == EnhancementType.ABSTRACT
 
 
+def test_may_write_raw_enhancements_follows_entitlement():
+    entitled = ReferenceAccessControlService(
+        entitlements=frozenset({Entitlement.RAW_ENHANCEMENT_WRITER})
+    )
+    unentitled = ReferenceAccessControlService(
+        entitlements=frozenset({Entitlement.FULL_TEXT})
+    )
+
+    assert entitled.may_write_raw_enhancements
+    assert not unentitled.may_write_raw_enhancements
+
+
 def test_redact_returns_empty_list_when_only_full_text_present():
     acl = ReferenceAccessControlService(entitlements=frozenset())
     reference = ReferenceFactory(

--- a/tests/unit/domain/references/services/test_enhancement_service.py
+++ b/tests/unit/domain/references/services/test_enhancement_service.py
@@ -5,6 +5,7 @@ from uuid import UUID, uuid7
 
 import pytest
 
+from app.core.entitlements import Entitlement
 from app.core.exceptions import (
     BlobSizeExceededError,
     FullTextDownloadError,
@@ -16,10 +17,14 @@ from app.core.exceptions import (
 from app.domain.references.models.models import (
     EnhancementRequest,
     EnhancementRequestStatus,
+    EnhancementType,
     PendingEnhancement,
     PendingEnhancementStatus,
     Reference,
     RobotResultValidationEntry,
+)
+from app.domain.references.services.access_control_service import (
+    ReferenceAccessControlService,
 )
 from app.domain.references.services.anti_corruption_service import (
     ReferenceAntiCorruptionService,
@@ -234,6 +239,7 @@ async def test_process_robot_enhancement_batch_result_happy_path():
             [pending_enhancement],
             fake_add_enhancement,
             results,
+            ReferenceAccessControlService(),
         )
     ]
     assert len(messages) == 1
@@ -288,6 +294,7 @@ async def test_process_robot_enhancement_batch_result_handles_both_entry_types()
             [pending_enhancement_1, pending_enhancement_2],
             fake_add_enhancement,
             results,
+            ReferenceAccessControlService(),
         )
     ]
     assert len(messages) == 2
@@ -340,6 +347,7 @@ async def test_process_robot_enhancement_batch_result_missing_reference_id():
             [pending_enhancement_1, pending_enhancement_2],
             fake_add_enhancement,
             results,
+            ReferenceAccessControlService(),
         )
     ]
     assert len(messages) == 2
@@ -395,6 +403,7 @@ async def test_process_robot_enhancement_batch_result_surplus_reference_id(fake_
             [pending_enhancement],
             fake_add_enhancement,
             results,
+            ReferenceAccessControlService(),
         )
     ]
     # Should process both entries but only categorize the expected one
@@ -442,6 +451,7 @@ async def test_process_robot_enhancement_batch_result_parse_failure(fake_uow):
             [pending_enhancement],
             fake_add_enhancement,
             results,
+            ReferenceAccessControlService(),
         )
     ]
     # Should have parse failure message + missing reference message
@@ -455,11 +465,30 @@ async def test_process_robot_enhancement_batch_result_parse_failure(fake_uow):
     assert {pending_enhancement.id} == results.failed_pending_enhancement_ids
 
 
+def make_raw_enhancement_result_entry(reference_id: UUID) -> str:
+    """Helper to create a raw enhancement EnhancementResultEntry jsonl line."""
+    return json.dumps(
+        {
+            "reference_id": str(reference_id),
+            "content": {
+                "enhancement_type": "raw",
+                "source_export_date": str(datetime.now(tz=UTC)),
+                "description": "nonsense",
+                "data": {"some": "data"},
+                "metadata": {},
+            },
+            "source": "test_source",
+            "visibility": "public",
+            "created_at": datetime.now(tz=UTC).isoformat(),
+        }
+    )
+
+
 @pytest.mark.asyncio
 async def test_process_robot_enhancement_batch_result_raw_enhancement(fake_uow):
     """
-    Test that process_robot_enhancement_batch_result returns a robot error
-    if the enhancement type is a raw enhancement.
+    Test that process_robot_enhancement_batch_result returns a robot error if the
+    enhancement type is raw and the robot is not entitled to write raw enhancements.
     """
     reference_id = uuid7()
     pending_enhancement = create_pending_enhancement(reference_id)
@@ -467,26 +496,9 @@ async def test_process_robot_enhancement_batch_result_raw_enhancement(fake_uow):
 
     uow = fake_uow()
     mock_blob_repo = MagicMock()
-    fake_stream = create_fake_stream(
-        [
-            json.dumps(
-                {
-                    "reference_id": str(reference_id),
-                    "content": {
-                        "enhancement_type": "raw",
-                        "source_export_date": str(datetime.now(tz=UTC)),
-                        "description": "nonsense",
-                        "data": {"some": "data"},
-                        "metadata": {},
-                    },
-                    "source": "test_source",
-                    "visibility": "public",
-                    "created_at": datetime.now(tz=UTC).isoformat(),
-                }
-            )
-        ]
+    mock_blob_repo.stream_file_from_blob_storage = create_fake_stream(
+        [make_raw_enhancement_result_entry(reference_id)]
     )
-    mock_blob_repo.stream_file_from_blob_storage = fake_stream
     service = EnhancementService(
         ReferenceAntiCorruptionService(mock_blob_repo), uow, MagicMock()
     )
@@ -506,15 +518,70 @@ async def test_process_robot_enhancement_batch_result_raw_enhancement(fake_uow):
             [pending_enhancement],
             fake_add_enhancement,
             results,
+            ReferenceAccessControlService(),
         )
     ]
 
     assert len(messages) == 1
     assert messages[0].reference_id == reference_id
-    assert messages[0].error == "Robot returned illegal raw enhancement type"
+    assert "not entitled to return raw enhancements" in messages[0].error
     assert len(results.imported_enhancement_ids) == 0
     assert len(results.successful_pending_enhancement_ids) == 0
     assert {pending_enhancement.id} == results.failed_pending_enhancement_ids
+
+
+@pytest.mark.asyncio
+async def test_process_robot_enhancement_batch_result_entitled_raw_enhancement(
+    fake_uow,
+):
+    """
+    Test that a raw enhancement is imported when the robot holds the
+    raw_enhancement_writer entitlement.
+    """
+    reference_id = uuid7()
+    pending_enhancement = create_pending_enhancement(reference_id)
+    result_file = create_result_file()
+
+    uow = fake_uow()
+    mock_blob_repo = MagicMock()
+    mock_blob_repo.stream_file_from_blob_storage = create_fake_stream(
+        [make_raw_enhancement_result_entry(reference_id)]
+    )
+    service = EnhancementService(
+        ReferenceAntiCorruptionService(mock_blob_repo), uow, MagicMock()
+    )
+
+    added_enhancements = []
+
+    async def fake_add_enhancement(enhancement):
+        added_enhancements.append(enhancement)
+        return (PendingEnhancementStatus.COMPLETED, "Enhancement added.")
+
+    results = create_processed_results()
+
+    messages = [
+        RobotResultValidationEntry.model_validate_json(msg)
+        async for msg in service.process_robot_enhancement_batch_result(
+            pending_enhancement.robot_enhancement_batch_id,
+            mock_blob_repo,
+            result_file,
+            [pending_enhancement],
+            fake_add_enhancement,
+            results,
+            ReferenceAccessControlService(
+                entitlements=frozenset({Entitlement.RAW_ENHANCEMENT_WRITER})
+            ),
+        )
+    ]
+
+    assert len(messages) == 1
+    assert messages[0].reference_id == reference_id
+    assert not messages[0].error
+    assert len(added_enhancements) == 1
+    assert added_enhancements[0].content.enhancement_type == EnhancementType.RAW
+    assert len(results.imported_enhancement_ids) == 1
+    assert {pending_enhancement.id} == results.successful_pending_enhancement_ids
+    assert not results.failed_pending_enhancement_ids
 
 
 @pytest.mark.asyncio
@@ -554,6 +621,7 @@ async def test_process_robot_enhancement_batch_result_add_enhancement_fails(fake
             [pending_enhancement],
             fake_add_enhancement,
             results,
+            ReferenceAccessControlService(),
         )
     ]
     assert len(messages) == 1
@@ -595,6 +663,7 @@ async def test_process_robot_enhancement_batch_result_empty_result_file():
             [pending_enhancement],
             fake_add_enhancement,
             results,
+            ReferenceAccessControlService(),
         )
     ]
     assert len(messages) == 1
@@ -647,6 +716,7 @@ async def test_process_robot_enhancement_batch_result_duplicate_reference_ids():
             [pending_enhancement],
             fake_add_enhancement,
             results,
+            ReferenceAccessControlService(),
         )
     ]
     assert len(messages) == 2
@@ -709,6 +779,7 @@ async def test_process_robot_enhancement_batch_result_multiple_pending_enhanceme
             [pending_enhancement_1, pending_enhancement_2, pending_enhancement_3],
             fake_add_enhancement,
             results,
+            ReferenceAccessControlService(),
         )
     ]
     assert len(messages) == 3
@@ -762,6 +833,7 @@ async def test_process_robot_enhancement_batch_result_discarded_enhancements():
             [pending_enhancement],
             fake_add_enhancement,
             results,
+            ReferenceAccessControlService(),
         )
     ]
     assert len(messages) == 1
@@ -843,6 +915,7 @@ async def test_process_robot_result_stores_full_text_before_persistence():
             [pending_enhancement],
             fake_add_enhancement,
             results,
+            ReferenceAccessControlService(),
         )
     ]
 
@@ -886,6 +959,7 @@ async def test_process_robot_result_full_text_download_failure_skips_add():
             [pending_enhancement],
             add_enhancement,
             results,
+            ReferenceAccessControlService(),
         )
     ]
 

--- a/tests/unit/domain/references/test_tasks.py
+++ b/tests/unit/domain/references/test_tasks.py
@@ -7,6 +7,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 from taskiq import InMemoryBroker
 
+from app.core.entitlements import Entitlement
 from app.core.exceptions import SQLIntegrityError
 from app.domain.references.models.models import (
     DuplicateDetermination,
@@ -30,6 +31,7 @@ from app.domain.references.tasks import (
     run_search_export_task,
     validate_and_import_robot_enhancement_batch_result,
 )
+from app.domain.robots.models.models import Robot
 from app.persistence.blob.models import BlobStorageFile
 from app.tasks import broker
 
@@ -148,6 +150,15 @@ async def test_validate_and_import_robot_enhancement_batch_result(monkeypatch):
     )
     mock_detect_and_dispatch.return_value = []
 
+    mock_robot_service = AsyncMock()
+    mock_robot_service.get_robot_standalone.return_value = Robot(
+        id=robot_id,
+        name="robot",
+        description="a robot",
+        owner="owner",
+        entitlements=frozenset({Entitlement.RAW_ENHANCEMENT_WRITER}),
+    )
+
     monkeypatch.setattr(
         "app.domain.references.tasks.get_blob_repository",
         AsyncMock(return_value=AsyncMock()),
@@ -155,6 +166,10 @@ async def test_validate_and_import_robot_enhancement_batch_result(monkeypatch):
     monkeypatch.setattr(
         "app.domain.references.tasks.get_reference_service",
         AsyncMock(return_value=mock_reference_service),
+    )
+    monkeypatch.setattr(
+        "app.domain.references.tasks.get_robot_service",
+        AsyncMock(return_value=mock_robot_service),
     )
 
     await validate_and_import_robot_enhancement_batch_result(robot_enhancement_batch_id)
@@ -164,6 +179,10 @@ async def test_validate_and_import_robot_enhancement_batch_result(monkeypatch):
     )
 
     validate_method.assert_awaited_once()
+    # The batch's robot supplies the entitlements gating the result file.
+    mock_robot_service.get_robot_standalone.assert_awaited_once_with(robot_id)
+    access_control_service = validate_method.call_args.kwargs["access_control_service"]
+    assert access_control_service.may_write_raw_enhancements
 
     mock_detect_and_dispatch.assert_awaited_once()
     call_kwargs = mock_detect_and_dispatch.call_args.kwargs

--- a/uv.lock
+++ b/uv.lock
@@ -705,7 +705,7 @@ test = [
 
 [[package]]
 name = "destiny-sdk"
-version = "0.14.0"
+version = "0.14.1"
 source = { editable = "libs/sdk" }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
Closes #881 

Loosens the existing block on robot-produced raw enhancements to be an entitlement check.