### PR TITLE
Introduce issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -13,7 +13,7 @@ Describe the bug, include reproduction steps or a demo if possible.
 
 ### Expected Behavior
 
-What will the behavior look like when the big is fixed? This doubles as the acceptance criteria for the ticket.
+What will the behavior look like when the bug is fixed? This doubles as the acceptance criteria for the ticket.
 
 ### Root cause (if known)
 

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,22 @@
+---
+name: Bug
+about: Report an unexpected problem or behavior
+title: ""
+type: Bug
+labels: []
+assignees: []
+---
+
+### Current Behavior
+
+Describe the bug, include reproduction steps or a demo if possible.
+
+### Expected Behavior
+
+What will the behavior look like when the big is fixed? This doubles as the acceptance criteria for the ticket.
+
+### Root cause (if known)
+
+### Scope of fix (if known)
+
+Include any suggestions for fixing the issue, or additional appropriate context from initial investigation

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -7,16 +7,18 @@ labels: []
 assignees: []
 ---
 
-### Current Behavior
+### Current behavior
 
-Describe the bug, include reproduction steps or a demo if possible.
+Describe the bug. Include reproduction steps or a demo if possible. Include any additional appropriate context from initial investigation (log, traces, alerts etc).
 
-### Expected Behavior
+### Expected behavior & acceptance criteria
 
 What will the behavior look like when the bug is fixed? This doubles as the acceptance criteria for the ticket.
 
 ### Root cause (if known)
 
+If the root cause of this bug has been identified, include it.
+
 ### Scope of fix (if known)
 
-Include any suggestions for fixing the issue, or additional appropriate context from initial investigation
+Include any suggestions for fixing the issue.

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,7 +1,7 @@
 ---
-name: Bug
-about: Report an unexpected problem or behavior
+name: 🐛 Bug
 title: ""
+about: Something is not right
 type: Bug
 labels: []
 assignees: []

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -22,3 +22,5 @@ If the root cause of this bug has been identified, include it.
 ## Scope of fix (if known)
 
 Include any suggestions for fixing the issue.
+
+-

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -7,18 +7,18 @@ labels: []
 assignees: []
 ---
 
-### Current behavior
+## Current behavior
 
 Describe the bug. Include reproduction steps or a demo if possible. Include any additional appropriate context from initial investigation (log, traces, alerts etc).
 
-### Expected behavior & acceptance criteria
+## Expected behavior & acceptance criteria
 
 What will the behavior look like when the bug is fixed? This doubles as the acceptance criteria for the ticket.
 
-### Root cause (if known)
+## Root cause (if known)
 
 If the root cause of this bug has been identified, include it.
 
-### Scope of fix (if known)
+## Scope of fix (if known)
 
 Include any suggestions for fixing the issue.

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -9,18 +9,18 @@ assignees: []
 
 ## Current behavior
 
-Describe the bug. Include reproduction steps or a demo if possible. Include any additional appropriate context from initial investigation (log, traces, alerts etc).
+<!-- Describe the bug. Include reproduction steps or a demo if possible. Include any additional appropriate context from initial investigation (log, traces, alerts etc). -->
 
 ## Expected behavior & acceptance criteria
 
-What will the behavior look like when the bug is fixed? This doubles as the acceptance criteria for the ticket.
+<!-- What will the behavior look like when the bug is fixed? This doubles as the acceptance criteria for the ticket. -->
 
 ## Root cause (if known)
 
-If the root cause of this bug has been identified, include it.
+<!-- If the root cause of this bug has been identified, include it. -->
 
 ## Scope of fix (if known)
 
-Include any suggestions for fixing the issue.
+<!-- Include any suggestions for fixing the issue. -->
 
 -

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -9,24 +9,24 @@ assignees: []
 
 ## Summary
 
-Brief summary (2-3 sentences max) of the purpose of the epic.
+<!-- Brief summary (2-3 sentences max) of the purpose of the epic. -->
 
 ## Context
 
-Any background needed to understand the goal of the epic. Useful to include current state, priority of work, stakeholder or user problems or opportunities etc.
+<!-- Any background needed to understand the goal of the epic. Useful to include current state, priority of work, stakeholder or user problems or opportunities etc. -->
 
 ## Epic Scope
 
-High level scope of the epic, including high-level product requirements.
+<!-- High level scope of the epic, including high-level product requirements. -->
 
 -
 
 ## Excluded scope (if any)
 
-Capture any scope-exclusion decisions.
+<!-- Capture any scope-exclusion decisions. -->
 
 -
 
 ## Ordering & related work (if needed)
 
-Does this work need a critical path/dependency diagram? Are there issues that could be completed in parallel? Does this relate to other work in ways that is difficult to communicate through blocking relationships?
+<!-- Does this work need a critical path/dependency diagram? Are there issues that could be completed in parallel? Does this relate to other work in ways that is difficult to communicate through blocking relationships? -->

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,6 +1,6 @@
 ---
-name: EPIC
-about: Track a large body of work made up of multiple issues
+name: 🚜 EPIC
+about: Something big needs doing
 title: ""
 type: EPIC
 labels: []
@@ -23,6 +23,6 @@ High level scope of the epic, including high-level product requirements, known w
 
 Capture any scope-exclusion decisions.
 
-### Ordering (if needed)
+### Related (if needed)
 
-Does this relate to other work in ways that is difficult to communicate through blocking relationships?
+Does this relate to other work in ways that is difficult to communicate through blocking relationships? Are there issues that could be completed in parallel?

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -15,9 +15,9 @@ Brief summary (2-3 sentences max) of the purpose of the epic.
 
 Any background needed to understand the goal of the epic. Useful to include current state, priority of work, stakeholder or user problems or opportunities etc.
 
-## Epic Scope/Work Required
+## Epic Scope
 
-High level scope of the epic, including high-level product requirements, known work required, known unknowns.
+High level scope of the epic, including high-level product requirements.
 
 -
 

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -6,3 +6,23 @@ type: EPIC
 labels: []
 assignees: []
 ---
+
+### Summary
+
+Brief summary (2-3 sentences max) of the purpose of the epic.
+
+### Context
+
+Any background needed to understand the goal of the epic. Useful to include current state, priority of work, stakeholder or user requests etc.
+
+### Epic Scope/Work Required
+
+High level scope of the epic, including high-level product requirements, known work required, known unknowns.
+
+### Excluded scope (If any)
+
+Capture any scope-exclusion decisions.
+
+### Ordering (if needed)
+
+Does this relate to other work in ways that is difficult to communicate through blocking relationships?

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,8 @@
+---
+name: EPIC
+about: Track a large body of work made up of multiple issues
+title: ""
+type: EPIC
+labels: []
+assignees: []
+---

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -13,7 +13,7 @@ Brief summary (2-3 sentences max) of the purpose of the epic.
 
 ### Context
 
-Any background needed to understand the goal of the epic. Useful to include current state, priority of work, stakeholder or user requests etc.
+Any background needed to understand the goal of the epic. Useful to include current state, priority of work, stakeholder or user problems or opportunities etc.
 
 ### Epic Scope/Work Required
 
@@ -23,6 +23,6 @@ High level scope of the epic, including high-level product requirements, known w
 
 Capture any scope-exclusion decisions.
 
-### Related (if needed)
+### Ordering & related work (if needed)
 
-Does this relate to other work in ways that is difficult to communicate through blocking relationships? Are there issues that could be completed in parallel?
+Does this work need a critical path/dependency diagram? Are there issues that could be completed in parallel? Does this relate to other work in ways that is difficult to communicate through blocking relationships?

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -19,9 +19,13 @@ Any background needed to understand the goal of the epic. Useful to include curr
 
 High level scope of the epic, including high-level product requirements, known work required, known unknowns.
 
+-
+
 ## Excluded scope (if any)
 
 Capture any scope-exclusion decisions.
+
+-
 
 ## Ordering & related work (if needed)
 

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -19,7 +19,7 @@ Any background needed to understand the goal of the epic. Useful to include curr
 
 High level scope of the epic, including high-level product requirements, known work required, known unknowns.
 
-### Excluded scope (If any)
+### Excluded scope (if any)
 
 Capture any scope-exclusion decisions.
 

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -7,22 +7,22 @@ labels: []
 assignees: []
 ---
 
-### Summary
+## Summary
 
 Brief summary (2-3 sentences max) of the purpose of the epic.
 
-### Context
+## Context
 
 Any background needed to understand the goal of the epic. Useful to include current state, priority of work, stakeholder or user problems or opportunities etc.
 
-### Epic Scope/Work Required
+## Epic Scope/Work Required
 
 High level scope of the epic, including high-level product requirements, known work required, known unknowns.
 
-### Excluded scope (if any)
+## Excluded scope (if any)
 
 Capture any scope-exclusion decisions.
 
-### Ordering & related work (if needed)
+## Ordering & related work (if needed)
 
 Does this work need a critical path/dependency diagram? Are there issues that could be completed in parallel? Does this relate to other work in ways that is difficult to communicate through blocking relationships?

--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -5,3 +5,15 @@ title: ""
 labels: []
 assignees: []
 ---
+
+### Context/Outcome
+
+Any background needed to understand this issue. Useful to include notes on current state, the problem this issue is solving etc
+
+### Scope
+
+Outline the issue scope, what work needs to be done. Optionally include implementation suggestions.
+
+### Acceptance Criteria
+
+When is this work complete?

--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -12,7 +12,7 @@ assignees: []
 
 ## Context
 
-<!-- Any background needed to understand this issue. Useful to include notes on current state, the problem this issue is solving etc -->
+<!-- Any background needed to understand this issue. Useful to include notes on current state, the problem this issue is solving, a concrete example, etc -->
 
 ## Scope
 

--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -18,9 +18,13 @@ Any background needed to understand this issue. Useful to include notes on curre
 
 Outline the issue scope, what work needs to be done. Optionally include implementation recommendation.
 
+-
+
 ## Acceptance Criteria
 
 When is this work complete?
+
+-
 
 ## Related (if needed)
 

--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -1,0 +1,7 @@
+---
+name: Issue
+about: A task, a feature request, or an untyped issue
+title: ""
+labels: []
+assignees: []
+---

--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -1,6 +1,6 @@
 ---
-name: Issue
-about: A task, a feature request, or an untyped issue
+name: 🛠️ Issue
+about: Something needs doing
 title: ""
 labels: []
 assignees: []
@@ -17,3 +17,7 @@ Outline the issue scope, what work needs to be done. Optionally include implemen
 ### Acceptance Criteria
 
 When is this work complete?
+
+### Related (if needed)
+
+Does this relate to other work in ways that is difficult to communicate through blocking relationships?

--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -6,22 +6,22 @@ labels: []
 assignees: []
 ---
 
-### Outcome
+## Outcome
 
 What this issue achieves, in one or two sentences. Write it so that it still holds if the scope below changes.
 
-### Context
+## Context
 
 Any background needed to understand this issue. Useful to include notes on current state, the problem this issue is solving etc
 
-### Scope
+## Scope
 
 Outline the issue scope, what work needs to be done. Optionally include implementation recommendation.
 
-### Acceptance Criteria
+## Acceptance Criteria
 
 When is this work complete?
 
-### Related (if needed)
+## Related (if needed)
 
 Does this relate to other work in ways that is difficult to communicate through blocking relationships?

--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -6,13 +6,17 @@ labels: []
 assignees: []
 ---
 
-### Context/Outcome
+### Outcome
+
+What this issue achieves, in one or two sentences. Write it so that it still holds if the scope below changes.
+
+### Context
 
 Any background needed to understand this issue. Useful to include notes on current state, the problem this issue is solving etc
 
 ### Scope
 
-Outline the issue scope, what work needs to be done. Optionally include implementation suggestions.
+Outline the issue scope, what work needs to be done. Optionally include implementation recommendation.
 
 ### Acceptance Criteria
 

--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -8,24 +8,24 @@ assignees: []
 
 ## Outcome
 
-What this issue achieves, in one or two sentences. Write it so that it still holds if the scope below changes.
+<!-- What this issue achieves, in one or two sentences. Write it so that it still holds if the scope below changes. -->
 
 ## Context
 
-Any background needed to understand this issue. Useful to include notes on current state, the problem this issue is solving etc
+<!-- Any background needed to understand this issue. Useful to include notes on current state, the problem this issue is solving etc -->
 
 ## Scope
 
-Outline the issue scope, what work needs to be done. Optionally include implementation recommendation.
+<!-- Outline the issue scope, what work needs to be done. Optionally include implementation recommendation. -->
 
 -
 
 ## Acceptance Criteria
 
-When is this work complete?
+<!-- When is this work complete? -->
 
 -
 
 ## Related (if needed)
 
-Does this relate to other work in ways that is difficult to communicate through blocking relationships?
+<!-- Does this relate to other work in ways that is difficult to communicate through blocking relationships? -->


### PR DESCRIPTION
## Context 

First part of retrospective action from 2026-07-30

## What's changed?
I've added three issue templates, one for bugs, one for epics, and a generic catch-all for tasks/features. Felt it was appropriate to keep things simple for the time being. 

These will be available in the issue picker after merging. 
