### PR TITLE
Select candidates by configured policy, without interim writes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,6 @@ OTEL_CONFIG='{"trace_endpoint": "http://localhost:4318/v1/traces", "meter_endpoi
 OTEL_CONFIG='{"trace_endpoint": "https://api.honeycomb.io/v1/traces", "meter_endpoint": "https://api.honeycomb.io/v1/metrics", "log_endpoint": "https://api.honeycomb.io/v1/logs", "api_key": "replace-me", "instrument_sql": false}'
 OTEL_ENABLED=false
 FEATURE_FLAGS='{}'
-DEDUP_SCORING='{"MAX_AUTHOR_CLAUSES": 25, "MIN_AUTHOR_TOKEN_LENGTH": 2}'
+DEDUP_SCORING='{"MAX_AUTHOR_CLAUSES": 25, "MIN_AUTHOR_TOKEN_LENGTH": 2, "CANDIDATE_K": 10, "RETRIEVAL_POLICY": "candidate_selection_v1"}'
 
 CORS_ALLOW_ORIGINS='["http://localhost:3000"]'

--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,6 @@ OTEL_CONFIG='{"trace_endpoint": "http://localhost:4318/v1/traces", "meter_endpoi
 OTEL_CONFIG='{"trace_endpoint": "https://api.honeycomb.io/v1/traces", "meter_endpoint": "https://api.honeycomb.io/v1/metrics", "log_endpoint": "https://api.honeycomb.io/v1/logs", "api_key": "replace-me", "instrument_sql": false}'
 OTEL_ENABLED=false
 FEATURE_FLAGS='{}'
-DEDUP_SCORING='{"MAX_AUTHOR_CLAUSES": 25, "MIN_AUTHOR_TOKEN_LENGTH": 2, "CANDIDATE_K": 10, "RETRIEVAL_POLICY": "candidate_selection_v1"}'
+DEDUP_SCORING='{"MAX_AUTHOR_CLAUSES": 25, "MIN_AUTHOR_TOKEN_LENGTH": 2, "CANDIDATE_K": 10, "DEFAULT_RETRIEVAL_POLICY": "candidate_selection_v1"}'
 
 CORS_ALLOW_ORIGINS='["http://localhost:3000"]'

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -400,7 +400,7 @@ class DedupCandidateScoringConfig(BaseModel):
         le=1000,
         description="Default number of candidate references to retrieve.",
     )
-    retrieval_policy: RetrievalPolicyName = Field(
+    default_retrieval_policy: RetrievalPolicyName = Field(
         default=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
         description="Candidate retrieval policy used when no override is supplied.",
     )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -19,7 +19,10 @@ from pydantic import (
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from app.core.telemetry.logger import get_logger
-from app.domain.references.models.models import ExternalIdentifierType
+from app.domain.references.models.models import (
+    ExternalIdentifierType,
+    RetrievalPolicyName,
+)
 from app.persistence.blob.models import BlobContainer, BlobStorageLocation
 from app.utils.time_and_date import iso8601_duration_adapter
 
@@ -392,10 +395,14 @@ class DedupCandidateScoringConfig(BaseModel):
         description="Minimum token length for author name matching.",
     )
     candidate_k: int = Field(
-        default=100,
+        default=10,
         ge=1,
         le=1000,
         description="Default number of candidate references to retrieve.",
+    )
+    retrieval_policy: RetrievalPolicyName = Field(
+        default=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
+        description="Candidate retrieval policy used when no override is supplied.",
     )
 
 

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -885,6 +885,9 @@ class RetrievalPolicyName(StrEnum):
     """Evaluation-only probe: soft_year_decay_v1 with zero edit-distance title
     matching. Used to measure the recall and latency impact of disabling fuzzy
     title matching for this query shape. Not for production nomination."""
+    CANDIDATE_SELECTION_V1 = "candidate_selection_v1"
+    """First production policy: soft year decay and non-fuzzy title matching;
+    requires publication year and unions exact identifier candidates."""
 
 
 class CandidateIdentifier(GenericExternalIdentifier):
@@ -948,12 +951,12 @@ class CandidateSelectionRequest(BaseModel):
     input: CandidateSelectionInput = Field(
         description="The reference to find candidates for."
     )
-    retrieval_policy: RetrievalPolicyName = Field(
-        default=RetrievalPolicyName.CURRENT_FUZZY_V1,
+    retrieval_policy: RetrievalPolicyName | None = Field(
+        default=None,
         description=(
             "Named, server-side retrieval policy fixing the full candidate regime "
             "(query shape, year strategy, identifier union). Defaults to the "
-            "current fuzzy baseline."
+            "server's configured candidate-selection policy."
         ),
     )
     k: int | None = Field(
@@ -1054,7 +1057,7 @@ class CandidateSelectionDiagnostics(BaseModel):
 class CandidateSelectionResult(BaseModel):
     """Ranked candidates and diagnostics for a candidate-selection request."""
 
-    retrieval_policy: RetrievalPolicyName = RetrievalPolicyName.CURRENT_FUZZY_V1
+    retrieval_policy: RetrievalPolicyName
     index_version: str | None = Field(
         default=None,
         description="The reference index version the candidates were drawn from.",

--- a/app/domain/references/models/retrieval_policy.py
+++ b/app/domain/references/models/retrieval_policy.py
@@ -105,6 +105,13 @@ RETRIEVAL_POLICIES: Mapping[RetrievalPolicyName, RetrievalPolicy] = MappingProxy
                 year_decay=YearDecayConfig(),
                 title_fuzziness="0",
             ),
+            RetrievalPolicy(
+                name=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
+                union_identifiers=True,
+                year_strategy=YearStrategy.SOFT_DECAY,
+                year_decay=YearDecayConfig(),
+                title_fuzziness="0",
+            ),
         )
     }
 )

--- a/app/domain/references/service.py
+++ b/app/domain/references/service.py
@@ -1289,18 +1289,25 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
                     )
                 return
 
-        # Carry on with normal processing
-        reference_duplicate_decision = (
-            await self._deduplication_service.nominate_candidate_canonicals(
-                reference_duplicate_decision
+        if settings.feature_flags.enable_canonical_candidate_search:
+            candidate_selection = (
+                await self._deduplication_service.select_candidate_canonicals(
+                    reference_duplicate_decision.reference_id
+                )
             )
-        )
-
-        reference_duplicate_decision = (
-            await self._deduplication_service.determine_canonical_from_candidates(
-                reference_duplicate_decision
+            reference_duplicate_decision = (
+                await self._deduplication_service.determine_canonical_from_candidates(
+                    reference_duplicate_decision,
+                    candidate_selection,
+                )
             )
-        )
+        else:
+            reference_duplicate_decision = reference_duplicate_decision.model_copy(
+                update={
+                    "duplicate_determination": DuplicateDetermination.UNSEARCHABLE,
+                    "detail": "Canonical candidate search is disabled.",
+                }
+            )
 
         (
             reference_duplicate_decision,

--- a/app/domain/references/service.py
+++ b/app/domain/references/service.py
@@ -1302,11 +1302,11 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
                 )
             )
         else:
-            reference_duplicate_decision = reference_duplicate_decision.model_copy(
-                update={
-                    "duplicate_determination": DuplicateDetermination.UNSEARCHABLE,
-                    "detail": "Canonical candidate search is disabled.",
-                }
+            reference_duplicate_decision.duplicate_determination = (
+                DuplicateDetermination.UNSEARCHABLE
+            )
+            reference_duplicate_decision.detail = (
+                "Canonical candidate search is disabled."
             )
 
         (

--- a/app/domain/references/services/deduplication_service.py
+++ b/app/domain/references/services/deduplication_service.py
@@ -28,7 +28,6 @@ from app.domain.references.models.models import (
     Reference,
     ReferenceDuplicateDecision,
     ReferenceDuplicateDeterminationResult,
-    RetrievalPolicyName,
     YearDecay,
 )
 from app.domain.references.models.projections import (
@@ -200,16 +199,12 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
     async def get_deduplication_candidates(
         self, request: CandidateSelectionRequest
     ) -> CandidateSelectionResult:
-        """
-        Retrieve ranked candidate canonicals for a reference, without persisting.
-
-        Read-only evaluation surface for deduplication candidate retrieval: it runs
-        the shared Elasticsearch candidate query and, optionally, unions exact
-        identifier matches from Postgres, returning route provenance and retrieval
-        diagnostics. It writes no duplicate-decision or candidate state.
-        """
+        """Return ranked candidates with provenance, without persisting state."""
         k = request.k or settings.dedup_scoring.candidate_k
-        policy = resolve_retrieval_policy(request.retrieval_policy)
+        policy_name = (
+            request.retrieval_policy or settings.dedup_scoring.retrieval_policy
+        )
+        policy = resolve_retrieval_policy(policy_name)
 
         (
             search_fields,
@@ -217,17 +212,15 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
             identifier_lookups,
         ) = await self._resolve_candidate_selection_input(request.input)
 
-        # Exact identifier matching does not depend on bibliographic searchability;
-        # it is the route for records that fail the ES searchability gate, so it runs
-        # regardless of it.
+        # Identifier matching remains available when bibliographic input cannot
+        # pass the Elasticsearch searchability gate.
         identifier_matches: dict[UUID, dict[tuple, CandidateIdentifier]] = {}
         if policy.union_identifiers and identifier_lookups:
             identifier_matches = await self._union_identifier_matches(
                 identifier_lookups, self_id=self_id
             )
 
-        # The ES candidate query and its index-version stamp are only meaningful for
-        # searchable inputs.
+        # The ES query and index-version stamp only apply to searchable input.
         searchable = policy.is_input_searchable(search_fields)
         es_result = None
         index_version = None
@@ -377,11 +370,8 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
         for reference in matched_references:
             if reference.id == self_id:
                 continue
-            # Unlike the ES query, this read-only path does not restrict to
-            # CANONICAL-at-rest references: that filter guards a nomination write
-            # race we don't have, so an exact identifier match is surfaced whatever
-            # its dedup state. A match on a duplicate resolves to its canonical,
-            # which may be a different, older reference outside the queried set.
+            # Identifier matches are not restricted to canonical-at-rest records.
+            # A duplicate match resolves to its canonical reference.
             if reference.is_canonical_like:
                 canonical_id = reference.id
             elif (
@@ -521,119 +511,61 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
             reference_duplicate_decision
         )
 
-    async def nominate_candidate_canonicals(
-        self, reference_duplicate_decision: ReferenceDuplicateDecision
-    ) -> ReferenceDuplicateDecision:
-        """
-        Nominate candidate canonical references for the given decision.
-
-        This uses the control retrieval policy's search strategy.
-
-        :param reference_duplicate_decision: The decision to find candidates for.
-        :type reference_duplicate_decision: ReferenceDuplicateDecision
-        :return: The updated decision with candidate IDs and status.
-        :rtype: ReferenceDuplicateDecision
-        """
-        if not settings.feature_flags.enable_canonical_candidate_search:
-            return await self.sql_uow.reference_duplicate_decisions.update_by_pk(
-                reference_duplicate_decision.id,
-                duplicate_determination=DuplicateDetermination.UNSEARCHABLE,
-                detail="Canonical candidate search is disabled.",
-            )
-
-        reference = await self.sql_uow.references.get_by_pk(
-            reference_duplicate_decision.reference_id,
-            preload=["enhancements", "identifiers"],
-        )
-
-        search_fields = (
-            ReferenceSearchFieldsProjection.get_canonical_candidate_search_fields(
-                reference
+    async def select_candidate_canonicals(
+        self, reference_id: UUID
+    ) -> CandidateSelectionResult:
+        """Select candidates and return their complete retrieval provenance."""
+        return await self.get_deduplication_candidates(
+            CandidateSelectionRequest(
+                input=CandidateSelectionInput(reference_id=reference_id),
+                hydrate=False,
             )
         )
 
-        if not search_fields.is_searchable:
-            return await self.sql_uow.reference_duplicate_decisions.update_by_pk(
-                reference_duplicate_decision.id,
-                duplicate_determination=DuplicateDetermination.UNSEARCHABLE,
-            )
-        # The candidate depth here preserves this path's historical behaviour; the
-        # production K is chosen by the recall@K evaluation, not this path.
-        query = build_candidate_canonical_search_query(
-            search_fields,
-            scoring_config=settings.dedup_scoring,
-            policy=resolve_retrieval_policy(RetrievalPolicyName.CURRENT_FUZZY_V1),
-            reference_id=reference.id,
-        )
-        search_result = await self.es_uow.references.search_for_candidate_canonicals(
-            query,
-            k=10,
-        )
-
-        if not search_result.hits:
-            reference_duplicate_decision = (
-                await self.sql_uow.reference_duplicate_decisions.update_by_pk(
-                    reference_duplicate_decision.id,
-                    # This should simplify to CANONICAL only once the search strategy is
-                    # implemented and evaluated.
-                    duplicate_determination=DuplicateDetermination.CANONICAL
-                    if settings.env == Environment.TEST
-                    else DuplicateDetermination.UNSEARCHABLE,
-                )
-            )
-        else:
-            # Is there a search result score that would be enough for us to mark as
-            # duplicate without proceeding to the next step?
-            reference_duplicate_decision = (
-                await self.sql_uow.reference_duplicate_decisions.update_by_pk(
-                    reference_duplicate_decision.id,
-                    candidate_canonical_ids=[
-                        result.id for result in search_result.hits
-                    ],
-                    duplicate_determination=DuplicateDetermination.NOMINATED,
-                )
-            )
-
-        return reference_duplicate_decision
-
-    async def __placeholder_duplicate_determinator(
-        self, reference_duplicate_decision: ReferenceDuplicateDecision
+    async def _placeholder_duplicate_determinator(
+        self, candidate_selection: CandidateSelectionResult
     ) -> ReferenceDuplicateDeterminationResult:
         """
-        Implement a basic placeholder duplicate determinator.
+        Choose the first candidate only in tests; production returns unsearchable.
 
-        Temporary implementation: takes the first candidate as the duplicate.
-        This is the one with the highest score in the candidate nomination stage.
-        This completes the flow but should not be used in production.
+        This temporary behaviour is replaced by the deep-deduplication adjudicator.
 
-        :param reference_duplicate_decision: The decision to determine duplicates for.
-        :type reference_duplicate_decision: ReferenceDuplicateDecision
+        :param candidate_selection: Full candidate retrieval result.
+        :type candidate_selection: CandidateSelectionResult
         :return: The result of the duplicate determination.
         :rtype: ReferenceDuplicateDeterminationResult
         """
-        return (
-            ReferenceDuplicateDeterminationResult(
+        if candidate_selection.candidates and settings.env == Environment.TEST:
+            return ReferenceDuplicateDeterminationResult(
                 duplicate_determination=DuplicateDetermination.DUPLICATE,
-                canonical_reference_id=reference_duplicate_decision.candidate_canonical_ids[
-                    0
-                ],
+                canonical_reference_id=candidate_selection.candidates[0].reference_id,
             )
-            if settings.env == Environment.TEST
-            and reference_duplicate_decision.candidate_canonical_ids
-            else ReferenceDuplicateDeterminationResult(
-                duplicate_determination=DuplicateDetermination.UNSEARCHABLE,
-                detail="Placeholder duplicate determinator used.",
+
+        if (
+            settings.env == Environment.TEST
+            and candidate_selection.input_searchability.searchable
+        ):
+            return ReferenceDuplicateDeterminationResult(
+                duplicate_determination=DuplicateDetermination.CANONICAL,
             )
+
+        return ReferenceDuplicateDeterminationResult(
+            duplicate_determination=DuplicateDetermination.UNSEARCHABLE,
+            detail="Placeholder duplicate determinator used.",
         )
 
     async def determine_canonical_from_candidates(
-        self, reference_duplicate_decision: ReferenceDuplicateDecision
+        self,
+        reference_duplicate_decision: ReferenceDuplicateDecision,
+        candidate_selection: CandidateSelectionResult,
     ) -> ReferenceDuplicateDecision:
         """
         Determine a canonical reference from its candidates.
 
         :param reference_duplicate_decision: The decision to determine duplicates for.
         :type reference_duplicate_decision: ReferenceDuplicateDecision
+        :param candidate_selection: Full retrieval result for the scoring path.
+        :type candidate_selection: CandidateSelectionResult
         :return: The updated decision with the determination result.
         :rtype: ReferenceDuplicateDecision
         """
@@ -643,10 +575,8 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
         ):
             return reference_duplicate_decision
 
-        duplicate_determination_result = (
-            await self.__placeholder_duplicate_determinator(
-                reference_duplicate_decision
-            )
+        duplicate_determination_result = await self._placeholder_duplicate_determinator(
+            candidate_selection
         )
 
         return await self.sql_uow.reference_duplicate_decisions.update_by_pk(

--- a/app/domain/references/services/deduplication_service.py
+++ b/app/domain/references/services/deduplication_service.py
@@ -202,7 +202,7 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
         """Return ranked candidates with provenance, without persisting state."""
         k = request.k or settings.dedup_scoring.candidate_k
         policy_name = (
-            request.retrieval_policy or settings.dedup_scoring.retrieval_policy
+            request.retrieval_policy or settings.dedup_scoring.default_retrieval_policy
         )
         policy = resolve_retrieval_policy(policy_name)
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -3,7 +3,13 @@
 import pytest
 from pydantic import ValidationError
 
-from app.core.config import AzureBlobConfig, ESConfig, MinioConfig
+from app.core.config import (
+    AzureBlobConfig,
+    DedupCandidateScoringConfig,
+    ESConfig,
+    MinioConfig,
+)
+from app.domain.references.models.models import RetrievalPolicyName
 from app.persistence.blob.models import BlobContainer
 
 
@@ -62,3 +68,11 @@ def test_blob_backend_config_requires_all_containers():
             secret_key="s",
             containers={BlobContainer.OPERATIONS: "ops"},
         )
+
+
+def test_candidate_selection_config_defaults_to_production_policy_and_k():
+    """Candidate selection uses the deployed policy unless explicitly overridden."""
+    config = DedupCandidateScoringConfig()
+
+    assert config.retrieval_policy is RetrievalPolicyName.CANDIDATE_SELECTION_V1
+    assert config.candidate_k == 10

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -74,5 +74,5 @@ def test_candidate_selection_config_defaults_to_production_policy_and_k():
     """Candidate selection uses the deployed policy unless explicitly overridden."""
     config = DedupCandidateScoringConfig()
 
-    assert config.retrieval_policy is RetrievalPolicyName.CANDIDATE_SELECTION_V1
+    assert config.default_retrieval_policy is RetrievalPolicyName.CANDIDATE_SELECTION_V1
     assert config.candidate_k == 10

--- a/tests/e2e/imports/conftest.py
+++ b/tests/e2e/imports/conftest.py
@@ -11,6 +11,7 @@ import httpx
 import pytest
 from aiohttp import web
 from destiny_sdk.enhancements import EnhancementFileInput
+from destiny_sdk.identifiers import OpenAlexIdentifier
 from destiny_sdk.references import ReferenceFileInput
 from elasticsearch import AsyncElasticsearch
 
@@ -36,7 +37,8 @@ def generate_sdk_reference_file_inputs() -> Callable[[int], list[ReferenceFileIn
                 enhancements=[
                     EnhancementFileInput(**e.model_dump()) for e in r.enhancements or []
                 ],
-                identifiers=[i.identifier for i in r.identifiers or []],
+                # Avoid accidental identifier candidates between unrelated records.
+                identifiers=[OpenAlexIdentifier(identifier=f"W{uuid7().int}")],
             )
             for r in references
         ]

--- a/tests/e2e/imports/test_candidate_selection.py
+++ b/tests/e2e/imports/test_candidate_selection.py
@@ -101,7 +101,7 @@ async def test_candidates_inline_unions_es_and_identifier_without_persisting(  #
 
     assert response.status_code == 200
     body = response.json()
-    assert body["retrieval_policy"] == "current_fuzzy_v1"
+    assert body["retrieval_policy"] == "candidate_selection_v1"
     assert body["index_version"].startswith("reference_v")
     assert body["k_requested"] == 50
     assert body["input_searchability"]["searchable"] is True
@@ -159,7 +159,7 @@ async def test_candidates_by_reference_id_is_searchable_and_read_only(
     assert response.status_code == 200
     body = response.json()
     assert body["input_searchability"]["searchable"] is True
-    assert body["k_requested"] == 100  # configured default
+    assert body["k_requested"] == 10  # configured default
     # The input reference excludes itself from its own candidates.
     assert all(c["reference_id"] != str(reference_id) for c in body["candidates"])
     assert await _count_duplicate_decisions(pg_session) == decisions_before

--- a/tests/e2e/imports/test_deduplication.py
+++ b/tests/e2e/imports/test_deduplication.py
@@ -136,15 +136,26 @@ def duplicate_reference(
 def non_duplicate_reference(
     canonical_reference: Reference,
 ) -> Reference:
-    """Get a slightly mutated canonical reference to definitely not be a duplicate."""
-    duplicate = canonical_reference.model_copy(deep=True, update={"id": uuid7()})
-    assert duplicate.enhancements
+    """Get a reference with no candidate-level overlap with the canonical."""
+    non_duplicate = canonical_reference.model_copy(deep=True, update={"id": uuid7()})
+    assert non_duplicate.enhancements
     assert isinstance(
-        duplicate.enhancements[0].content, BibliographicMetadataEnhancement
+        non_duplicate.enhancements[0].content, BibliographicMetadataEnhancement
     )
-    assert duplicate.enhancements[0].content.publication_year
-    duplicate.enhancements[0].content.publication_year -= 10
-    return duplicate
+    bibliographic = non_duplicate.enhancements[0].content
+    assert bibliographic.publication_year
+    bibliographic.title = "An Unrelated Study of Marine Ecosystems"
+    bibliographic.authorship = [
+        Authorship(display_name="Alex Morgan", position="first")
+    ]
+    bibliographic.publication_year -= 10
+    non_duplicate.identifiers = [
+        LinkedExternalIdentifierFactory.build(
+            identifier=OpenAlexIdentifierFactory.build(),
+            reference_id=non_duplicate.id,
+        )
+    ]
+    return non_duplicate
 
 
 @pytest.fixture

--- a/tests/unit/domain/references/deduplication/test_candidate_selection.py
+++ b/tests/unit/domain/references/deduplication/test_candidate_selection.py
@@ -213,6 +213,34 @@ async def test_no_year_filter_v1_passes_strategy_and_stamps_policy(build_service
 
 
 @pytest.mark.asyncio
+async def test_request_without_overrides_honours_rollback_policy_and_configured_k(
+    build_service, monkeypatch
+):
+    from app.domain.references.services import deduplication_service as dedup_module
+
+    service, es_refs, _, _ = build_service()
+    monkeypatch.setattr(
+        dedup_module.settings.dedup_scoring,
+        "retrieval_policy",
+        RetrievalPolicyName.CURRENT_FUZZY_V1,
+    )
+    monkeypatch.setattr(dedup_module.settings.dedup_scoring, "candidate_k", 17)
+
+    result = await service.get_deduplication_candidates(
+        CandidateSelectionRequest(
+            input=CandidateSelectionInput(
+                title="t", authors=["a"], publication_year=2020
+            ),
+            hydrate=False,
+        )
+    )
+
+    assert result.retrieval_policy is RetrievalPolicyName.CURRENT_FUZZY_V1
+    assert result.k_requested == 17
+    assert es_refs.search_for_candidate_canonicals.call_args.kwargs["k"] == 17
+
+
+@pytest.mark.asyncio
 async def test_year_optional_policy_searches_missing_year_input(build_service):
     service, es_refs, _, _ = build_service(
         es_result=_es_result(ESScoreResult(id=uuid7(), score=4.0))
@@ -264,7 +292,7 @@ async def test_inline_input_returns_ranked_es_candidates(build_service):
         )
     )
 
-    assert result.retrieval_policy == RetrievalPolicyName.CURRENT_FUZZY_V1
+    assert result.retrieval_policy == RetrievalPolicyName.CANDIDATE_SELECTION_V1
     assert result.index_version == "reference_v3"
     assert result.input_searchability.searchable is True
     assert [c.reference_id for c in result.candidates] == [id1, id2]
@@ -299,8 +327,8 @@ async def test_reference_id_input_self_excludes_and_defaults_k(build_service):
     query = es_refs.search_for_candidate_canonicals.call_args.args[0]
     kwargs = es_refs.search_for_candidate_canonicals.call_args.kwargs
     assert query.excluded_reference_id == reference.id
-    assert kwargs["k"] == 100  # configured default
-    assert result.k_requested == 100
+    assert kwargs["k"] == 10  # configured default
+    assert result.k_requested == 10
     assert [c.reference_id for c in result.candidates] == [hit]
 
 
@@ -337,9 +365,14 @@ async def test_identifier_only_match_ranks_ahead_of_es(build_service):
             "duplicate_decision": None,  # canonical-like
         }
     )
-    es_id = uuid7()
+    es_ids = [uuid7() for _ in range(10)]
     service, _, sql_refs, _ = build_service(
-        es_result=_es_result(ESScoreResult(id=es_id, score=5.0)),
+        es_result=_es_result(
+            *[
+                ESScoreResult(id=es_id, score=float(10 - rank))
+                for rank, es_id in enumerate(es_ids)
+            ]
+        ),
         found_references=[identifier_ref],
     )
 
@@ -361,14 +394,61 @@ async def test_identifier_only_match_ranks_ahead_of_es(build_service):
     )
 
     # Identifier-only match first, then the ES-scored candidate.
-    assert [c.reference_id for c in result.candidates] == [identifier_ref.id, es_id]
+    assert [candidate.reference_id for candidate in result.candidates] == [
+        identifier_ref.id,
+        *es_ids,
+    ]
     assert result.candidates[0].rank == 1
     id_route = result.candidates[0].routes[0]
     assert id_route.type == "identifier"
     assert id_route.matched_identifiers[0].identifier == str(doi.identifier)
     assert result.candidates[1].routes[0].type == "elasticsearch"
     assert result.diagnostics.identifier_returned == 1
-    assert result.diagnostics.candidate_count == 2
+    assert result.diagnostics.candidate_count == 11
+    assert result.diagnostics.candidate_count > result.k_requested
+
+
+@pytest.mark.asyncio
+async def test_same_canonical_from_both_routes_is_returned_once(build_service):
+    doi = DOIIdentifierFactory.build()
+    matched = ReferenceFactory.build(visibility="public")
+    matched = matched.model_copy(
+        update={
+            "identifiers": [
+                LinkedExternalIdentifierFactory.build(
+                    identifier=doi, reference_id=matched.id
+                )
+            ],
+            "duplicate_decision": None,
+        }
+    )
+    service, _, _, _ = build_service(
+        es_result=_es_result(ESScoreResult(id=matched.id, score=5.0)),
+        found_references=[matched],
+    )
+
+    result = await service.get_deduplication_candidates(
+        CandidateSelectionRequest(
+            input=CandidateSelectionInput(
+                title="A study",
+                authors=["Jane Doe"],
+                publication_year=2025,
+                identifiers=[
+                    CandidateIdentifier(
+                        identifier_type=ExternalIdentifierType.DOI,
+                        identifier=str(doi.identifier),
+                    )
+                ],
+            ),
+            hydrate=False,
+        )
+    )
+
+    assert [candidate.reference_id for candidate in result.candidates] == [matched.id]
+    assert {route.type for route in result.candidates[0].routes} == {
+        "elasticsearch",
+        "identifier",
+    }
 
 
 @pytest.mark.asyncio
@@ -411,6 +491,49 @@ async def test_identifier_match_on_duplicate_resolves_to_canonical(build_service
     )
 
     assert [c.reference_id for c in result.candidates] == [canonical_id]
+
+
+@pytest.mark.asyncio
+async def test_identifier_match_keeps_canonical_with_existing_duplicates_eligible(
+    build_service,
+):
+    doi = DOIIdentifierFactory.build()
+    canonical = ReferenceFactory.build(visibility="public")
+    canonical = canonical.model_copy(
+        update={
+            "identifiers": [
+                LinkedExternalIdentifierFactory.build(
+                    identifier=doi, reference_id=canonical.id
+                )
+            ],
+            "duplicate_decision": ReferenceDuplicateDecision(
+                reference_id=canonical.id,
+                active_decision=True,
+                duplicate_determination=DuplicateDetermination.CANONICAL,
+            ),
+            "duplicate_references": [ReferenceFactory.build(visibility="public")],
+        }
+    )
+    service, _, _, _ = build_service(found_references=[canonical])
+
+    result = await service.get_deduplication_candidates(
+        CandidateSelectionRequest(
+            input=CandidateSelectionInput(
+                title="A study",
+                authors=["Jane Doe"],
+                publication_year=2025,
+                identifiers=[
+                    CandidateIdentifier(
+                        identifier_type=ExternalIdentifierType.DOI,
+                        identifier=str(doi.identifier),
+                    )
+                ],
+            ),
+            hydrate=False,
+        )
+    )
+
+    assert [candidate.reference_id for candidate in result.candidates] == [canonical.id]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/domain/references/deduplication/test_candidate_selection.py
+++ b/tests/unit/domain/references/deduplication/test_candidate_selection.py
@@ -221,7 +221,7 @@ async def test_request_without_overrides_honours_rollback_policy_and_configured_
     service, es_refs, _, _ = build_service()
     monkeypatch.setattr(
         dedup_module.settings.dedup_scoring,
-        "retrieval_policy",
+        "default_retrieval_policy",
         RetrievalPolicyName.CURRENT_FUZZY_V1,
     )
     monkeypatch.setattr(dedup_module.settings.dedup_scoring, "candidate_k", 17)

--- a/tests/unit/domain/references/models/test_retrieval_policy.py
+++ b/tests/unit/domain/references/models/test_retrieval_policy.py
@@ -186,6 +186,16 @@ def test_soft_year_decay_nonfuzzy_probe_v1_regime():
     assert policy.title_fuzziness == "0"
 
 
+def test_candidate_selection_v1_matches_selected_probe_parameters():
+    automatic = resolve_retrieval_policy(RetrievalPolicyName.CANDIDATE_SELECTION_V1)
+    probe = resolve_retrieval_policy(
+        RetrievalPolicyName.SOFT_YEAR_DECAY_NONFUZZY_PROBE_V1
+    )
+
+    assert automatic.name is RetrievalPolicyName.CANDIDATE_SELECTION_V1
+    assert automatic.model_dump(exclude={"name"}) == probe.model_dump(exclude={"name"})
+
+
 def test_fuzzy_policies_default_to_auto_fuzziness():
     for name in (
         RetrievalPolicyName.CURRENT_FUZZY_V1,

--- a/tests/unit/domain/references/services/test_deduplication_service.py
+++ b/tests/unit/domain/references/services/test_deduplication_service.py
@@ -7,18 +7,29 @@ import pytest
 from destiny_sdk.enhancements import Authorship
 from destiny_sdk.identifiers import OtherIdentifier
 
+from app.core.config import Environment
 from app.core.exceptions import DeduplicationValueError
 from app.domain.references.models.models import (
+    Candidate,
+    CandidateSelectionDiagnostics,
+    CandidateSelectionResult,
     DuplicateDetermination,
     ExternalIdentifierType,
+    InputSearchability,
     LinkedExternalIdentifier,
     Reference,
     ReferenceDuplicateDecision,
+    RetrievalPolicyName,
 )
 from app.domain.references.services.anti_corruption_service import (
     ReferenceAntiCorruptionService,
 )
 from app.domain.references.services.deduplication_service import DeduplicationService
+from app.persistence.es.persistence import (
+    CandidateCanonicalSearchResult,
+    ESScoreResult,
+    ESSearchTotal,
+)
 from tests.factories import (
     BibliographicMetadataEnhancementFactory,
     DOIIdentifierFactory,
@@ -30,6 +41,39 @@ from tests.factories import (
     ReferenceFactory,
 )
 from tests.unit.domain.conftest import link_fake_repos
+
+
+def _mock_candidate_selection(service: DeduplicationService, *candidate_ids) -> None:
+    """Configure repositories used by the shared read-only candidate selector."""
+    service.sql_uow.references.find_with_identifiers = AsyncMock(  # type: ignore[method-assign]
+        return_value=[]
+    )
+    service.es_uow = MagicMock()
+    service.es_uow.references.get_current_index_name = AsyncMock(
+        return_value="reference_v3"
+    )
+    service.es_uow.references.search_for_candidate_canonicals = AsyncMock(
+        return_value=CandidateCanonicalSearchResult(
+            hits=[ESScoreResult(id=id_, score=1.0) for id_ in candidate_ids],
+            total=ESSearchTotal(value=len(candidate_ids), relation="eq"),
+            took_ms=1,
+        )
+    )
+
+
+def _candidate_selection(*candidate_ids) -> CandidateSelectionResult:
+    """Build the retrieval contract consumed by temporary determination tests."""
+    return CandidateSelectionResult(
+        retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
+        index_version="reference_v3",
+        k_requested=10,
+        input_searchability=InputSearchability(searchable=True, reason="ok"),
+        diagnostics=CandidateSelectionDiagnostics(candidate_count=len(candidate_ids)),
+        candidates=[
+            Candidate(reference_id=id_, rank=rank, routes=[])
+            for rank, id_ in enumerate(candidate_ids, start=1)
+        ],
+    )
 
 
 @pytest.fixture
@@ -244,132 +288,167 @@ async def test_register_duplicate_decision_invalid_combination(
 
 
 @pytest.mark.asyncio
-async def test_nominate_candidate_canonicals_candidates_not_found(
+async def test_unsearchable_reference_returns_empty_selection_without_es_search(
     reference, anti_corruption_service, fake_uow, fake_repository
 ):
     reference.enhancements = []
+    service = DeduplicationService(
+        anti_corruption_service,
+        fake_uow(references=fake_repository([reference])),
+        fake_uow(),
+    )
+
+    _mock_candidate_selection(service)
+    result = await service.select_candidate_canonicals(reference.id)
+
+    assert result.retrieval_policy.value == "candidate_selection_v1"
+    assert not result.input_searchability.searchable
+    assert not result.candidates
+    service.es_uow.references.search_for_candidate_canonicals.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_select_candidate_canonicals_returns_unhydrated_provenance(
+    searchable_reference, anti_corruption_service, fake_uow, fake_repository
+):
+    service = DeduplicationService(
+        anti_corruption_service,
+        fake_uow(references=fake_repository([searchable_reference])),
+        fake_uow(),
+    )
+
+    candidate_id = uuid7()
+    _mock_candidate_selection(service, candidate_id)
+    result = await service.select_candidate_canonicals(searchable_reference.id)
+
+    assert result.retrieval_policy.value == "candidate_selection_v1"
+    assert result.index_version == "reference_v3"
+    assert result.k_requested == 10
+    assert [candidate.reference_id for candidate in result.candidates] == [candidate_id]
+    assert result.candidates[0].routes[0].type == "elasticsearch"
+    assert result.candidates[0].routes[0].policy == "candidate_selection_v1"
+    assert result.candidates[0].reference is None
+    search_call = service.es_uow.references.search_for_candidate_canonicals.await_args
+    assert search_call.kwargs["track_total_hits"] is True
+
+
+@pytest.mark.asyncio
+async def test_searchable_reference_returns_empty_selection_after_es_search(
+    searchable_reference, anti_corruption_service, fake_uow, fake_repository
+):
+    service = DeduplicationService(
+        anti_corruption_service,
+        fake_uow(references=fake_repository([searchable_reference])),
+        fake_uow(),
+    )
+    _mock_candidate_selection(service)
+    result = await service.select_candidate_canonicals(searchable_reference.id)
+
+    assert result.input_searchability.searchable
+    assert not result.candidates
+    service.es_uow.references.search_for_candidate_canonicals.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_placeholder_selects_first_candidate_in_test_environment(
+    reference, anti_corruption_service, fake_uow, fake_repository
+):
     decision = ReferenceDuplicateDecision(
         reference_id=reference.id,
         duplicate_determination=DuplicateDetermination.PENDING,
     )
     service = DeduplicationService(
         anti_corruption_service,
-        fake_uow(
-            reference_duplicate_decisions=fake_repository([decision]),
-            references=fake_repository([reference]),
-        ),
+        fake_uow(reference_duplicate_decisions=fake_repository([decision])),
         fake_uow(),
     )
+    first_candidate_id = uuid7()
 
-    # Patch service.es_uow to mock search_for_candidate_canonicals
-    service.es_uow = MagicMock()
-    candidate_result = [MagicMock(id=uuid7())]
-    service.es_uow.references.search_for_candidate_canonicals = AsyncMock(
-        return_value=candidate_result
+    result = await service.determine_canonical_from_candidates(
+        decision,
+        _candidate_selection(first_candidate_id, uuid7()),
     )
-    result = await service.nominate_candidate_canonicals(decision)
-    assert result.duplicate_determination == DuplicateDetermination.UNSEARCHABLE
-    assert not result.candidate_canonical_ids
-    service.es_uow.references.search_for_candidate_canonicals.assert_not_awaited()
+
+    assert result.duplicate_determination is DuplicateDetermination.DUPLICATE
+    assert result.canonical_reference_id == first_candidate_id
 
 
 @pytest.mark.asyncio
-async def test_nominate_candidate_canonicals_candidates_found(
-    searchable_reference, anti_corruption_service, fake_uow, fake_repository
+async def test_placeholder_marks_searchable_empty_selection_canonical_in_tests(
+    reference, anti_corruption_service, fake_uow, fake_repository
 ):
     decision = ReferenceDuplicateDecision(
-        reference_id=searchable_reference.id,
+        reference_id=reference.id,
         duplicate_determination=DuplicateDetermination.PENDING,
     )
     service = DeduplicationService(
         anti_corruption_service,
-        fake_uow(
-            reference_duplicate_decisions=fake_repository([decision]),
-            references=fake_repository([searchable_reference]),
-        ),
+        fake_uow(reference_duplicate_decisions=fake_repository([decision])),
         fake_uow(),
     )
 
-    # Patch service.es_uow to mock search_for_candidate_duplicates
-    service.es_uow = MagicMock()
-    candidate_hit = MagicMock(id=uuid7())
-    service.es_uow.references.search_for_candidate_canonicals = AsyncMock(
-        return_value=MagicMock(hits=[candidate_hit])
+    result = await service.determine_canonical_from_candidates(
+        decision,
+        _candidate_selection(),
     )
-    result = await service.nominate_candidate_canonicals(decision)
-    assert result.duplicate_determination == DuplicateDetermination.NOMINATED
-    assert result.candidate_canonical_ids == [candidate_hit.id]
-    service.es_uow.references.search_for_candidate_canonicals.assert_awaited()
+
+    assert result.duplicate_determination is DuplicateDetermination.CANONICAL
 
 
 @pytest.mark.asyncio
-async def test_nominate_candidate_canonicals_flag_disabled(
-    searchable_reference,
-    anti_corruption_service,
-    fake_uow,
-    fake_repository,
-    monkeypatch,
+async def test_placeholder_marks_unsearchable_selection_unsearchable_in_tests(
+    reference, anti_corruption_service, fake_uow, fake_repository
 ):
-    """When the feature flag is off, the decision is UNSEARCHABLE and ES is skipped."""
+    decision = ReferenceDuplicateDecision(
+        reference_id=reference.id,
+        duplicate_determination=DuplicateDetermination.PENDING,
+    )
+    service = DeduplicationService(
+        anti_corruption_service,
+        fake_uow(reference_duplicate_decisions=fake_repository([decision])),
+        fake_uow(),
+    )
+    selection = _candidate_selection().model_copy(
+        update={
+            "input_searchability": InputSearchability(
+                searchable=False, reason="missing title"
+            )
+        }
+    )
+
+    result = await service.determine_canonical_from_candidates(decision, selection)
+
+    assert result.duplicate_determination is DuplicateDetermination.UNSEARCHABLE
+
+
+@pytest.mark.asyncio
+async def test_placeholder_never_selects_candidate_outside_test_environment(
+    reference, anti_corruption_service, fake_uow, fake_repository, monkeypatch
+):
     from app.domain.references.services import deduplication_service as dedup_module
 
-    monkeypatch.setattr(
-        dedup_module.settings.feature_flags,
-        "enable_canonical_candidate_search",
-        False,
-    )
-
+    monkeypatch.setattr(dedup_module.settings, "env", Environment.LOCAL)
     decision = ReferenceDuplicateDecision(
-        reference_id=searchable_reference.id,
+        reference_id=reference.id,
         duplicate_determination=DuplicateDetermination.PENDING,
     )
     service = DeduplicationService(
         anti_corruption_service,
-        fake_uow(
-            reference_duplicate_decisions=fake_repository([decision]),
-            references=fake_repository([searchable_reference]),
-        ),
+        fake_uow(reference_duplicate_decisions=fake_repository([decision])),
         fake_uow(),
     )
-    service.es_uow = MagicMock()
-    service.es_uow.references.search_for_candidate_canonicals = AsyncMock()
 
-    result = await service.nominate_candidate_canonicals(decision)
-    assert result.duplicate_determination == DuplicateDetermination.UNSEARCHABLE
-    assert not result.candidate_canonical_ids
-    assert result.detail == "Canonical candidate search is disabled."
-    service.es_uow.references.search_for_candidate_canonicals.assert_not_awaited()
+    result = await service.determine_canonical_from_candidates(
+        decision,
+        _candidate_selection(uuid7()),
+    )
+
+    assert result.duplicate_determination is DuplicateDetermination.UNSEARCHABLE
+    assert result.canonical_reference_id is None
 
 
 @pytest.mark.asyncio
-async def test_nominate_candidate_canonicals_no_candidates(
-    searchable_reference, anti_corruption_service, fake_uow, fake_repository
-):
-    decision = ReferenceDuplicateDecision(
-        reference_id=searchable_reference.id,
-        duplicate_determination=DuplicateDetermination.PENDING,
-    )
-    service = DeduplicationService(
-        anti_corruption_service,
-        fake_uow(
-            references=fake_repository([searchable_reference]),
-            reference_duplicate_decisions=fake_repository([decision]),
-        ),
-        fake_uow(),
-    )
-    # Patch service.es_uow to mock search_for_candidate_canonicals
-    service.es_uow = MagicMock()
-    service.es_uow.references.search_for_candidate_canonicals = AsyncMock(
-        return_value=MagicMock(hits=[])
-    )
-    result = await service.nominate_candidate_canonicals(decision)
-    assert result.duplicate_determination == DuplicateDetermination.CANONICAL
-    assert not result.candidate_canonical_ids
-    service.es_uow.references.search_for_candidate_canonicals.assert_awaited()
-
-
-@pytest.mark.asyncio
-async def test_determine_and_map_duplicate_happy_path(
+async def test_map_duplicate_decision_activates_new_duplicate(
     fake_uow, fake_repository, anti_corruption_service
 ):
     # Setup reference and decision
@@ -384,8 +463,8 @@ async def test_determine_and_map_duplicate_happy_path(
 
     decision = ReferenceDuplicateDecision(
         reference_id=reference.id,
-        candidate_canonical_ids=[canonical.id],
-        duplicate_determination=DuplicateDetermination.NOMINATED,
+        duplicate_determination=DuplicateDetermination.DUPLICATE,
+        canonical_reference_id=canonical.id,
     )
 
     ref_repo = fake_repository([reference, canonical])
@@ -398,9 +477,7 @@ async def test_determine_and_map_duplicate_happy_path(
         ),
         fake_uow(),
     )
-    # Split: determine then map
-    determined = await service.determine_canonical_from_candidates(decision)
-    out_decision, decision_changed, _ = await service.map_duplicate_decision(determined)
+    out_decision, decision_changed, _ = await service.map_duplicate_decision(decision)
     assert out_decision.duplicate_determination == DuplicateDetermination.DUPLICATE
     assert out_decision.canonical_reference_id == canonical.id
     assert decision_changed
@@ -410,7 +487,7 @@ async def test_determine_and_map_duplicate_happy_path(
 
 
 @pytest.mark.asyncio
-async def test_determine_and_map_duplicate_no_change(
+async def test_map_duplicate_decision_reports_matching_active_decision_unchanged(
     fake_uow, fake_repository, anti_corruption_service
 ):
     # Setup reference and decision
@@ -431,8 +508,8 @@ async def test_determine_and_map_duplicate_no_change(
 
     decision = ReferenceDuplicateDecision(
         reference_id=reference.id,
-        candidate_canonical_ids=[canonical.id],
-        duplicate_determination=DuplicateDetermination.NOMINATED,
+        duplicate_determination=DuplicateDetermination.DUPLICATE,
+        canonical_reference_id=canonical.id,
     )
 
     ref_repo = fake_repository([reference, canonical])
@@ -445,9 +522,7 @@ async def test_determine_and_map_duplicate_no_change(
         ),
         fake_uow(),
     )
-    # Split: determine then map
-    determined = await service.determine_canonical_from_candidates(decision)
-    out_decision, decision_changed, _ = await service.map_duplicate_decision(determined)
+    out_decision, decision_changed, _ = await service.map_duplicate_decision(decision)
     assert out_decision.duplicate_determination == DuplicateDetermination.DUPLICATE
     assert out_decision.canonical_reference_id == canonical.id
     assert decision_changed is False
@@ -457,7 +532,7 @@ async def test_determine_and_map_duplicate_no_change(
 
 
 @pytest.mark.asyncio
-async def test_determine_no_op_terminal(
+async def test_determine_returns_terminal_decision_unchanged(
     fake_uow, fake_repository, anti_corruption_service
 ):
     reference = MagicMock(spec=Reference)
@@ -466,7 +541,6 @@ async def test_determine_no_op_terminal(
 
     decision = ReferenceDuplicateDecision(
         reference_id=reference.id,
-        candidate_canonical_ids=[],
         duplicate_determination=DuplicateDetermination.CANONICAL,
     )
     ref_repo = fake_repository([reference])
@@ -479,12 +553,14 @@ async def test_determine_no_op_terminal(
         ),
         fake_uow(),
     )
-    determined = await service.determine_canonical_from_candidates(decision)
+    determined = await service.determine_canonical_from_candidates(
+        decision, _candidate_selection()
+    )
     assert determined == decision
 
 
 @pytest.mark.asyncio
-async def test_determine_and_map_duplicate_decoupled_canonical_change(
+async def test_map_duplicate_decision_decouples_duplicate_becoming_canonical(
     fake_uow, fake_repository, anti_corruption_service
 ):
     # Setup reference and active decision (was DUPLICATE, now CANONICAL)
@@ -513,8 +589,7 @@ async def test_determine_and_map_duplicate_decoupled_canonical_change(
         ),
         fake_uow(),
     )
-    determined = await service.determine_canonical_from_candidates(decision)
-    out_decision, decision_changed, _ = await service.map_duplicate_decision(determined)
+    out_decision, decision_changed, _ = await service.map_duplicate_decision(decision)
     assert out_decision.duplicate_determination == DuplicateDetermination.DECOUPLED
     assert (
         "Decouple reason: Existing duplicate decision changed." in out_decision.detail
@@ -529,7 +604,7 @@ async def test_determine_and_map_duplicate_decoupled_canonical_change(
 
 
 @pytest.mark.asyncio
-async def test_determine_and_map_duplicate_decoupled_different_canonical(
+async def test_map_duplicate_decision_decouples_changed_canonical_target(
     fake_uow, fake_repository, anti_corruption_service
 ):
     # Setup reference and active decision (was DUPLICATE of A, now DUPLICATE of B)
@@ -553,8 +628,8 @@ async def test_determine_and_map_duplicate_decoupled_different_canonical(
 
     decision = ReferenceDuplicateDecision(
         reference_id=reference.id,
-        candidate_canonical_ids=[canonical_b.id],
-        duplicate_determination=DuplicateDetermination.NOMINATED,
+        duplicate_determination=DuplicateDetermination.DUPLICATE,
+        canonical_reference_id=canonical_b.id,
     )
 
     ref_repo = fake_repository([reference, canonical_a, canonical_b])
@@ -567,8 +642,7 @@ async def test_determine_and_map_duplicate_decoupled_different_canonical(
         ),
         fake_uow(),
     )
-    determined = await service.determine_canonical_from_candidates(decision)
-    out_decision, decision_changed, _ = await service.map_duplicate_decision(determined)
+    out_decision, decision_changed, _ = await service.map_duplicate_decision(decision)
     assert out_decision.duplicate_determination == DuplicateDetermination.DECOUPLED
     assert (
         "Decouple reason: Existing duplicate decision changed." in out_decision.detail
@@ -577,7 +651,7 @@ async def test_determine_and_map_duplicate_decoupled_different_canonical(
 
 
 @pytest.mark.asyncio
-async def test_determine_and_map_duplicate_decoupled_has_duplicates(
+async def test_map_duplicate_decision_decouples_reference_with_duplicates(
     fake_uow, fake_repository, anti_corruption_service
 ):
     """Reference with existing duplicates cannot become a duplicate itself."""
@@ -600,8 +674,8 @@ async def test_determine_and_map_duplicate_decoupled_has_duplicates(
 
     decision = ReferenceDuplicateDecision(
         reference_id=reference.id,
-        candidate_canonical_ids=[candidate.id],
-        duplicate_determination=DuplicateDetermination.NOMINATED,
+        duplicate_determination=DuplicateDetermination.DUPLICATE,
+        canonical_reference_id=candidate.id,
     )
 
     ref_repo = fake_repository([reference, candidate])
@@ -615,8 +689,7 @@ async def test_determine_and_map_duplicate_decoupled_has_duplicates(
         fake_uow(),
     )
 
-    determined = await service.determine_canonical_from_candidates(decision)
-    out_decision, decision_changed, _ = await service.map_duplicate_decision(determined)
+    out_decision, decision_changed, _ = await service.map_duplicate_decision(decision)
     assert out_decision.duplicate_determination == DuplicateDetermination.DECOUPLED
     assert "Decouple reason: Reference has existing duplicates" in out_decision.detail
     assert decision_changed
@@ -652,7 +725,7 @@ async def test_map_duplicate_decision_rejects_self_reference(
 
 
 @pytest.mark.asyncio
-async def test_determine_and_map_duplicate_now_duplicate(
+async def test_map_duplicate_decision_replaces_active_canonical_decision(
     fake_uow, fake_repository, anti_corruption_service
 ):
     # Setup reference and active decision (was CANONICAL, now DUPLICATE)
@@ -673,8 +746,8 @@ async def test_determine_and_map_duplicate_now_duplicate(
 
     decision = ReferenceDuplicateDecision(
         reference_id=reference.id,
-        candidate_canonical_ids=[canonical.id],
-        duplicate_determination=DuplicateDetermination.NOMINATED,
+        duplicate_determination=DuplicateDetermination.DUPLICATE,
+        canonical_reference_id=canonical.id,
     )
 
     ref_repo = fake_repository([reference, canonical])
@@ -687,8 +760,7 @@ async def test_determine_and_map_duplicate_now_duplicate(
         ),
         fake_uow(),
     )
-    determined = await service.determine_canonical_from_candidates(decision)
-    out_decision, decision_changed, _ = await service.map_duplicate_decision(determined)
+    out_decision, decision_changed, _ = await service.map_duplicate_decision(decision)
     assert out_decision.duplicate_determination == DuplicateDetermination.DUPLICATE
     assert decision_changed
     old_decision = await dec_repo.get_by_pk(active_decision.id)

--- a/tests/unit/domain/references/test_service.py
+++ b/tests/unit/domain/references/test_service.py
@@ -16,17 +16,21 @@ from app.core.exceptions import (
     SQLNotFoundError,
 )
 from app.domain.references.models.models import (
+    CandidateSelectionDiagnostics,
+    CandidateSelectionResult,
     DuplicateDetermination,
     Enhancement,
     EnhancementRequest,
     EnhancementRequestSearchStatus,
     ExternalIdentifierAdapter,
+    InputSearchability,
     LinkedExternalIdentifier,
     PendingEnhancement,
     PendingEnhancementStatus,
     Reference,
     ReferenceDuplicateDecision,
     ReferenceWithChangeset,
+    RetrievalPolicyName,
     RobotAutomationPercolationResult,
     RobotEnhancementBatch,
     SearchQuery,
@@ -81,6 +85,107 @@ async def test_get_reference_not_found(fake_repository, fake_uow):
     dummy_id = uuid7()
     with pytest.raises(SQLNotFoundError):
         await service.get_reference(dummy_id)
+
+
+@pytest.fixture
+def duplicate_processing_service(
+    fake_repository, fake_uow, monkeypatch
+) -> tuple[ReferenceService, ReferenceDuplicateDecision]:
+    """Build duplicate-processing collaborators shared by orchestration tests."""
+    from app.domain.references import service as reference_service_module
+
+    monkeypatch.setattr(
+        reference_service_module.settings, "trusted_unique_identifier_types", []
+    )
+    decision = ReferenceDuplicateDecision(
+        reference_id=uuid7(),
+        duplicate_determination=DuplicateDetermination.PENDING,
+    )
+    service = ReferenceService(
+        ReferenceAntiCorruptionService(fake_repository()), fake_uow(), fake_uow()
+    )
+    service._deduplication_service.select_candidate_canonicals = AsyncMock()  # type: ignore[method-assign]  # noqa: SLF001
+    service._deduplication_service.determine_canonical_from_candidates = (  # type: ignore[method-assign]  # noqa: SLF001
+        AsyncMock()
+    )
+    service._deduplication_service.map_duplicate_decision = AsyncMock(  # type: ignore[method-assign]  # noqa: SLF001
+        return_value=(decision, False, None)
+    )
+    service.apply_reference_duplicate_decision_side_effects = AsyncMock()  # type: ignore[method-assign]
+    return service, decision
+
+
+@pytest.mark.asyncio
+async def test_process_duplicate_decision_passes_full_candidate_selection(
+    duplicate_processing_service, monkeypatch
+):
+    from app.domain.references import service as reference_service_module
+
+    monkeypatch.setattr(
+        reference_service_module.settings.feature_flags,
+        "enable_canonical_candidate_search",
+        True,
+    )
+    service, decision = duplicate_processing_service
+    determined = decision.model_copy(
+        update={"duplicate_determination": DuplicateDetermination.UNSEARCHABLE}
+    )
+    candidate_selection = CandidateSelectionResult(
+        retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
+        index_version="reference_v3",
+        k_requested=10,
+        input_searchability=InputSearchability(searchable=True, reason="ok"),
+        diagnostics=CandidateSelectionDiagnostics(candidate_count=0),
+        candidates=[],
+    )
+    service._deduplication_service.select_candidate_canonicals = AsyncMock(  # noqa: SLF001
+        return_value=candidate_selection
+    )
+    service._deduplication_service.determine_canonical_from_candidates = (  # noqa: SLF001
+        AsyncMock(return_value=determined)
+    )
+    service._deduplication_service.map_duplicate_decision = AsyncMock(  # noqa: SLF001
+        return_value=(determined, False, None)
+    )
+    service.apply_reference_duplicate_decision_side_effects = AsyncMock()  # type: ignore[method-assign]
+
+    await service.process_reference_duplicate_decision(decision)
+
+    service._deduplication_service.select_candidate_canonicals.assert_awaited_once_with(  # noqa: SLF001
+        decision.reference_id
+    )
+    service._deduplication_service.determine_canonical_from_candidates.assert_awaited_once_with(  # noqa: SLF001
+        decision,
+        candidate_selection,
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_duplicate_decision_skips_selection_when_disabled(
+    duplicate_processing_service, monkeypatch
+):
+    from app.domain.references import service as reference_service_module
+
+    monkeypatch.setattr(
+        reference_service_module.settings.feature_flags,
+        "enable_canonical_candidate_search",
+        False,
+    )
+    service, decision = duplicate_processing_service
+
+    await service.process_reference_duplicate_decision(decision)
+
+    service._deduplication_service.select_candidate_canonicals.assert_not_awaited()  # noqa: SLF001
+    service._deduplication_service.determine_canonical_from_candidates.assert_not_awaited()  # noqa: SLF001
+    mapped_decision = (
+        service._deduplication_service.map_duplicate_decision.await_args.args[  # noqa: SLF001
+            0
+        ]
+    )
+    assert (
+        mapped_decision.duplicate_determination is DuplicateDetermination.UNSEARCHABLE
+    )
+    assert mapped_decision.detail == "Canonical candidate search is disabled."
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #876

## Outcome

Candidate selection now uses the configured production retrieval policy and returns the complete, non-persisted candidate set required by later evaluation and scoring work.

The Candidate Selection API and automatic path share the same policy resolution, eligibility rules, identifier union and Elasticsearch retrieval behaviour.

## What changed

- Added the stable `candidate_selection_v1` production policy, matching [#819's selected retrieval shape](https://github.com/destiny-evidence/destiny-repository/issues/819#issuecomment-5099312229):
  - soft publication-year decay
  - non-fuzzy title matching
  - publication year required for the Elasticsearch route
  - exact identifier union enabled
- Made the default retrieval policy and candidate count configurable through `DEDUP_SCORING`.
- Set the defaults to `candidate_selection_v1` and `k=10`.
- Kept rollback to `current_fuzzy_v1` available through configuration alone.
- Made automatic candidate selection return `CandidateSelectionResult`, including candidate routes, retrieval policy, index version, input searchability and retrieval diagnostics.
- Removed the interim `NOMINATED` decision and candidate-ID writes.
- Unified Elasticsearch and exact-identifier candidates by canonical ID while retaining every matching route. The resulting union may exceed `k`.
- Kept community-bound canonicals eligible for retrieval.
- Kept exact identifier matching available when the input cannot use the Elasticsearch route.
- Kept exact Elasticsearch hit counts enabled for retrieval diagnostics.
- Passed the complete candidate-selection result into the temporary determination step.
- Confined placeholder determination behaviour to tests. Non-test environments remain `UNSEARCHABLE` until the deep-deduplication assessment path is enabled.
- When candidate search is disabled, the existing decision is marked `UNSEARCHABLE` without running retrieval.

The trusted OpenAlex identifier shortcut remains enabled and unchanged. This PR does not enable automatic merging or switch off that shortcut.

The placeholder determinator is deliberately temporary. #874 replaces it with the write-free deep-deduplication assessment path using a stand-in scorer; #887 later integrates the released Deduper.

## Verification

- Full default suite: 1,041 passed, 1 intentionally skipped
- Candidate Selection end-to-end tests: 9 passed
- Changed-file linting, formatting and type checks passed

The skipped test is a long-running 100,000-reference SQL performance test that is deliberately excluded from regular test runs.
