### PR TITLE
Add static enhancement CLI utility

### DIFF
--- a/cli/add_static_enhancements.py
+++ b/cli/add_static_enhancements.py
@@ -1,0 +1,418 @@
+r"""
+A utility to add a static list of enhancements to references.
+
+This utility:
+- Accepts either:
+    - a .jsonl file of `Enhancement`s
+    - a text file of reference ids and a single
+      `destiny_sdk.enhancements.EnhancementFileInput` to apply to each of them
+- Requests enhancements from the repository for each unique reference_id
+- Acts as a robot to add the enhancements to the references in the repository
+- Prints the results of the original enhancement request
+
+Add an enhancement per reference, with a robot to write them::
+
+    uv run python -m cli.add_static_enhancements --env staging \
+        --enhancement-file enhancements.jsonl \
+        --create-robot 'your-project-static-enhancement-robot'
+
+Tag those same references, reusing a robot::
+
+    uv run python -m cli.add_static_enhancements --env staging \
+        --reference-id-file references.txt \
+        --enhancement '{"source": "your-project-initial-hydration",
+            "visibility": "public", "content": {"enhancement_type": "annotation",
+            "annotations": [{"annotation_type": "boolean",
+            "scheme": "domain-inclusion", "label": "your-project", "value": true}]}}' \
+        --robot-id 019ec8b0-9173-76f0-9d09-b7bdf4e31047
+
+The caller must have robot.writer and enhancement_request.writer permissions.
+"""
+
+# ruff: noqa: T201
+import argparse
+import json
+import sys
+import time
+from collections.abc import Iterable
+from pathlib import Path
+from uuid import UUID
+
+import httpx
+from destiny_sdk.client import RobotClient
+from destiny_sdk.enhancements import Enhancement, EnhancementFileInput, EnhancementType
+from destiny_sdk.robots import (
+    EnhancementRequestIn,
+    EnhancementRequestRead,
+    EnhancementRequestStatus,
+    ProvisionedRobot,
+    Robot,
+    RobotEnhancementBatch,
+    RobotEnhancementBatchResult,
+    RobotEntitlement,
+    RobotIn,
+)
+from pydantic import HttpUrl, ValidationError
+
+from cli.client import ApiArgumentParser
+from cli.register_robot import register_robot
+
+# Marks robots provisioned by this utility. Only robots with this owner are allowed to
+# be represented by this utility.
+ROBOT_OWNER_MARKER = "cli/add_static_enhancements"
+
+ROBOT_DESCRIPTION = (
+    "Writes static enhancements supplied by cli.add_static_enhancements. Its secret "
+    "is cycled on each run and it does not poll for work of its own."
+)
+
+BATCH_SIZE = 10_000
+
+
+def enhancement_input(value: str) -> EnhancementFileInput:
+    """Parse an `EnhancementFileInput` passed as a json string."""
+    try:
+        return EnhancementFileInput.model_validate_json(value)
+    except ValidationError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
+def read_reference_ids(file: Path) -> set[UUID]:
+    """Read reference ids from a text file, one per line."""
+    return {
+        UUID(line.strip()) for line in file.read_text().splitlines() if line.strip()
+    }
+
+
+def load_enhancements(
+    enhancement_file: Path | None,
+    reference_id_file: Path | None,
+    enhancement: EnhancementFileInput | None,
+) -> dict[UUID, Enhancement]:
+    """Build the enhancement to add for each reference, keyed by reference id."""
+    if enhancement_file:
+        enhancements = [
+            Enhancement.from_jsonl(line)
+            for line in enhancement_file.read_text().splitlines()
+            if line.strip()
+        ]
+    else:
+        enhancements = [
+            Enhancement(reference_id=reference_id, **enhancement.model_dump())  # type: ignore[union-attr]
+            for reference_id in read_reference_ids(reference_id_file)  # type: ignore[arg-type]
+        ]
+
+    by_reference = {
+        enhancement_.reference_id: enhancement_ for enhancement_ in enhancements
+    }
+    if len(by_reference) < len(enhancements):
+        msg = "Duplicate enhancements for the same reference id are not allowed."
+        raise ValueError(msg)
+    return by_reference
+
+
+def required_entitlements(enhancements: Iterable[Enhancement]) -> set[RobotEntitlement]:
+    """Return the entitlements a robot needs in order to write these enhancements."""
+    return {
+        RobotEntitlement.RAW_ENHANCEMENT_WRITER
+        for enhancement in enhancements
+        if enhancement.content.enhancement_type == EnhancementType.RAW
+    }
+
+
+def resolve_robot(
+    client: httpx.Client,
+    robot_id: UUID | None,
+    name: str | None,
+    entitlements: set[RobotEntitlement],
+) -> ProvisionedRobot:
+    """Provision a bespoke robot, or reuse one this utility provisioned earlier."""
+    if name:
+        robot = register_robot(
+            client,
+            RobotIn(
+                name=name,
+                description=ROBOT_DESCRIPTION,
+                owner=ROBOT_OWNER_MARKER,
+                entitlements=entitlements,
+            ),
+        )
+        print(f"Registered robot {robot.id}. Reuse it with --robot-id {robot.id}.")
+        return robot
+
+    response = client.get(f"/robots/{robot_id}/")
+    response.raise_for_status()
+    existing = Robot.model_validate(response.json())
+
+    if existing.owner != ROBOT_OWNER_MARKER:
+        msg = (
+            f"Robot {existing.id} ({existing.name!r}, owned by {existing.owner!r}) was "
+            "not provisioned by this utility. Use --create-robot instead."
+        )
+        raise ValueError(msg)
+    if missing := entitlements - existing.entitlements:
+        msg = (
+            f"Robot {existing.id} is not entitled to {', '.join(sorted(missing))}, so "
+            "it cannot write these enhancements."
+        )
+        raise ValueError(msg)
+
+    # No secret is passed in, so take a fresh one. The owner marker makes this safe.
+    print(f"Cycling the secret for robot {existing.id} ({existing.name!r}).")
+    response = client.post(f"/robots/{existing.id}/secret/")
+    response.raise_for_status()
+    return ProvisionedRobot.model_validate(response.json())
+
+
+def request_enhancements(
+    client: httpx.Client,
+    robot_id: UUID,
+    reference_ids: set[UUID],
+    source: str | None,
+) -> EnhancementRequestRead:
+    """Request an enhancement from the repository for each reference."""
+    response = client.post(
+        "/enhancement-requests/",
+        json=EnhancementRequestIn(
+            robot_id=robot_id,
+            reference_ids=list(reference_ids),
+            source=source,
+        ).model_dump(mode="json"),
+        timeout=120,
+    )
+    response.raise_for_status()
+    request = EnhancementRequestRead.model_validate(response.json())
+    print(
+        f"Enhancement request {request.id} created for {len(reference_ids)} "
+        f"references ({request.request_status})."
+    )
+    return request
+
+
+def fulfil_enhancements(
+    robot_client: RobotClient,
+    robot_id: UUID,
+    enhancements: dict[UUID, Enhancement],
+) -> set[UUID]:
+    """Act as the robot, claiming each pending batch and writing its enhancements."""
+    enhanced: set[UUID] = set()
+    # Batch reference and result files live on signed blob URLs, not the repository.
+    with httpx.Client(timeout=120) as blob_client:
+        while batch := robot_client.poll_robot_enhancement_batch(
+            robot_id=robot_id, limit=BATCH_SIZE
+        ):
+            enhanced |= _fulfil_batch(robot_client, blob_client, batch, enhancements)
+            print(f"Batch {batch.id}: {len(enhanced)}/{len(enhancements)} submitted.")
+    return enhanced
+
+
+def _fulfil_batch(
+    robot_client: RobotClient,
+    blob_client: httpx.Client,
+    batch: RobotEnhancementBatch,
+    enhancements: dict[UUID, Enhancement],
+) -> set[UUID]:
+    """Upload the static enhancements for one batch and report it complete."""
+    reference_ids = _batch_reference_ids(blob_client, batch.reference_storage_url)
+
+    if unknown := reference_ids - enhancements.keys():
+        msg = (
+            f"Batch {batch.id} holds {len(unknown)} reference(s) that were not "
+            "requested. Abandoning the batch."
+        )
+        raise ValueError(msg)
+
+    response = blob_client.put(
+        str(batch.result_storage_url),
+        content="\n".join(
+            enhancements[reference_id].to_jsonl() for reference_id in reference_ids
+        ).encode(),
+        headers={
+            "Content-Type": "application/jsonl",
+            "x-ms-blob-type": "BlockBlob",
+        },
+    )
+    response.raise_for_status()
+
+    robot_client.send_robot_enhancement_batch_result(
+        RobotEnhancementBatchResult(request_id=batch.id)
+    )
+    return reference_ids
+
+
+def _batch_reference_ids(
+    blob_client: httpx.Client, reference_storage_url: HttpUrl
+) -> set[UUID]:
+    """Read the reference ids out of a batch's reference file."""
+    with blob_client.stream("GET", str(reference_storage_url)) as response:
+        response.raise_for_status()
+        # Only the ids are needed; validating the rest would fail the batch over data
+        # this utility never looks at.
+        return {
+            UUID(json.loads(line)["id"])
+            for line in response.iter_lines()
+            if line.strip()
+        }
+
+
+def poll_until_complete(
+    client: httpx.Client,
+    request_id: UUID,
+    poll_interval: float = 5,
+) -> EnhancementRequestRead:
+    """Poll the enhancement request until it stops progressing."""
+    print(f"Polling enhancement request {request_id}...")
+    while True:
+        response = client.get(f"/enhancement-requests/{request_id}/")
+        response.raise_for_status()
+        request = EnhancementRequestRead.model_validate(response.json())
+        print(f"request_status={request.request_status}")
+        if request.request_status in EnhancementRequestStatus.get_terminal_statuses():
+            return request
+        time.sleep(poll_interval)
+
+
+def add_static_enhancements(
+    client: httpx.Client,
+    robot: ProvisionedRobot,
+    enhancements: dict[UUID, Enhancement],
+    source: str | None = None,
+    poll_interval: float = 5,
+) -> None:
+    """Request the enhancements, then write them to the repository as the robot."""
+    request = request_enhancements(
+        client=client,
+        robot_id=robot.id,
+        reference_ids=set(enhancements),
+        source=source,
+    )
+
+    robot_client = RobotClient(
+        base_url=HttpUrl(str(client.base_url)),
+        secret_key=robot.client_secret,
+        client_id=robot.id,
+    )
+    enhanced = fulfil_enhancements(
+        robot_client=robot_client,
+        robot_id=robot.id,
+        enhancements=enhancements,
+    )
+    if missing := enhancements.keys() - enhanced:
+        print(f"{len(missing)} enhancement(s) were never offered in a batch.")
+
+    request = poll_until_complete(client, request.id, poll_interval)
+    if request.request_status is EnhancementRequestStatus.PARTIAL_FAILED:
+        print(
+            "Enhancements already on their reference are discarded, which also "
+            "reports as partial_failed."
+        )
+    if request.error:
+        print(f"Error: {request.error}")
+
+
+def argument_parser() -> ApiArgumentParser:
+    """Parse the environment, the enhancements to add, and the robot to add them as."""
+    parser = ApiArgumentParser(
+        description=(
+            "Adds a static list of enhancements to references, acting as a robot."
+        )
+    )
+
+    enhancements = parser.add_mutually_exclusive_group(required=True)
+    enhancements.add_argument(
+        "--enhancement-file",
+        type=Path,
+        help="Path to a .jsonl file of `Enhancement`s, one per line.",
+    )
+    enhancements.add_argument(
+        "--reference-id-file",
+        type=Path,
+        help=(
+            "Path to a text file of reference ids, one per line, to apply "
+            "--enhancement to."
+        ),
+    )
+    parser.add_argument(
+        "--enhancement",
+        type=enhancement_input,
+        help=(
+            "A single `EnhancementFileInput` as json, applied to every id in "
+            "--reference-id-file."
+        ),
+    )
+
+    robot = parser.add_mutually_exclusive_group(required=True)
+    robot.add_argument(
+        "--create-robot",
+        metavar="NAME",
+        help="Register a bespoke robot with this name to write the enhancements.",
+    )
+    robot.add_argument(
+        "--robot-id",
+        type=UUID,
+        help=(
+            "ID of a robot to write the enhancements as. It must have owner "
+            f"{ROBOT_OWNER_MARKER} and will have its secret cycled."
+        ),
+    )
+
+    parser.add_argument(
+        "--source",
+        default="cli/add_static_enhancements",
+        help="Source identifier for the enhancement request.",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=float,
+        default=5,
+        help="Seconds to wait between enhancement request status checks.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would be written without calling the repository.",
+    )
+
+    return parser
+
+
+if __name__ == "__main__":
+    parser = argument_parser()
+    args = parser.parse_args()
+
+    if args.reference_id_file and not args.enhancement:
+        parser.error("--reference-id-file requires --enhancement")
+    if args.enhancement_file and args.enhancement:
+        parser.error("--enhancement only applies to --reference-id-file")
+
+    try:
+        enhancements = load_enhancements(
+            enhancement_file=args.enhancement_file,
+            reference_id_file=args.reference_id_file,
+            enhancement=args.enhancement,
+        )
+        entitlements = required_entitlements(enhancements.values())
+        print(f"{len(enhancements)} enhancements to add.")
+
+        if args.dry_run:
+            print("[DRY RUN] Nothing created.")
+            sys.exit(0)
+
+        with args.client as client:
+            robot = resolve_robot(
+                client=client,
+                robot_id=args.robot_id,
+                name=args.create_robot,
+                entitlements=entitlements,
+            )
+            add_static_enhancements(
+                client=client,
+                robot=robot,
+                enhancements=enhancements,
+                source=args.source,
+                poll_interval=args.poll_interval,
+            )
+
+    except (ValueError, httpx.HTTPError, OSError) as exc:
+        print(f"Adding static enhancements failed: {exc}")
+        sys.exit(1)

--- a/cli/add_static_enhancements.py
+++ b/cli/add_static_enhancements.py
@@ -26,7 +26,8 @@ Tag those same references, reusing a robot::
             "scheme": "domain-inclusion", "label": "your-project", "value": true}]}}' \
         --robot-id 019ec8b0-9173-76f0-9d09-b7bdf4e31047
 
-The caller must have robot.writer and enhancement_request.writer permissions.
+The caller must have robot.writer and enhancement_request.writer permissions. It also
+may require robot.entitlement.writer if creating a robot to write raw enhancements.
 """
 
 # ruff: noqa: T201
@@ -34,7 +35,9 @@ import argparse
 import json
 import sys
 import time
+from collections import Counter
 from collections.abc import Iterable
+from math import ceil
 from pathlib import Path
 from uuid import UUID
 
@@ -54,6 +57,7 @@ from destiny_sdk.robots import (
 )
 from pydantic import HttpUrl, ValidationError
 
+from app.utils.lists import list_chunker
 from cli.client import ApiArgumentParser
 from cli.register_robot import register_robot
 
@@ -67,6 +71,9 @@ ROBOT_DESCRIPTION = (
 )
 
 BATCH_SIZE = 10_000
+
+# Give up waiting for the repository to import and index, and report where it got to.
+POLL_TIMEOUT = 600
 
 
 def enhancement_input(value: str) -> EnhancementFileInput:
@@ -120,6 +127,31 @@ def required_entitlements(enhancements: Iterable[Enhancement]) -> set[RobotEntit
     }
 
 
+def claim_robot(
+    client: httpx.Client,
+    robot_id: UUID | None,
+    entitlements: set[RobotEntitlement],
+) -> Robot:
+    """Fetch an existing robot and check this utility may write as it."""
+    response = client.get(f"/robots/{robot_id}/")
+    response.raise_for_status()
+    existing = Robot.model_validate(response.json())
+
+    if existing.owner != ROBOT_OWNER_MARKER:
+        msg = (
+            f"Robot {existing.id} ({existing.name!r}, owned by {existing.owner!r}) was "
+            "not provisioned by this utility. Use --create-robot instead."
+        )
+        raise ValueError(msg)
+    if missing := entitlements - existing.entitlements:
+        msg = (
+            f"Robot {existing.id} is not entitled to {', '.join(sorted(missing))}, so "
+            "it cannot write these enhancements."
+        )
+        raise ValueError(msg)
+    return existing
+
+
 def resolve_robot(
     client: httpx.Client,
     robot_id: UUID | None,
@@ -140,23 +172,7 @@ def resolve_robot(
         print(f"Registered robot {robot.id}. Reuse it with --robot-id {robot.id}.")
         return robot
 
-    response = client.get(f"/robots/{robot_id}/")
-    response.raise_for_status()
-    existing = Robot.model_validate(response.json())
-
-    if existing.owner != ROBOT_OWNER_MARKER:
-        msg = (
-            f"Robot {existing.id} ({existing.name!r}, owned by {existing.owner!r}) was "
-            "not provisioned by this utility. Use --create-robot instead."
-        )
-        raise ValueError(msg)
-    if missing := entitlements - existing.entitlements:
-        msg = (
-            f"Robot {existing.id} is not entitled to {', '.join(sorted(missing))}, so "
-            "it cannot write these enhancements."
-        )
-        raise ValueError(msg)
-
+    existing = claim_robot(client, robot_id, entitlements)
     # No secret is passed in, so take a fresh one. The owner marker makes this safe.
     print(f"Cycling the secret for robot {existing.id} ({existing.name!r}).")
     response = client.post(f"/robots/{existing.id}/secret/")
@@ -164,29 +180,50 @@ def resolve_robot(
     return ProvisionedRobot.model_validate(response.json())
 
 
+def describe_robot(
+    client: httpx.Client,
+    robot_id: UUID | None,
+    name: str | None,
+    entitlements: set[RobotEntitlement],
+) -> None:
+    """Report the robot a real run would use, provisioning nothing."""
+    granted = ", ".join(sorted(entitlements)) or "no entitlements"
+    if name:
+        print(
+            f"Would register robot {name!r} owned by {ROBOT_OWNER_MARKER}, {granted}."
+        )
+        return
+
+    existing = claim_robot(client, robot_id, entitlements)
+    print(f"Would cycle the secret for robot {existing.id} ({existing.name!r}).")
+
+
 def request_enhancements(
     client: httpx.Client,
     robot_id: UUID,
     reference_ids: set[UUID],
     source: str | None,
-) -> EnhancementRequestRead:
-    """Request an enhancement from the repository for each reference."""
-    response = client.post(
-        "/enhancement-requests/",
-        json=EnhancementRequestIn(
-            robot_id=robot_id,
-            reference_ids=list(reference_ids),
-            source=source,
-        ).model_dump(mode="json"),
-        timeout=120,
-    )
-    response.raise_for_status()
-    request = EnhancementRequestRead.model_validate(response.json())
-    print(
-        f"Enhancement request {request.id} created for {len(reference_ids)} "
-        f"references ({request.request_status})."
-    )
-    return request
+) -> set[UUID]:
+    """Request an enhancement from the repository for each reference in chunks."""
+    request_ids: set[UUID] = set()
+    for chunk in list_chunker(sorted(reference_ids), BATCH_SIZE):
+        response = client.post(
+            "/enhancement-requests/",
+            json=EnhancementRequestIn(
+                robot_id=robot_id,
+                reference_ids=chunk,
+                source=source,
+            ).model_dump(mode="json"),
+            timeout=120,
+        )
+        response.raise_for_status()
+        request = EnhancementRequestRead.model_validate(response.json())
+        print(
+            f"Enhancement request {request.id} created for {len(chunk)} "
+            f"references ({request.request_status})."
+        )
+        request_ids.add(request.id)
+    return request_ids
 
 
 def fulfil_enhancements(
@@ -257,19 +294,39 @@ def _batch_reference_ids(
 
 def poll_until_complete(
     client: httpx.Client,
-    request_id: UUID,
-    poll_interval: float = 5,
-) -> EnhancementRequestRead:
-    """Poll the enhancement request until it stops progressing."""
-    print(f"Polling enhancement request {request_id}...")
-    while True:
-        response = client.get(f"/enhancement-requests/{request_id}/")
-        response.raise_for_status()
-        request = EnhancementRequestRead.model_validate(response.json())
-        print(f"request_status={request.request_status}")
-        if request.request_status in EnhancementRequestStatus.get_terminal_statuses():
-            return request
+    request_ids: set[UUID],
+    poll_interval: float = 10,
+) -> dict[UUID, EnhancementRequestRead]:
+    """
+    Poll the enhancement requests until each stops progressing.
+
+    Every outstanding request is polled each round rather than one at a time, since
+    the repository imports them concurrently. Returns whatever has settled within
+    ``POLL_TIMEOUT``, which may be less than was asked for.
+    """
+    print(f"Polling {len(request_ids)} enhancement request(s)...")
+    terminal = EnhancementRequestStatus.get_terminal_statuses()
+    settled: dict[UUID, EnhancementRequestRead] = {}
+
+    deadline = time.monotonic() + POLL_TIMEOUT
+    while time.monotonic() < deadline:
+        for request_id in request_ids - settled.keys():
+            response = client.get(f"/enhancement-requests/{request_id}/")
+            response.raise_for_status()
+            request = EnhancementRequestRead.model_validate(response.json())
+            if request.request_status in terminal:
+                settled[request_id] = request
+
+        print(f"{len(settled)}/{len(request_ids)} request(s) settled.")
+        if len(settled) == len(request_ids):
+            return settled
         time.sleep(poll_interval)
+
+    print(
+        f"Gave up after {POLL_TIMEOUT}s with "
+        f"{len(request_ids) - len(settled)} request(s) still in progress."
+    )
+    return settled
 
 
 def add_static_enhancements(
@@ -277,10 +334,10 @@ def add_static_enhancements(
     robot: ProvisionedRobot,
     enhancements: dict[UUID, Enhancement],
     source: str | None = None,
-    poll_interval: float = 5,
+    poll_interval: float = 10,
 ) -> None:
     """Request the enhancements, then write them to the repository as the robot."""
-    request = request_enhancements(
+    request_ids = request_enhancements(
         client=client,
         robot_id=robot.id,
         reference_ids=set(enhancements),
@@ -300,14 +357,17 @@ def add_static_enhancements(
     if missing := enhancements.keys() - enhanced:
         print(f"{len(missing)} enhancement(s) were never offered in a batch.")
 
-    request = poll_until_complete(client, request.id, poll_interval)
-    if request.request_status is EnhancementRequestStatus.PARTIAL_FAILED:
+    settled = poll_until_complete(client, request_ids, poll_interval)
+    statuses = Counter(request.request_status for request in settled.values())
+    print(", ".join(f"{status}={n}" for status, n in sorted(statuses.items())))
+    if EnhancementRequestStatus.PARTIAL_FAILED in statuses:
         print(
             "Enhancements already on their reference are discarded, which also "
             "reports as partial_failed."
         )
-    if request.error:
-        print(f"Error: {request.error}")
+    for request in settled.values():
+        if request.error:
+            print(f"Request {request.id} error: {request.error}")
 
 
 def argument_parser() -> ApiArgumentParser:
@@ -364,13 +424,13 @@ def argument_parser() -> ApiArgumentParser:
     parser.add_argument(
         "--poll-interval",
         type=float,
-        default=5,
+        default=10,
         help="Seconds to wait between enhancement request status checks.",
     )
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Report what would be written without calling the repository.",
+        help="Report what would be written and by which robot, changing nothing.",
     )
 
     return parser
@@ -392,13 +452,22 @@ if __name__ == "__main__":
             enhancement=args.enhancement,
         )
         entitlements = required_entitlements(enhancements.values())
-        print(f"{len(enhancements)} enhancements to add.")
-
-        if args.dry_run:
-            print("[DRY RUN] Nothing created.")
-            sys.exit(0)
+        print(
+            f"{len(enhancements)} enhancements to add across "
+            f"{ceil(len(enhancements) / BATCH_SIZE)} enhancement request(s)."
+        )
 
         with args.client as client:
+            if args.dry_run:
+                describe_robot(
+                    client=client,
+                    robot_id=args.robot_id,
+                    name=args.create_robot,
+                    entitlements=entitlements,
+                )
+                print("[DRY RUN] Nothing created.")
+                sys.exit(0)
+
             robot = resolve_robot(
                 client=client,
                 robot_id=args.robot_id,

--- a/libs/sdk/pyproject.toml
+++ b/libs/sdk/pyproject.toml
@@ -36,7 +36,7 @@ license = "Apache-2.0"
 name = "destiny_sdk"
 readme = "README.md"
 requires-python = ">=3.12, <4"
-version = "0.14.2"
+version = "0.14.3"
 
 [project.optional-dependencies]
 labs = []

--- a/libs/sdk/pyproject.toml
+++ b/libs/sdk/pyproject.toml
@@ -36,7 +36,7 @@ license = "Apache-2.0"
 name = "destiny_sdk"
 readme = "README.md"
 requires-python = ">=3.12, <4"
-version = "0.14.1"
+version = "0.14.2"
 
 [project.optional-dependencies]
 labs = []

--- a/libs/sdk/src/destiny_sdk/client.py
+++ b/libs/sdk/src/destiny_sdk/client.py
@@ -202,7 +202,7 @@ class RobotClient:
             use a default lease duration.
         :type lease_duration: str | None
         """
-        response = self.session.post(
+        response = self.session.patch(
             f"/robot-enhancement-batches/{robot_enhancement_batch_id}/renew-lease/",
             params={"lease": lease_duration} if lease_duration else None,
         )

--- a/libs/sdk/src/destiny_sdk/robots.py
+++ b/libs/sdk/src/destiny_sdk/robots.py
@@ -182,6 +182,17 @@ class EnhancementRequestStatus(StrEnum):
     COMPLETED = auto()
     """All enhancements have been created."""
 
+    @classmethod
+    def get_terminal_statuses(cls) -> set["EnhancementRequestStatus"]:
+        """Return the statuses at which an enhancement request has stopped moving."""
+        return {
+            cls.REJECTED,
+            cls.PARTIAL_FAILED,
+            cls.FAILED,
+            cls.INDEXING_FAILED,
+            cls.COMPLETED,
+        }
+
 
 class EnhancementRequestSearchStatus(StrEnum):
     """Progress of the search phase of a search-based enhancement request."""

--- a/tests/cli/test_add_static_enhancements.py
+++ b/tests/cli/test_add_static_enhancements.py
@@ -29,6 +29,7 @@ from app.core.config import Environment
 from cli.add_static_enhancements import (
     ROBOT_OWNER_MARKER,
     _fulfil_batch,
+    describe_robot,
     enhancement_input,
     load_enhancements,
     required_entitlements,
@@ -187,6 +188,24 @@ def test_our_own_robot_has_its_secret_cycled(httpx_mock: HTTPXMock) -> None:
 
     assert provisioned.id == robot.id
     assert provisioned.client_secret == "a-fresh-secret"
+
+
+def test_dry_run_checks_the_robot_without_cycling_its_secret(
+    httpx_mock: HTTPXMock, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A dry run resolves the robot for real but must not provision anything."""
+    robot = _robot(owner=ROBOT_OWNER_MARKER)
+    httpx_mock.add_response(
+        method="GET",
+        url=f"http://127.0.0.1:8000/v1/robots/{robot.id}/",
+        json=robot.model_dump(mode="json"),
+    )
+
+    # No secret cycle is registered, so httpx_mock fails the test if one is sent.
+    with get_client(Environment.LOCAL) as client:
+        describe_robot(client, robot.id, None, set())
+
+    assert "Would cycle the secret" in capsys.readouterr().out
 
 
 def test_batch_holding_another_requesters_reference_is_abandoned(

--- a/tests/cli/test_add_static_enhancements.py
+++ b/tests/cli/test_add_static_enhancements.py
@@ -1,0 +1,219 @@
+"""Tests for the static enhancement utility's input handling and robot safeguards."""
+
+import argparse
+import datetime
+from pathlib import Path
+from uuid import UUID, uuid7
+
+import httpx
+import pytest
+from destiny_sdk.client import RobotClient
+from destiny_sdk.enhancements import (
+    AnnotationEnhancement,
+    BooleanAnnotation,
+    Enhancement,
+    EnhancementFileInput,
+    RawEnhancement,
+    Visibility,
+)
+from destiny_sdk.robots import (
+    ProvisionedRobot,
+    Robot,
+    RobotEnhancementBatch,
+    RobotEntitlement,
+)
+from pydantic import HttpUrl
+from pytest_httpx import HTTPXMock
+
+from app.core.config import Environment
+from cli.add_static_enhancements import (
+    ROBOT_OWNER_MARKER,
+    _fulfil_batch,
+    enhancement_input,
+    load_enhancements,
+    required_entitlements,
+    resolve_robot,
+)
+from cli.client import get_client
+
+SOURCE = "galenos-lsr-export@2026-08-05"
+
+ANNOTATION = AnnotationEnhancement(
+    annotations=[
+        BooleanAnnotation(scheme="domain-inclusion", label="galenos", value=True)
+    ]
+)
+RAW = RawEnhancement(
+    source_export_date=datetime.datetime(2026, 8, 5, tzinfo=datetime.UTC),
+    description="A GALENOS study row.",
+    data={"LSR number": "1"},
+)
+
+
+def _enhancement(reference_id: UUID, content: object) -> Enhancement:
+    """Build an enhancement of the given content for a reference."""
+    return Enhancement(
+        reference_id=reference_id,
+        source=SOURCE,
+        visibility=Visibility.PUBLIC,
+        content=content,  # type: ignore[arg-type]
+    )
+
+
+def _enhancement_file(tmp_path: Path, *enhancements: Enhancement) -> Path:
+    """Write enhancements to a .jsonl file."""
+    file = tmp_path / "enhancements.jsonl"
+    file.write_text("\n".join(enhancement.to_jsonl() for enhancement in enhancements))
+    return file
+
+
+def _robot(owner: str, entitlements: set[RobotEntitlement] | None = None) -> Robot:
+    """Build a registered robot owned by the given owner."""
+    return Robot(
+        id=uuid7(),
+        name="galenos-static-enhancements",
+        description="Writes GALENOS study data.",
+        owner=owner,
+        entitlements=entitlements or set(),
+    )
+
+
+def test_enhancement_is_applied_to_every_reference_id(tmp_path: Path) -> None:
+    """One `EnhancementFileInput` is applied to each id, ignoring repeats and blanks."""
+    first, second = uuid7(), uuid7()
+    file = tmp_path / "references.txt"
+    file.write_text(f"{first}\n{second}\n\n{second}\n")
+
+    enhancements = load_enhancements(
+        None,
+        file,
+        EnhancementFileInput(
+            source=SOURCE, visibility=Visibility.PUBLIC, content=ANNOTATION
+        ),
+    )
+
+    assert enhancements.keys() == {first, second}
+    assert {enhancement.source for enhancement in enhancements.values()} == {SOURCE}
+
+
+def test_two_enhancements_for_one_reference_are_rejected(tmp_path: Path) -> None:
+    """A reference can only be enhanced once per request, so this input is refused."""
+    reference_id = uuid7()
+    file = _enhancement_file(
+        tmp_path,
+        _enhancement(reference_id, ANNOTATION),
+        _enhancement(reference_id, RAW),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Duplicate enhancements for the same reference id are not allowed",
+    ):
+        load_enhancements(file, None, None)
+
+
+def test_only_raw_enhancements_require_an_entitlement() -> None:
+    """Raw enhancements need an entitlement to write; other content does not."""
+    annotation = _enhancement(uuid7(), ANNOTATION)
+    raw = _enhancement(uuid7(), RAW)
+
+    assert required_entitlements([annotation]) == set()
+    assert required_entitlements([annotation, raw]) == {
+        RobotEntitlement.RAW_ENHANCEMENT_WRITER
+    }
+
+
+def test_malformed_enhancement_json_fails_at_parse_time() -> None:
+    """An unparseable ``--enhancement`` reports pydantic's complaint, not a trace."""
+    with pytest.raises(argparse.ArgumentTypeError, match="visibility"):
+        enhancement_input('{"source": "x", "content": {"enhancement_type": "raw"}}')
+
+
+def test_robot_we_did_not_provision_is_refused(httpx_mock: HTTPXMock) -> None:
+    """Another robot's secret is not ours to cycle, nor its queue ours to claim."""
+    robot = _robot(owner="destiny")
+    httpx_mock.add_response(
+        method="GET",
+        url=f"http://127.0.0.1:8000/v1/robots/{robot.id}/",
+        json=robot.model_dump(mode="json"),
+    )
+
+    with (
+        get_client(Environment.LOCAL) as client,
+        pytest.raises(ValueError, match="not provisioned by this utility"),
+    ):
+        resolve_robot(client, robot.id, None, set())
+
+
+def test_robot_missing_an_entitlement_is_refused(httpx_mock: HTTPXMock) -> None:
+    """A robot of ours is still refused if it cannot write the given enhancements."""
+    robot = _robot(owner=ROBOT_OWNER_MARKER)
+    httpx_mock.add_response(
+        method="GET",
+        url=f"http://127.0.0.1:8000/v1/robots/{robot.id}/",
+        json=robot.model_dump(mode="json"),
+    )
+
+    with (
+        get_client(Environment.LOCAL) as client,
+        pytest.raises(ValueError, match="not entitled"),
+    ):
+        resolve_robot(client, robot.id, None, {RobotEntitlement.RAW_ENHANCEMENT_WRITER})
+
+
+def test_our_own_robot_has_its_secret_cycled(httpx_mock: HTTPXMock) -> None:
+    """Reusing one of our robots takes a fresh secret rather than asking for one."""
+    robot = _robot(
+        owner=ROBOT_OWNER_MARKER,
+        entitlements={RobotEntitlement.RAW_ENHANCEMENT_WRITER},
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=f"http://127.0.0.1:8000/v1/robots/{robot.id}/",
+        json=robot.model_dump(mode="json"),
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=f"http://127.0.0.1:8000/v1/robots/{robot.id}/secret/",
+        json=ProvisionedRobot(
+            **robot.model_dump(), client_secret="a-fresh-secret"
+        ).model_dump(mode="json"),
+    )
+
+    with get_client(Environment.LOCAL) as client:
+        provisioned = resolve_robot(
+            client, robot.id, None, {RobotEntitlement.RAW_ENHANCEMENT_WRITER}
+        )
+
+    assert provisioned.id == robot.id
+    assert provisioned.client_secret == "a-fresh-secret"
+
+
+def test_batch_holding_another_requesters_reference_is_abandoned(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Nothing is submitted for a shared queue, so the batch expires and re-queues."""
+    ours, theirs = uuid7(), uuid7()
+    httpx_mock.add_response(
+        method="GET",
+        url="https://blob.example.com/references.jsonl",
+        text=f'{{"id": "{ours}"}}\n{{"id": "{theirs}"}}\n',
+    )
+    batch = RobotEnhancementBatch(
+        id=uuid7(),
+        reference_storage_url=HttpUrl("https://blob.example.com/references.jsonl"),
+        result_storage_url=HttpUrl("https://blob.example.com/results.jsonl"),
+    )
+    robot_client = RobotClient(
+        base_url=HttpUrl("http://127.0.0.1:8000"),
+        secret_key="unused",
+        client_id=uuid7(),
+    )
+
+    with (
+        httpx.Client() as blob_client,
+        pytest.raises(ValueError, match="were not requested"),
+    ):
+        _fulfil_batch(
+            robot_client, blob_client, batch, {ours: _enhancement(ours, ANNOTATION)}
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -705,7 +705,7 @@ test = [
 
 [[package]]
 name = "destiny-sdk"
-version = "0.14.2"
+version = "0.14.3"
 source = { editable = "libs/sdk" }
 dependencies = [
     { name = "authlib" },

--- a/uv.lock
+++ b/uv.lock
@@ -705,7 +705,7 @@ test = [
 
 [[package]]
 name = "destiny-sdk"
-version = "0.14.1"
+version = "0.14.2"
 source = { editable = "libs/sdk" }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
CLI utility to support #837 

Allows the direct upload of static enhancements to specified references in special circumstances.

Will be used with the references found in #836 to fulfil #837.

The script:
- takes in either a list of enhancements with reference ids on them, or a list of reference ids with a single enhancement to add to all references.
- either accepts an existing robot, or creates one for the run. in both cases the owner must be `cli/add_static_enhancements` as a safety guard
  - cycles the secret - the owner guard makes this safe and means we don't need to be copy-pasting secrets
- requests the enhancements
- fulfills the enhancements