### PR TITLE
Add reference migrator CLI utility

### DIFF
--- a/app/domain/references/models/validators.py
+++ b/app/domain/references/models/validators.py
@@ -42,6 +42,10 @@ class ReferenceFileInputValidator(BaseModel):
     )
     identifiers: list[JSON] = Field(min_length=1)
     enhancements: list[JSON] = Field(default_factory=list)
+    id: UUID | None = Field(
+        default=None,
+        description="Accepted but ignored.",
+    )
 
     model_config = ConfigDict(extra="forbid")
 

--- a/cli/migrate_references.py
+++ b/cli/migrate_references.py
@@ -1,0 +1,214 @@
+"""
+A utility to copy references from one environment into another.
+
+Actions:
+1. Export the references from the source, in chunks
+2. Register each export file as a batch of one import record in the destination
+3. Finalise the record and summarise each batch
+
+Export files are passed on by URL, never rewritten.
+
+*NOTE* This is lossy:
+- ``derived_from``, ``robot_version``, all ``id``s and all timestamps are dropped
+- duplicate clusters collapse into one reference holding the union of their content
+- the destination re-runs deduplication over its own corpus
+
+*BONUS*: It's totally valid to have a local `dest` if you want some remote references!
+"""
+
+# ruff: noqa: T201
+import sys
+import time
+from typing import TYPE_CHECKING
+
+import httpx
+from destiny_sdk.references import ExportStatus, ReferenceExportRead
+
+from app.core.config import Environment
+from app.utils.lists import list_chunker
+from cli.client import ApiArgumentParser, get_client
+from cli.post_import_file import (
+    finalise_import_record,
+    poll_and_summarise,
+    register_import_batch,
+    register_import_record,
+)
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+_DEFAULT_EXPORT_CHUNK_SIZE = 10_000
+
+
+def request_export(
+    client: httpx.Client,
+    reference_ids: list[str],
+    poll_interval: float,
+    max_polls: int,
+) -> ReferenceExportRead:
+    """Queue an export of the given references and poll it to completion."""
+    response = client.post("/references/exports/", json=reference_ids)
+    response.raise_for_status()
+    export = ReferenceExportRead.model_validate(response.json())
+    print(f"Export {export.id} queued for {len(reference_ids)} references.")
+
+    for _ in range(max_polls):
+        if export.status in (ExportStatus.COMPLETED, ExportStatus.FAILED):
+            break
+        time.sleep(poll_interval)
+        response = client.get(f"/references/exports/{export.id}/")
+        response.raise_for_status()
+        export = ReferenceExportRead.model_validate(response.json())
+        print(f"Export {export.id} status: {export.status}")
+    else:
+        msg = f"Export {export.id} did not complete after {max_polls} polls."
+        raise TimeoutError(msg)
+
+    if export.status is ExportStatus.FAILED or not export.result_url:
+        msg = f"Export {export.id} failed: {export.error}"
+        raise RuntimeError(msg)
+
+    print(f"Export {export.id} complete: {export.n_references} references.")
+    return export
+
+
+def migrate_references(  # noqa: PLR0913
+    source_client: httpx.Client,
+    dest_client: httpx.Client,
+    source_env: Environment,
+    reference_ids: list[str],
+    notes: str,
+    export_chunk_size: int = _DEFAULT_EXPORT_CHUNK_SIZE,
+    poll_interval: float = 5,
+    max_polls: int = 60,
+    *,
+    dry_run: bool = False,
+) -> None:
+    """Copy the given references from the source environment to the destination."""
+    reference_ids = list(dict.fromkeys(reference_ids))
+    chunks = list(list_chunker(reference_ids, export_chunk_size))
+
+    if dry_run:
+        print(
+            f"DRY-RUN: would export {len(reference_ids)} references from the source "
+            f"in {len(chunks)} chunk(s) and import them as {len(chunks)} batch(es)."
+        )
+        return
+
+    import_record = register_import_record(
+        dest_client,
+        expected_reference_count=len(reference_ids),
+        processor_name="cli.migrate_references",
+        processor_version="1.0.0",
+        source_name=f"destiny-repository-{source_env.value}",
+        notes=notes,
+    )
+
+    # A chunk at a time: the signed URLs in each export are short lived, so hand
+    # them over as they complete rather than banking them all up front.
+    batch_ids: list[UUID] = []
+    for i, chunk in enumerate(chunks, start=1):
+        print(f"\nChunk {i}/{len(chunks)} ({len(chunk)} references):")
+        export = request_export(source_client, chunk, poll_interval, max_polls)
+        batch = register_import_batch(
+            dest_client, import_record.id, str(export.result_url)
+        )
+        batch_ids.append(batch.id)
+
+    finalise_import_record(dest_client, import_record.id)
+
+    for batch_id in batch_ids:
+        poll_and_summarise(
+            dest_client,
+            import_record.id,
+            batch_id,
+            poll_interval=poll_interval,
+        )
+
+    print(f"\nMigration complete under import record {import_record.id}.")
+
+
+def argument_parser() -> ApiArgumentParser:
+    """Parse the source and destination environments and the id file."""
+    parser = ApiArgumentParser(
+        description=(
+            "Copies references from --env into --dest-env, which may not be "
+            "production."
+        )
+    )
+
+    parser.add_argument(
+        "--reference-id-file",
+        required=True,
+        help="Path to a file of newline-delimited reference ids in the source.",
+    )
+    parser.add_argument(
+        "--dest-env",
+        type=Environment,
+        choices=[env for env in Environment if env is not Environment.PRODUCTION],
+        required=True,
+        help="Environment to migrate into. Cannot be production.",
+    )
+    parser.add_argument(
+        "--notes",
+        default=None,
+        help="Notes for the destination import record. Defaults to a summary.",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=float,
+        default=5,
+        help="Seconds to wait between status checks (default 5).",
+    )
+    parser.add_argument(
+        "--max-polls",
+        type=int,
+        default=60,
+        help="Status checks to make per export before giving up (default 60).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would move, without moving it.",
+    )
+
+    return parser
+
+
+if __name__ == "__main__":
+    parser = argument_parser()
+    args = parser.parse_args()
+
+    try:
+        with open(args.reference_id_file) as ref_id_file:  # noqa: PTH123
+            reference_ids = [
+                line.strip() for line in ref_id_file.read().splitlines() if line.strip()
+            ]
+        if not reference_ids:
+            msg = f"No reference ids found in {args.reference_id_file}."
+            raise ValueError(msg)  # noqa: TRY301
+
+        print(
+            f"Migrating {len(reference_ids)} references "
+            f"{args.env.value} -> {args.dest_env.value}."
+        )
+
+        with (
+            args.client as source_client,
+            get_client(args.dest_env) as dest_client,
+        ):
+            migrate_references(
+                source_client=source_client,
+                dest_client=dest_client,
+                source_env=args.env,
+                reference_ids=reference_ids,
+                notes=args.notes
+                or f"Migrated from {args.env.value} via cli.migrate_references.",
+                poll_interval=args.poll_interval,
+                max_polls=args.max_polls,
+                dry_run=args.dry_run,
+            )
+
+    except (httpx.HTTPError, OSError, RuntimeError, TimeoutError, ValueError) as exc:
+        print(f"Migration failed: {exc}")
+        sys.exit(1)

--- a/cli/migrate_references.py
+++ b/cli/migrate_references.py
@@ -79,7 +79,7 @@ def migrate_references(  # noqa: PLR0913
     reference_ids: list[str],
     notes: str,
     export_chunk_size: int = _DEFAULT_EXPORT_CHUNK_SIZE,
-    poll_interval: float = 5,
+    poll_interval: float = 10,
     max_polls: int = 60,
     *,
     dry_run: bool = False,
@@ -157,8 +157,8 @@ def argument_parser() -> ApiArgumentParser:
     parser.add_argument(
         "--poll-interval",
         type=float,
-        default=5,
-        help="Seconds to wait between status checks (default 5).",
+        default=10,
+        help="Seconds to wait between status checks (default 10).",
     )
     parser.add_argument(
         "--max-polls",

--- a/tests/cli/test_migrate_references.py
+++ b/tests/cli/test_migrate_references.py
@@ -1,0 +1,161 @@
+"""Tests for the reference migration utility's safeguard and export handoff."""
+
+import json
+from uuid import UUID, uuid7
+
+import httpx
+import pytest
+from destiny_sdk.imports import ImportBatchStatus
+from destiny_sdk.references import ExportStatus
+from pytest_httpx import HTTPXMock
+
+from app.core.config import Environment
+from cli.client import get_client
+from cli.migrate_references import argument_parser, migrate_references
+
+SOURCE_URL = "https://source.example.com/v1"
+DEST_URL = "https://dest.example.com/v1"
+RESULT_URL = "https://source.blob.core.windows.net/exports/abc.jsonl?sig=redacted"
+
+
+def _client(url: str) -> httpx.Client:
+    """
+    Build a client for an arbitrary base URL with no authentication.
+
+    Must stay on a local environment. A real one attaches the SDK's OAuth
+    middleware, which acquires a token on every request over its own connection
+    — outside the transport ``pytest_httpx`` patches — so these tests would
+    prompt an interactive login.
+    """
+    return get_client(Environment.LOCAL, url)
+
+
+def _mock_export(httpx_mock: HTTPXMock) -> None:
+    """Stub a source export that completes immediately."""
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{SOURCE_URL}/references/exports/",
+        json={
+            "id": str(uuid7()),
+            "status": ExportStatus.COMPLETED.value,
+            "export_format": "jsonl",
+            "result_url": RESULT_URL,
+            "n_references": 2,
+            "error": None,
+        },
+    )
+
+
+def _mock_import(httpx_mock: HTTPXMock, record_id: UUID, batch_ids: list[UUID]) -> None:
+    """Stub the destination's record, batch, finalise and summary endpoints."""
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{DEST_URL}/imports/records/",
+        json={
+            "id": str(record_id),
+            "searched_at": "2026-08-06T00:00:00Z",
+            "processor_name": "cli.migrate_references",
+            "processor_version": "1.0.0",
+            "expected_reference_count": 2,
+            "source_name": "destiny-repository-production",
+            "status": "created",
+        },
+    )
+    for batch_id in batch_ids:
+        batch = {
+            "id": str(batch_id),
+            "storage_url": RESULT_URL,
+            "import_record_id": str(record_id),
+        }
+        httpx_mock.add_response(
+            method="POST",
+            url=f"{DEST_URL}/imports/records/{record_id}/batches/",
+            json=batch | {"status": ImportBatchStatus.CREATED.value},
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{DEST_URL}/imports/records/{record_id}/batches/{batch_id}/",
+            json=batch | {"status": ImportBatchStatus.COMPLETED.value},
+        )
+        httpx_mock.add_response(
+            method="GET",
+            url=f"{DEST_URL}/imports/records/{record_id}/batches/{batch_id}/summary/",
+            json=batch
+            | {
+                "import_batch_id": str(batch_id),
+                "import_batch_status": ImportBatchStatus.COMPLETED.value,
+                "results": {"completed": 2},
+                "failure_details": None,
+            },
+        )
+    httpx_mock.add_response(
+        method="PATCH",
+        url=f"{DEST_URL}/imports/records/{record_id}/finalise/",
+        json={},
+    )
+
+
+def test_production_destination_is_not_a_valid_choice(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The one safeguard: argparse won't accept production as a destination."""
+    with pytest.raises(SystemExit):
+        argument_parser().parse_args(
+            ["--reference-id-file", "ids.txt", "--dest-env", "production"]
+        )
+
+    assert "invalid choice: 'production'" in capsys.readouterr().err
+
+
+def test_signed_export_url_is_handed_over_unmodified(httpx_mock: HTTPXMock) -> None:
+    """The destination imports the source's file by URL; nothing is rewritten."""
+    record_id, batch_id = uuid7(), uuid7()
+    _mock_export(httpx_mock)
+    _mock_import(httpx_mock, record_id, [batch_id])
+
+    with _client(SOURCE_URL) as source_client, _client(DEST_URL) as dest_client:
+        migrate_references(
+            source_client=source_client,
+            dest_client=dest_client,
+            source_env=Environment.PRODUCTION,
+            reference_ids=[str(uuid7()), str(uuid7())],
+            notes="test",
+            poll_interval=0,
+        )
+
+    batch_request = next(
+        request
+        for request in httpx_mock.get_requests()
+        if request.method == "POST" and request.url.path.endswith("/batches/")
+    )
+    assert json.loads(batch_request.content)["storage_url"] == RESULT_URL
+
+
+def test_ids_beyond_the_chunk_size_become_separate_batches(
+    httpx_mock: HTTPXMock,
+) -> None:
+    """Chunking splits one import record into a batch per export."""
+    record_id = uuid7()
+    batch_ids = [uuid7(), uuid7()]
+    for _ in batch_ids:
+        _mock_export(httpx_mock)
+    _mock_import(httpx_mock, record_id, batch_ids)
+
+    with _client(SOURCE_URL) as source_client, _client(DEST_URL) as dest_client:
+        migrate_references(
+            source_client=source_client,
+            dest_client=dest_client,
+            source_env=Environment.PRODUCTION,
+            reference_ids=[str(uuid7()) for _ in range(3)],
+            notes="test",
+            export_chunk_size=2,
+            poll_interval=0,
+        )
+
+    export_sizes = [
+        len(json.loads(request.content))
+        for request in httpx_mock.get_requests()
+        if request.method == "POST"
+        and request.url.path.endswith("/references/exports/")
+    ]
+    assert export_sizes == [2, 1]

--- a/tests/unit/domain/references/models/test_validators.py
+++ b/tests/unit/domain/references/models/test_validators.py
@@ -1,10 +1,14 @@
 from uuid import uuid7
 
+import destiny_sdk
 import pytest
 
 from app.core.exceptions import ParseError
 from app.domain.references.models.models import ExternalIdentifierType
-from app.domain.references.models.validators import parse_identifier_lookup_from_string
+from app.domain.references.models.validators import (
+    ReferenceCreateResult,
+    parse_identifier_lookup_from_string,
+)
 
 
 @pytest.mark.parametrize(
@@ -81,3 +85,46 @@ def test_parse_identifier_lookup_from_string_cases(input_str, expected):
         assert res.identifier == identifier
         assert res.identifier_type == expected["identifier_type"]
         assert res.other_identifier_name == expected["other_identifier_name"]
+
+
+def test_exported_reference_imports_without_rewriting():
+    """A JSONL line straight from an export endpoint parses, ignoring its id."""
+    reference_id = uuid7()
+    exported = destiny_sdk.references.Reference(
+        id=reference_id,
+        identifiers=[{"identifier_type": "doi", "identifier": "10.1000/xyz"}],
+        enhancements=[
+            destiny_sdk.enhancements.Enhancement(
+                id=uuid7(),
+                reference_id=reference_id,
+                source="test-source",
+                visibility="public",
+                content={
+                    "enhancement_type": "abstract",
+                    "process": "closed_api",
+                    "abstract": "hello",
+                },
+            )
+        ],
+    ).to_jsonl()
+
+    result = ReferenceCreateResult.from_raw(exported, 1)
+
+    assert result.errors == []
+    assert result.reference is not None
+    assert result.reference.identifiers[0].identifier == "10.1000/xyz"
+    assert result.reference.enhancements[0].source == "test-source"
+    # ReferenceFileInput carries no id, so the exported one cannot be adopted.
+    assert "id" not in result.reference.model_dump()
+
+
+def test_unknown_top_level_field_is_still_rejected():
+    """Accepting `id` must not open the schema up to arbitrary fields."""
+    result = ReferenceCreateResult.from_raw(
+        '{"identifiers": [{"identifier_type": "doi", "identifier": "10.1/a"}],'
+        ' "nonsense": 1}',
+        1,
+    )
+
+    assert result.reference is None
+    assert "nonsense" in result.error_str


### PR DESCRIPTION
Adds CLI utility to migrate a set of references between environments (but never to production).

See docstring for more.

Required for #837 in order to hydrate staging with references to attach enhancements too (they all exist solely in production). Likely has many other uses!

A future implementer could/should expand this to a search interface. I'd be interested in looking at an easy way to flip _all_ CLI scripts between id-list and search-query inputs.