### PR TITLE
Record duplicate decision provenance and never replace a person's decision automatically

### DIFF
--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -180,6 +180,34 @@ class DuplicateDetermination(StrEnum):
         }
 
 
+class DuplicateDecisionAuthority(StrEnum):
+    """Who had authority for a duplicate decision."""
+
+    UNCLASSIFIED = auto()
+    """The authority of a historical decision has not been established."""
+    PERSON = auto()
+    """A person made the decision."""
+    SYSTEM = auto()
+    """The repository made the decision automatically."""
+
+
+class DuplicateDecisionTrigger(StrEnum):
+    """The event that caused a duplicate decision to be created."""
+
+    UNCLASSIFIED = auto()
+    """The trigger for a historical decision has not been established."""
+    MANUAL_API = auto()
+    """The manual duplicate-decision API created the decision."""
+    IMPORT = auto()
+    """Reference import processing created the decision."""
+    ENHANCEMENT = auto()
+    """Reserved. No path creates enhancement-triggered decisions yet."""
+    EXPLICIT_RERUN = auto()
+    """An explicit deduplication rerun caused the decision."""
+    MIGRATION = auto()
+    """A data migration classified or created the decision."""
+
+
 class Reference(
     DomainBaseModel,
     ProjectedBaseModel,  # References can self-project to the same structure
@@ -1142,6 +1170,14 @@ class ReferenceDuplicateDecision(DomainBaseModel, SQLAttributeMixin):
     """Model representing a decision on whether a reference is a duplicate."""
 
     reference_id: UUID = Field(description="The ID of the reference being evaluated.")
+    decision_authority: DuplicateDecisionAuthority = Field(
+        default=DuplicateDecisionAuthority.UNCLASSIFIED,
+        description="Whether a person or the system made the decision.",
+    )
+    decision_trigger: DuplicateDecisionTrigger = Field(
+        default=DuplicateDecisionTrigger.UNCLASSIFIED,
+        description="The event that caused the decision.",
+    )
     enhancement_id: UUID | None = Field(
         default=None,
         description=(
@@ -1168,6 +1204,20 @@ class ReferenceDuplicateDecision(DomainBaseModel, SQLAttributeMixin):
         default=None,
         description="Optional additional detail about the decision.",
     )
+
+    @model_validator(mode="after")
+    def check_provenance_is_classified_together(self) -> Self:
+        """Require authority and trigger to be classified together."""
+        authority_unclassified = (
+            self.decision_authority == DuplicateDecisionAuthority.UNCLASSIFIED
+        )
+        trigger_unclassified = (
+            self.decision_trigger == DuplicateDecisionTrigger.UNCLASSIFIED
+        )
+        if authority_unclassified != trigger_unclassified:
+            msg = "decision_authority and decision_trigger must be classified together"
+            raise ValueError(msg)
+        return self
 
     @model_validator(mode="after")
     def check_canonical_reference_id_populated_iff_duplicate(self) -> Self:

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -202,10 +202,8 @@ class DuplicateDecisionTrigger(StrEnum):
     """Reference import processing created the decision."""
     ENHANCEMENT = auto()
     """Reserved. No path creates enhancement-triggered decisions yet."""
-    EXPLICIT_RERUN = auto()
-    """An explicit deduplication rerun caused the decision."""
-    MIGRATION = auto()
-    """A data migration classified or created the decision."""
+    INVOKE_API = auto()
+    """The duplicate-decisions invoke API created the decision."""
 
 
 class Reference(

--- a/app/domain/references/models/sql.py
+++ b/app/domain/references/models/sql.py
@@ -24,6 +24,8 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.core.exceptions import SQLPreloadError, UnstoredFullTextError
 from app.domain.references.models.models import (
     AnnotationFilter,
+    DuplicateDecisionAuthority,
+    DuplicateDecisionTrigger,
     DuplicateDetermination,
     EnhancementRequestSearchStatus,
     EnhancementRequestStatus,
@@ -683,6 +685,20 @@ class ReferenceDuplicateDecision(
     # NB not foreign keys as can also refer to a reference that is not
     # imported, for instance an exact duplicate.
     reference_id: Mapped[UUID] = mapped_column(SQL_UUID, nullable=False)
+    # server_default is permanent: a rolling deploy serves the old revision, whose
+    # inserts omit these columns, while the migration has already run.
+    decision_authority: Mapped[DuplicateDecisionAuthority] = mapped_column(
+        String,
+        nullable=False,
+        default=DuplicateDecisionAuthority.UNCLASSIFIED,
+        server_default=DuplicateDecisionAuthority.UNCLASSIFIED,
+    )
+    decision_trigger: Mapped[DuplicateDecisionTrigger] = mapped_column(
+        String,
+        nullable=False,
+        default=DuplicateDecisionTrigger.UNCLASSIFIED,
+        server_default=DuplicateDecisionTrigger.UNCLASSIFIED,
+    )
     enhancement_id: Mapped[UUID | None] = mapped_column(
         SQL_UUID, ForeignKey("enhancement.id"), nullable=True
     )
@@ -733,6 +749,8 @@ class ReferenceDuplicateDecision(
         return cls(
             id=domain_obj.id,
             reference_id=domain_obj.reference_id,
+            decision_authority=domain_obj.decision_authority,
+            decision_trigger=domain_obj.decision_trigger,
             enhancement_id=domain_obj.enhancement_id,
             active_decision=domain_obj.active_decision,
             candidate_canonical_ids=domain_obj.candidate_canonical_ids,
@@ -749,6 +767,8 @@ class ReferenceDuplicateDecision(
         return DomainReferenceDuplicateDecision(
             id=self.id,
             reference_id=self.reference_id,
+            decision_authority=self.decision_authority,
+            decision_trigger=self.decision_trigger,
             enhancement_id=self.enhancement_id,
             active_decision=self.active_decision,
             candidate_canonical_ids=self.candidate_canonical_ids,

--- a/app/domain/references/service.py
+++ b/app/domain/references/service.py
@@ -27,6 +27,8 @@ from app.domain.references.models.models import (
     CandidateSelectionRequest,
     CandidateSelectionResult,
     CrossFacetCell,
+    DuplicateDecisionAuthority,
+    DuplicateDecisionTrigger,
     DuplicateDetermination,
     Enhancement,
     EnhancementRequest,
@@ -659,15 +661,14 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
                 reference_id=str(reference.id),
                 canonical_reference_id=str(canonical_reference.id),
             )
-            await self._deduplication_service.register_duplicate_decision_for_reference(
+            await self._deduplication_service.register_exact_duplicate_import_decision(
                 reference_id=reference.id,
-                duplicate_determination=DuplicateDetermination.EXACT_DUPLICATE,
                 canonical_reference_id=canonical_reference.id,
             )
             return reference_create_result
 
         duplicate_decision = (
-            await self._deduplication_service.register_duplicate_decision_for_reference(
+            await self._deduplication_service.register_pending_import_decision(
                 reference_id=reference.id
             )
         )
@@ -1420,6 +1421,8 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
             [
                 ReferenceDuplicateDecision(
                     reference_id=reference_id,
+                    decision_authority=DuplicateDecisionAuthority.SYSTEM,
+                    decision_trigger=DuplicateDecisionTrigger.EXPLICIT_RERUN,
                     duplicate_determination=DuplicateDetermination.PENDING,
                 )
                 for reference_id in reference_ids.reference_ids

--- a/app/domain/references/service.py
+++ b/app/domain/references/service.py
@@ -1412,17 +1412,17 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
         return updated, expiry
 
     @sql_unit_of_work
-    async def add_pending_duplicate_decisions_for_reference_ids(
+    async def register_pending_invoke_api_decisions(
         self,
         reference_ids: ReferenceIds,
     ) -> list[ReferenceDuplicateDecision]:
-        """Add a reference duplicate decision."""
+        """Register system decisions created through the invoke API."""
         return await self.sql_uow.reference_duplicate_decisions.add_bulk(
             [
                 ReferenceDuplicateDecision(
                     reference_id=reference_id,
                     decision_authority=DuplicateDecisionAuthority.SYSTEM,
-                    decision_trigger=DuplicateDecisionTrigger.EXPLICIT_RERUN,
+                    decision_trigger=DuplicateDecisionTrigger.INVOKE_API,
                     duplicate_determination=DuplicateDetermination.PENDING,
                 )
                 for reference_id in reference_ids.reference_ids
@@ -1435,7 +1435,7 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
     ) -> None:
         """Invoke deduplication for a list of references."""
         reference_duplicate_decisions = (
-            await self.add_pending_duplicate_decisions_for_reference_ids(
+            await self.register_pending_invoke_api_decisions(
                 reference_ids,
             )
         )

--- a/app/domain/references/services/anti_corruption_service.py
+++ b/app/domain/references/services/anti_corruption_service.py
@@ -10,6 +10,8 @@ from app.core.exceptions import DomainToSDKError, SDKToDomainError
 from app.domain.references.models.models import (
     AnnotationFilter,
     CrossFacetCell,
+    DuplicateDecisionAuthority,
+    DuplicateDecisionTrigger,
     Enhancement,
     EnhancementRequest,
     EnhancementRequestSearchStatus,
@@ -682,6 +684,8 @@ class ReferenceAntiCorruptionService(GenericAntiCorruptionService):
         try:
             reference_duplicate_decision = ReferenceDuplicateDecision(
                 reference_id=make_duplicate_decision.reference_id,
+                decision_authority=DuplicateDecisionAuthority.PERSON,
+                decision_trigger=DuplicateDecisionTrigger.MANUAL_API,
                 duplicate_determination=make_duplicate_decision.duplicate_determination,
                 canonical_reference_id=make_duplicate_decision.canonical_reference_id,
                 detail=make_duplicate_decision.detail,
@@ -702,5 +706,7 @@ class ReferenceAntiCorruptionService(GenericAntiCorruptionService):
             outcome=decision.duplicate_determination,
             canonical_reference_id=decision.canonical_reference_id,
             active_decision=decision.active_decision,
+            decision_authority=decision.decision_authority,
+            decision_trigger=decision.decision_trigger,
             detail=decision.detail,
         )

--- a/app/domain/references/services/deduplication_service.py
+++ b/app/domain/references/services/deduplication_service.py
@@ -737,7 +737,7 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
         Deduplicate the given reference using trusted unique identifiers.
 
         This shortcuts the regular deduplication flow. It runs whenever a pending
-        decision is processed, which is on import and on explicit rerun.
+        decision is processed, which is on import and through the invoke API.
 
         This is a very powerful operation and should only be used with identifier types
         that are certain to be unique and reliable. Misuse can lead to incorrect

--- a/app/domain/references/services/deduplication_service.py
+++ b/app/domain/references/services/deduplication_service.py
@@ -1,6 +1,6 @@
 """Service for managing reference duplicate detection."""
 
-from typing import Literal, assert_never
+from typing import assert_never
 from uuid import UUID
 
 from opentelemetry import trace
@@ -19,6 +19,8 @@ from app.domain.references.models.models import (
     CandidateSelectionInput,
     CandidateSelectionRequest,
     CandidateSelectionResult,
+    DuplicateDecisionAuthority,
+    DuplicateDecisionTrigger,
     DuplicateDetermination,
     EnhancementType,
     ExternalIdentifierType,
@@ -459,56 +461,57 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
                 return candidate
         return None
 
-    async def register_duplicate_decision_for_reference(
+    async def register_pending_import_decision(
         self,
         reference_id: UUID,
-        enhancement_id: UUID | None = None,
-        duplicate_determination: Literal[DuplicateDetermination.EXACT_DUPLICATE]
-        | None = None,
-        canonical_reference_id: UUID | None = None,
     ) -> ReferenceDuplicateDecision:
         """
-        Register a duplicate decision for a reference.
+        Register the initial PENDING decision for a newly ingested reference.
 
-        :param reference: The reference to register the duplicate decision for.
-        :type reference: app.domain.references.models.models.Reference
-        :param enhancement_id: The enhancement ID triggering with the duplicate
-            decision, defaults to None
-        :type enhancement_id: UUID | None, optional
-        :param duplicate_determination: Flag indicating if a reference was an exact
-            duplicate and not imported, defaults to None
-        :type duplicate_determination: Literal[DuplicateDetermination.EXACT_DUPLICATE]
-            | None, optional
-        :param canonical_reference_id: The canonical reference ID this reference is an
-            exact duplicate of, defaults to None
-        :type canonical_reference_id: UUID | None, optional
+        Inserted directly because :meth:`map_duplicate_decision` takes only terminal
+        determinations. Safe to bypass the guard: an inactive row displaces nothing.
+
+        :param reference_id: The reference being ingested.
+        :type reference_id: UUID
         :return: The registered duplicate decision
         :rtype: ReferenceDuplicateDecision
         """
-        if (duplicate_determination is not None) != (
-            canonical_reference_id is not None
-        ):
-            msg = (
-                "Both or neither of duplicate_determination and "
-                "canonical_reference_id must be provided."
-            )
-            raise DeduplicationValueError(msg)
-        _duplicate_determination = (
-            duplicate_determination
-            if duplicate_determination
-            else DuplicateDetermination.PENDING
-        )
-        reference_duplicate_decision = ReferenceDuplicateDecision(
-            reference_id=reference_id,
-            enhancement_id=enhancement_id,
-            duplicate_determination=_duplicate_determination,
-            canonical_reference_id=canonical_reference_id,
-            # If exact duplicate passed in, the decision is terminal and hence active
-            active_decision=_duplicate_determination
-            == DuplicateDetermination.EXACT_DUPLICATE,
-        )
         return await self.sql_uow.reference_duplicate_decisions.add(
-            reference_duplicate_decision
+            ReferenceDuplicateDecision(
+                reference_id=reference_id,
+                decision_authority=DuplicateDecisionAuthority.SYSTEM,
+                decision_trigger=DuplicateDecisionTrigger.IMPORT,
+                duplicate_determination=DuplicateDetermination.PENDING,
+            )
+        )
+
+    async def register_exact_duplicate_import_decision(
+        self,
+        reference_id: UUID,
+        canonical_reference_id: UUID,
+    ) -> ReferenceDuplicateDecision:
+        """
+        Register a terminal EXACT_DUPLICATE decision for a reference not imported.
+
+        Safe to bypass :meth:`map_duplicate_decision`: the reference is never stored
+        as a row of its own, so it cannot already carry a decision to replace.
+
+        :param reference_id: The reference that was not imported.
+        :type reference_id: UUID
+        :param canonical_reference_id: The reference it exactly duplicates.
+        :type canonical_reference_id: UUID
+        :return: The registered duplicate decision
+        :rtype: ReferenceDuplicateDecision
+        """
+        return await self.sql_uow.reference_duplicate_decisions.add(
+            ReferenceDuplicateDecision(
+                reference_id=reference_id,
+                decision_authority=DuplicateDecisionAuthority.SYSTEM,
+                decision_trigger=DuplicateDecisionTrigger.IMPORT,
+                duplicate_determination=DuplicateDetermination.EXACT_DUPLICATE,
+                canonical_reference_id=canonical_reference_id,
+                active_decision=True,
+            )
         )
 
     async def select_candidate_canonicals(
@@ -642,11 +645,31 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
             preload=["duplicate_decision", "duplicate_references"],
         )
         active_decision = reference.duplicate_decision
+        deactivated_decision = None
 
         # Preset to True, will be flipped if not changed
         decision_changed = True
 
+        # Only the resolving branch reactivates: a decoupled proposal left active
+        # would collide with the retained decision on the one-active-decision index.
+        new_decision.active_decision = False
+
         if (
+            active_decision
+            and active_decision.decision_authority == DuplicateDecisionAuthority.PERSON
+            and new_decision.decision_authority == DuplicateDecisionAuthority.SYSTEM
+            and not allow_destructive_decision
+        ):
+            proposed_determination = new_decision.duplicate_determination
+            new_decision.duplicate_determination = DuplicateDetermination.DECOUPLED
+            new_decision.detail = (
+                "Decouple reason: Automatic decisions cannot replace a person-made "
+                "active decision. "
+                f"Proposed determination: {proposed_determination.value}. "
+                + (new_decision.detail if new_decision.detail else "")
+            )
+            decision_changed = False
+        elif (
             active_decision
             and active_decision.duplicate_determination
             == DuplicateDetermination.DUPLICATE
@@ -693,6 +716,7 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
                 ):
                     decision_changed = False
                 active_decision.active_decision = False
+                deactivated_decision = active_decision
             new_decision.active_decision = True
 
         # Update in-place, it's just easier
@@ -702,7 +726,7 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
             new_decision
         )
 
-        return new_decision, decision_changed, active_decision
+        return new_decision, decision_changed, deactivated_decision
 
     async def shortcut_deduplication_using_identifiers(  # noqa: PLR0912
         self,
@@ -712,7 +736,8 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
         """
         Deduplicate the given reference using trusted unique identifiers.
 
-        This shortcuts the regular deduplication flow and is only run on import.
+        This shortcuts the regular deduplication flow. It runs whenever a pending
+        decision is processed, which is on import and on explicit rerun.
 
         This is a very powerful operation and should only be used with identifier types
         that are certain to be unique and reliable. Misuse can lead to incorrect
@@ -884,9 +909,17 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
             decision, _, _ = await self.map_duplicate_decision(
                 ReferenceDuplicateDecision(
                     reference_id=candidate_id,
+                    decision_authority=DuplicateDecisionAuthority.SYSTEM,
+                    # Same processing run as the proxy reference's decision, so the
+                    # same trigger. Legacy decisions have no trigger to copy.
+                    decision_trigger=(
+                        reference_duplicate_decision.decision_trigger
+                        if reference_duplicate_decision.decision_trigger
+                        != DuplicateDecisionTrigger.UNCLASSIFIED
+                        else DuplicateDecisionTrigger.IMPORT
+                    ),
                     duplicate_determination=DuplicateDetermination.DUPLICATE,
                     canonical_reference_id=canonical_id,
-                    active_decision=True,
                     detail=(
                         f"Shortcutted via proxy reference {reference.id} "
                         "with trusted identifier(s)"

--- a/app/migrations/versions/6df1b2b092ed_add_duplicate_decision_provenance.py
+++ b/app/migrations/versions/6df1b2b092ed_add_duplicate_decision_provenance.py
@@ -1,0 +1,81 @@
+"""Add duplicate decision authority and trigger.
+
+Revision ID: 6df1b2b092ed
+Revises: 9b2f1c4d7e83
+Create Date: 2026-08-06 00:00:00.000000+00:00
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "6df1b2b092ed"
+down_revision: Union[str, None] = "9b2f1c4d7e83"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_MANUAL_EEF_DECISIONS = """
+    detail IS NULL
+    AND duplicate_determination IN ('canonical', 'duplicate')
+    AND reference_id IN (
+        SELECT DISTINCT result.reference_id
+        FROM import_result AS result
+        JOIN import_batch AS batch ON batch.id = result.import_batch_id
+        JOIN import_record AS record ON record.id = batch.import_record_id
+        WHERE record.source_name LIKE 'eef-eppi-review-export%'
+          AND result.reference_id IS NOT NULL
+    )
+"""
+
+
+def upgrade() -> None:
+    op.add_column(
+        "reference_duplicate_decision",
+        sa.Column(
+            "decision_authority",
+            sa.String(),
+            nullable=False,
+            server_default="unclassified",
+        ),
+    )
+    op.add_column(
+        "reference_duplicate_decision",
+        sa.Column(
+            "decision_trigger",
+            sa.String(),
+            nullable=False,
+            server_default="unclassified",
+        ),
+    )
+
+    connection = op.get_bind()
+    # Production audit on 2026-08-06 found 1,664 current manual decisions, all
+    # linked to EEF imports. Re-derive the population at deployment for #752/#771.
+    expected = connection.execute(
+        sa.text(
+            "SELECT count(*) FROM reference_duplicate_decision WHERE "
+            + _MANUAL_EEF_DECISIONS
+        )
+    ).scalar_one()
+    result = connection.execute(
+        sa.text(
+            "UPDATE reference_duplicate_decision "
+            "SET decision_authority = 'person', decision_trigger = 'migration' "
+            "WHERE "
+            + _MANUAL_EEF_DECISIONS
+        )
+    )
+    if result.rowcount != expected:
+        msg = f"Expected to classify {expected} manual decisions; updated {result.rowcount}."
+        raise RuntimeError(msg)
+
+    # Server defaults stay: deploy and migrate are unordered jobs, so an old
+    # revision keeps serving and inserting without these columns.
+
+
+def downgrade() -> None:
+    op.drop_column("reference_duplicate_decision", "decision_trigger")
+    op.drop_column("reference_duplicate_decision", "decision_authority")

--- a/app/migrations/versions/6df1b2b092ed_add_duplicate_decision_provenance.py
+++ b/app/migrations/versions/6df1b2b092ed_add_duplicate_decision_provenance.py
@@ -63,7 +63,7 @@ def upgrade() -> None:
     result = connection.execute(
         sa.text(
             "UPDATE reference_duplicate_decision "
-            "SET decision_authority = 'person', decision_trigger = 'migration' "
+            "SET decision_authority = 'person', decision_trigger = 'manual_api' "
             "WHERE "
             + _MANUAL_EEF_DECISIONS
         )

--- a/docs/procedures/deduplication.rst
+++ b/docs/procedures/deduplication.rst
@@ -193,8 +193,8 @@ Decision authority and precedence
 Every duplicate decision records both its authority and its trigger. Authority is
 ``person``, ``system``, or ``unclassified``; historical decisions remain
 ``unclassified`` unless their authority can be established. Triggers distinguish the
-manual API, import processing, explicit reruns, and migrations. The ``enhancement``
-trigger is reserved: no path creates enhancement-triggered decisions today.
+manual API, import processing, and invoke API requests. The ``enhancement`` trigger is
+reserved: no path creates enhancement-triggered decisions today.
 
 An automatic proposal never replaces an active ``person`` decision, even when the
 proposed result is identical. The active decision is left unchanged and the proposal is
@@ -202,22 +202,9 @@ stored as an inactive ``DECOUPLED`` decision for review. Its detail records the 
 determination and reason, while its proposed canonical ID is retained. A person can
 still replace the active decision through the manual endpoint.
 
-Only ``person`` decisions are protected. ``unclassified`` means the authority of a
-decision has not been established, not that a person made it, so automatic decisions
-may replace it. Treating unclassified history as person-made would freeze the corpus
-against reprocessing, and it would misrepresent decisions the system itself made before
-provenance was recorded. Manual decisions that can be reliably identified are
-reclassified to ``person`` by migration before automatic operation resumes.
-
-This matters most for ``UNSEARCHABLE``. That determination records that a processing
-attempt could not reach a duplicate verdict with the route and evidence available, not
-that the reference was judged unique. It is terminal so the task can complete, and it
-remains replaceable when later evidence arrives, which is why the trusted-identifier
-shortcut deliberately pulls unsearchable references into a duplicate graph.
-
-This protection applies to the reference whose active decision would change. A
-person-made canonical remains an eligible target for another reference's automatic
-``DUPLICATE`` decision because the canonical's own decision is not being replaced.
+The protection covers only the reference whose own active decision would change. A
+person-made canonical can still become the target of another reference's automatic
+``DUPLICATE`` decision, because that leaves the canonical's own decision untouched.
 
 
 Action Decision

--- a/docs/procedures/deduplication.rst
+++ b/docs/procedures/deduplication.rst
@@ -176,7 +176,7 @@ If candidate canonicals are found, each is compared in detail against the incomi
 
 This algorithm is still being built out. For now, we have a placeholder that we will update in the future:
 
-.. automethod:: app.domain.references.services.deduplication_service.DeduplicationService.__placeholder_duplicate_determinator
+.. automethod:: app.domain.references.services.deduplication_service.DeduplicationService._placeholder_duplicate_determinator
 
 
 Manual Resolution
@@ -185,6 +185,39 @@ Manual Resolution
 The ``POST /references/duplicate-decisions/`` endpoint provides an interface to manually make duplicate decisions.
 
 This may be useful if the automated process raises a reference for manual review, or if a user simply wants to manually deduplicate references.
+
+
+Decision authority and precedence
+---------------------------------
+
+Every duplicate decision records both its authority and its trigger. Authority is
+``person``, ``system``, or ``unclassified``; historical decisions remain
+``unclassified`` unless their authority can be established. Triggers distinguish the
+manual API, import processing, explicit reruns, and migrations. The ``enhancement``
+trigger is reserved: no path creates enhancement-triggered decisions today.
+
+An automatic proposal never replaces an active ``person`` decision, even when the
+proposed result is identical. The active decision is left unchanged and the proposal is
+stored as an inactive ``DECOUPLED`` decision for review. Its detail records the proposed
+determination and reason, while its proposed canonical ID is retained. A person can
+still replace the active decision through the manual endpoint.
+
+Only ``person`` decisions are protected. ``unclassified`` means the authority of a
+decision has not been established, not that a person made it, so automatic decisions
+may replace it. Treating unclassified history as person-made would freeze the corpus
+against reprocessing, and it would misrepresent decisions the system itself made before
+provenance was recorded. Manual decisions that can be reliably identified are
+reclassified to ``person`` by migration before automatic operation resumes.
+
+This matters most for ``UNSEARCHABLE``. That determination records that a processing
+attempt could not reach a duplicate verdict with the route and evidence available, not
+that the reference was judged unique. It is terminal so the task can complete, and it
+remains replaceable when later evidence arrives, which is why the trusted-identifier
+shortcut deliberately pulls unsearchable references into a duplicate graph.
+
+This protection applies to the reference whose active decision would change. A
+person-made canonical remains an eligible target for another reference's automatic
+``DUPLICATE`` decision because the canonical's own decision is not being replaced.
 
 
 Action Decision
@@ -202,39 +235,45 @@ The bold lines in the flowchart indicate what we expect to be nominal flow.
     flowchart LR
 
         N["New Decision (N)"]
+        C0{"N names a non-canonical reference?"}
         C1{"Active Decision Exists? (A)"}
+        CA{"N System & A Person?"}
         C2{A == N?}
         C3{A Canonical & N Duplicate?}
         C4{N is Canonical?}
-        C5{N's Canonical is Canonical?}
         C6{Reference has duplicates?}
         T[[Activate New Decision]]
         M([Mark for Manual Handling])
+        E["Reject with an error"]
 
-        N ==> C1
-        C1 ==>|Yes| C2
+        N ==> C0
+        C0 -->|Yes| E
+        C0 ==>|No| C1
+        C1 ==>|Yes| CA
         C1 -->|No| C4
+        CA -->|Yes| M
+        CA ==>|No| C2
         C2 ==>|Yes| T
         C2 -->|No| C3
         C3 ==>|Yes| T
         C3 -->|No| M
-        C4 -->|No| C5
         C4 ==>|Yes| T
-        C5 -->|No| M
-        C5 ==>|Yes| C6
+        C4 -->|No| C6
         C6 -->|Yes| M
         C6 ==>|No| T
         M ~~~ T
 
 There are three cases where the new decision is not automatically activated:
 
-1. The active decision is duplicate and the new decision is canonical or a duplicate of a different reference. This is a destructive change to the existing canonical reference, which may have implications for its enhancements, and needs to be reviewed in context.
+1. An automatic proposal would replace a person-made active decision. This applies even when the proposed result is identical.
 
-2. The proposed canonical reference is not actually canonical.
+2. The active decision is duplicate and the new decision is canonical or a duplicate of a different reference. This is a destructive change to the existing canonical reference, which may have implications for its enhancements, and needs to be reviewed in context.
 
 3. The reference being marked as a duplicate already has duplicates pointing to it (which would create a chaining situation).
 
-These are marked as ``DECOUPLED`` for manual review via the ``POST /references/duplicate-decisions/`` endpoint.
+These are marked as ``DECOUPLED`` for manual review via the ``POST /references/duplicate-decisions/`` endpoint. The decoupled decision is stored inactive, so the reference keeps whichever decision was already active.
+
+A proposal naming a canonical reference that is not itself canonical is not decoupled. It is rejected outright, and the manual endpoint returns ``422``.
 
 .. _deduplicated-projection:
 

--- a/libs/sdk/pyproject.toml
+++ b/libs/sdk/pyproject.toml
@@ -36,7 +36,7 @@ license = "Apache-2.0"
 name = "destiny_sdk"
 readme = "README.md"
 requires-python = ">=3.12, <4"
-version = "0.14.1"
+version = "0.14.2"
 
 [project.optional-dependencies]
 labs = []

--- a/libs/sdk/src/destiny_sdk/deduplication.py
+++ b/libs/sdk/src/destiny_sdk/deduplication.py
@@ -17,6 +17,34 @@ class ManualDuplicateDetermination(StrEnum):
     """The reference is not a duplicate of another reference."""
 
 
+class DuplicateDecisionAuthority(StrEnum):
+    """Who had authority for a duplicate decision."""
+
+    UNCLASSIFIED = auto()
+    """The authority of a historical decision has not been established."""
+    PERSON = auto()
+    """A person made the decision."""
+    SYSTEM = auto()
+    """The repository made the decision automatically."""
+
+
+class DuplicateDecisionTrigger(StrEnum):
+    """The event that caused a duplicate decision."""
+
+    UNCLASSIFIED = auto()
+    """The trigger for a historical decision has not been established."""
+    MANUAL_API = auto()
+    """The manual duplicate-decision API created the decision."""
+    IMPORT = auto()
+    """Reference import processing created the decision."""
+    ENHANCEMENT = auto()
+    """Reserved. No path creates enhancement-triggered decisions yet."""
+    EXPLICIT_RERUN = auto()
+    """An explicit deduplication rerun caused the decision."""
+    MIGRATION = auto()
+    """A data migration classified or created the decision."""
+
+
 class MakeDuplicateDecision(BaseModel):
     """Model for making a duplicate decision."""
 
@@ -77,6 +105,15 @@ class MakeDuplicateDecisionResult(BaseModel):
     )
     active_decision: bool = Field(
         description="Whether this decision is the active decision for the reference.",
+    )
+    # Defaulted so a newer SDK can still parse a server that predates these fields.
+    decision_authority: DuplicateDecisionAuthority = Field(
+        default=DuplicateDecisionAuthority.UNCLASSIFIED,
+        description="Whether a person or the system made the decision.",
+    )
+    decision_trigger: DuplicateDecisionTrigger = Field(
+        default=DuplicateDecisionTrigger.UNCLASSIFIED,
+        description="The event that caused the decision.",
     )
     detail: str | None = Field(
         default=None,

--- a/libs/sdk/src/destiny_sdk/deduplication.py
+++ b/libs/sdk/src/destiny_sdk/deduplication.py
@@ -39,10 +39,8 @@ class DuplicateDecisionTrigger(StrEnum):
     """Reference import processing created the decision."""
     ENHANCEMENT = auto()
     """Reserved. No path creates enhancement-triggered decisions yet."""
-    EXPLICIT_RERUN = auto()
-    """An explicit deduplication rerun caused the decision."""
-    MIGRATION = auto()
-    """A data migration classified or created the decision."""
+    INVOKE_API = auto()
+    """The duplicate-decisions invoke API created the decision."""
 
 
 class MakeDuplicateDecision(BaseModel):

--- a/libs/sdk/tests/unit/test_deduplication.py
+++ b/libs/sdk/tests/unit/test_deduplication.py
@@ -1,0 +1,46 @@
+from uuid import uuid7
+
+import destiny_sdk
+
+
+def test_make_duplicate_decision_result_parses_response_without_provenance():
+    """A newer SDK must still parse a server that predates the provenance fields."""
+    obj = destiny_sdk.deduplication.MakeDuplicateDecisionResult.model_validate(
+        {
+            "id": str(uuid7()),
+            "reference_id": str(uuid7()),
+            "outcome": "canonical",
+            "active_decision": True,
+        }
+    )
+
+    assert (
+        obj.decision_authority
+        == destiny_sdk.deduplication.DuplicateDecisionAuthority.UNCLASSIFIED
+    )
+    assert (
+        obj.decision_trigger
+        == destiny_sdk.deduplication.DuplicateDecisionTrigger.UNCLASSIFIED
+    )
+
+
+def test_make_duplicate_decision_result_keeps_provenance_when_sent():
+    obj = destiny_sdk.deduplication.MakeDuplicateDecisionResult.model_validate(
+        {
+            "id": str(uuid7()),
+            "reference_id": str(uuid7()),
+            "outcome": "canonical",
+            "active_decision": True,
+            "decision_authority": "person",
+            "decision_trigger": "manual_api",
+        }
+    )
+
+    assert (
+        obj.decision_authority
+        == destiny_sdk.deduplication.DuplicateDecisionAuthority.PERSON
+    )
+    assert (
+        obj.decision_trigger
+        == destiny_sdk.deduplication.DuplicateDecisionTrigger.MANUAL_API
+    )

--- a/tests/e2e/imports/test_deduplication.py
+++ b/tests/e2e/imports/test_deduplication.py
@@ -399,7 +399,7 @@ async def test_import_non_duplicate(  # noqa: PLR0913
 # NB tests below this line are probably best placed in `enhancements.test_deduplication.py`,
 # with new enhancements triggering the changes, but at time of writing the enhancement->dedup
 # trigger is not yet implemented.
-async def test_canonical_becomes_duplicate(  # noqa: PLR0913
+async def test_manual_canonical_survives_automatic_duplicate(  # noqa: PLR0913
     destiny_client_v1: httpx.AsyncClient,
     pg_session: AsyncSession,
     es_client: AsyncElasticsearch,
@@ -409,7 +409,7 @@ async def test_canonical_becomes_duplicate(  # noqa: PLR0913
     canonical_reference: Reference,
     duplicate_reference: Reference,
 ):
-    """Verify behaviour when a canonical-like reference becomes a duplicate."""
+    """Verify a person's canonical decision is not replaced by an automatic duplicate."""
     canonical_reference_id = (
         await import_references(
             destiny_client_v1,
@@ -447,19 +447,25 @@ async def test_canonical_becomes_duplicate(  # noqa: PLR0913
     duplicate_decision = await poll_duplicate_process(
         pg_session,
         duplicate_reference.id,
-        required_state=DuplicateDetermination.DUPLICATE,
+        required_state=DuplicateDetermination.DECOUPLED,
     )
+    assert duplicate_decision.detail
     assert (
-        duplicate_decision.duplicate_determination == DuplicateDetermination.DUPLICATE
+        "Automatic decisions cannot replace a person-made active decision"
+        in duplicate_decision.detail
     )
+    assert "Proposed determination: duplicate" in duplicate_decision.detail
     assert duplicate_decision.canonical_reference_id == canonical_reference_id
+    assert not duplicate_decision.active_decision
+
     old_decision = await pg_session.get(
         SQLReferenceDuplicateDecision, canonical_decision_id
     )
     assert old_decision
-    assert not old_decision.active_decision
+    assert old_decision.active_decision
+    assert old_decision.duplicate_determination == DuplicateDetermination.CANONICAL
 
-    # Check that the Elasticsearch index contains only the canonical.
+    # The protected reference keeps its canonical decision, so it stays searchable.
     await es_client.indices.refresh(index=ReferenceDocument.Index.name)
     es_result = await es_client.search(
         index=ReferenceDocument.Index.name,
@@ -472,10 +478,13 @@ async def test_canonical_becomes_duplicate(  # noqa: PLR0913
             }
         },
     )
-    assert es_result["hits"]["total"]["value"] == 1
-    assert es_result["hits"]["hits"][0]["_id"] == str(canonical_reference_id)
-    es_source = es_result["hits"]["hits"][0]["_source"]
-    assert es_source["duplicate_determination"] == DuplicateDetermination.CANONICAL
+    assert {hit["_id"] for hit in es_result["hits"]["hits"]} == {
+        str(canonical_reference_id),
+        str(duplicate_reference.id),
+    }
+    assert {
+        hit["_source"]["duplicate_determination"] for hit in es_result["hits"]["hits"]
+    } == {DuplicateDetermination.CANONICAL}
 
 
 async def test_duplicate_becomes_canonical(  # noqa: PLR0913
@@ -534,7 +543,10 @@ async def test_duplicate_becomes_canonical(  # noqa: PLR0913
         duplicate_decision.duplicate_determination == DuplicateDetermination.DECOUPLED
     )
     assert duplicate_decision.detail
-    assert "Existing duplicate decision changed" in duplicate_decision.detail
+    assert (
+        "Automatic decisions cannot replace a person-made active decision"
+        in duplicate_decision.detail
+    )
     assert not duplicate_decision.canonical_reference_id
     assert not duplicate_decision.active_decision
 
@@ -607,7 +619,10 @@ async def test_duplicate_change(  # noqa: PLR0913
         required_state=DuplicateDetermination.DECOUPLED,
     )
     assert duplicate_decision.detail
-    assert "Existing duplicate decision changed" in duplicate_decision.detail
+    assert (
+        "Automatic decisions cannot replace a person-made active decision"
+        in duplicate_decision.detail
+    )
     assert duplicate_decision.canonical_reference_id == canonical_reference_id
     assert not duplicate_decision.active_decision
 

--- a/tests/e2e/imports/test_deduplication.py
+++ b/tests/e2e/imports/test_deduplication.py
@@ -20,6 +20,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.domain.references.models.es import ReferenceDocument
 from app.domain.references.models.models import (
+    DuplicateDecisionAuthority,
+    DuplicateDecisionTrigger,
     DuplicateDetermination,
     Enhancement,
     ExternalIdentifierType,
@@ -51,6 +53,38 @@ from tests.factories import (
     OpenAlexIdentifierFactory,
     ReferenceFactory,
 )
+
+
+async def _make_unclassified_active_decision(
+    destiny_client_v1: httpx.AsyncClient,
+    pg_session: AsyncSession,
+    *,
+    reference_id: UUID,
+    determination: DuplicateDetermination,
+    canonical_reference_id: UUID | None = None,
+) -> UUID:
+    """Create projected decision state, then mark its provenance as historical."""
+    payload = {
+        "reference_id": str(reference_id),
+        "duplicate_determination": determination.value,
+    }
+    if canonical_reference_id:
+        payload["canonical_reference_id"] = str(canonical_reference_id)
+
+    response = await destiny_client_v1.post(
+        "/references/duplicate-decisions/",
+        json=[payload],
+    )
+    assert response.status_code == 201
+    decision_id = UUID(response.json()[0]["id"])
+
+    pg_session.expire_all()
+    decision = await pg_session.get(SQLReferenceDuplicateDecision, decision_id)
+    assert decision
+    decision.decision_authority = DuplicateDecisionAuthority.UNCLASSIFIED
+    decision.decision_trigger = DuplicateDecisionTrigger.UNCLASSIFIED
+    await pg_session.commit()
+    return decision_id
 
 
 @pytest.fixture
@@ -399,7 +433,7 @@ async def test_import_non_duplicate(  # noqa: PLR0913
 # NB tests below this line are probably best placed in `enhancements.test_deduplication.py`,
 # with new enhancements triggering the changes, but at time of writing the enhancement->dedup
 # trigger is not yet implemented.
-async def test_manual_canonical_survives_automatic_duplicate(  # noqa: PLR0913
+async def test_canonical_becomes_duplicate(  # noqa: PLR0913
     destiny_client_v1: httpx.AsyncClient,
     pg_session: AsyncSession,
     es_client: AsyncElasticsearch,
@@ -409,7 +443,7 @@ async def test_manual_canonical_survives_automatic_duplicate(  # noqa: PLR0913
     canonical_reference: Reference,
     duplicate_reference: Reference,
 ):
-    """Verify a person's canonical decision is not replaced by an automatic duplicate."""
+    """Verify behaviour when a canonical-like reference becomes a duplicate."""
     canonical_reference_id = (
         await import_references(
             destiny_client_v1,
@@ -423,17 +457,18 @@ async def test_manual_canonical_survives_automatic_duplicate(  # noqa: PLR0913
     pg_session.add(SQLReference.from_domain(duplicate_reference))
     await pg_session.commit()
 
-    make_response = await destiny_client_v1.post(
-        "/references/duplicate-decisions/",
-        json=[
-            {
-                "reference_id": str(duplicate_reference.id),
-                "duplicate_determination": "canonical",
-            }
-        ],
+    canonical_decision_id = await _make_unclassified_active_decision(
+        destiny_client_v1,
+        pg_session,
+        reference_id=duplicate_reference.id,
+        determination=DuplicateDetermination.CANONICAL,
     )
-    assert make_response.status_code == 201
-    canonical_decision_id = UUID(make_response.json()[0]["id"])
+
+    await es_client.indices.refresh(index=ReferenceDocument.Index.name)
+    assert await es_client.exists(
+        index=ReferenceDocument.Index.name,
+        id=str(duplicate_reference.id),
+    )
 
     # Now deduplicate the duplicate again and check downstream
     await destiny_client_v1.post(
@@ -447,25 +482,19 @@ async def test_manual_canonical_survives_automatic_duplicate(  # noqa: PLR0913
     duplicate_decision = await poll_duplicate_process(
         pg_session,
         duplicate_reference.id,
-        required_state=DuplicateDetermination.DECOUPLED,
+        required_state=DuplicateDetermination.DUPLICATE,
     )
-    assert duplicate_decision.detail
     assert (
-        "Automatic decisions cannot replace a person-made active decision"
-        in duplicate_decision.detail
+        duplicate_decision.duplicate_determination == DuplicateDetermination.DUPLICATE
     )
-    assert "Proposed determination: duplicate" in duplicate_decision.detail
     assert duplicate_decision.canonical_reference_id == canonical_reference_id
-    assert not duplicate_decision.active_decision
-
     old_decision = await pg_session.get(
         SQLReferenceDuplicateDecision, canonical_decision_id
     )
     assert old_decision
-    assert old_decision.active_decision
-    assert old_decision.duplicate_determination == DuplicateDetermination.CANONICAL
+    assert not old_decision.active_decision
 
-    # The protected reference keeps its canonical decision, so it stays searchable.
+    # Check that the Elasticsearch index contains only the canonical.
     await es_client.indices.refresh(index=ReferenceDocument.Index.name)
     es_result = await es_client.search(
         index=ReferenceDocument.Index.name,
@@ -478,13 +507,10 @@ async def test_manual_canonical_survives_automatic_duplicate(  # noqa: PLR0913
             }
         },
     )
-    assert {hit["_id"] for hit in es_result["hits"]["hits"]} == {
-        str(canonical_reference_id),
-        str(duplicate_reference.id),
-    }
-    assert {
-        hit["_source"]["duplicate_determination"] for hit in es_result["hits"]["hits"]
-    } == {DuplicateDetermination.CANONICAL}
+    assert es_result["hits"]["total"]["value"] == 1
+    assert es_result["hits"]["hits"][0]["_id"] == str(canonical_reference_id)
+    es_source = es_result["hits"]["hits"][0]["_source"]
+    assert es_source["duplicate_determination"] == DuplicateDetermination.CANONICAL
 
 
 async def test_duplicate_becomes_canonical(  # noqa: PLR0913
@@ -512,18 +538,13 @@ async def test_duplicate_becomes_canonical(  # noqa: PLR0913
     pg_session.add(SQLReference.from_domain(non_duplicate_reference))
     await pg_session.commit()
 
-    make_response = await destiny_client_v1.post(
-        "/references/duplicate-decisions/",
-        json=[
-            {
-                "reference_id": str(non_duplicate_reference.id),
-                "duplicate_determination": "duplicate",
-                "canonical_reference_id": str(canonical_reference_id),
-            }
-        ],
+    non_canonical_decision_id = await _make_unclassified_active_decision(
+        destiny_client_v1,
+        pg_session,
+        reference_id=non_duplicate_reference.id,
+        determination=DuplicateDetermination.DUPLICATE,
+        canonical_reference_id=canonical_reference_id,
     )
-    assert make_response.status_code == 201
-    non_canonical_decision_id = UUID(make_response.json()[0]["id"])
 
     # Now deduplicate the non-duplicate again and check downstream
     await destiny_client_v1.post(
@@ -543,10 +564,7 @@ async def test_duplicate_becomes_canonical(  # noqa: PLR0913
         duplicate_decision.duplicate_determination == DuplicateDetermination.DECOUPLED
     )
     assert duplicate_decision.detail
-    assert (
-        "Automatic decisions cannot replace a person-made active decision"
-        in duplicate_decision.detail
-    )
+    assert "Existing duplicate decision changed" in duplicate_decision.detail
     assert not duplicate_decision.canonical_reference_id
     assert not duplicate_decision.active_decision
 
@@ -591,18 +609,13 @@ async def test_duplicate_change(  # noqa: PLR0913
     pg_session.add(SQLReference.from_domain(duplicate_reference))
     await pg_session.commit()
 
-    make_response = await destiny_client_v1.post(
-        "/references/duplicate-decisions/",
-        json=[
-            {
-                "reference_id": str(duplicate_reference.id),
-                "duplicate_determination": "duplicate",
-                "canonical_reference_id": str(non_duplicate_reference_id),
-            }
-        ],
+    duplicate_decision_id = await _make_unclassified_active_decision(
+        destiny_client_v1,
+        pg_session,
+        reference_id=duplicate_reference.id,
+        determination=DuplicateDetermination.DUPLICATE,
+        canonical_reference_id=non_duplicate_reference_id,
     )
-    assert make_response.status_code == 201
-    duplicate_decision_id = UUID(make_response.json()[0]["id"])
 
     # Deduplicate the duplicate again and check downstream
     await destiny_client_v1.post(
@@ -619,10 +632,7 @@ async def test_duplicate_change(  # noqa: PLR0913
         required_state=DuplicateDetermination.DECOUPLED,
     )
     assert duplicate_decision.detail
-    assert (
-        "Automatic decisions cannot replace a person-made active decision"
-        in duplicate_decision.detail
-    )
+    assert "Existing duplicate decision changed" in duplicate_decision.detail
     assert duplicate_decision.canonical_reference_id == canonical_reference_id
     assert not duplicate_decision.active_decision
 
@@ -631,6 +641,16 @@ async def test_duplicate_change(  # noqa: PLR0913
     )
     assert old_decision
     assert old_decision.active_decision
+
+    await es_client.indices.refresh(index=ReferenceDocument.Index.name)
+    canonical_before = await es_client.get(
+        index=ReferenceDocument.Index.name,
+        id=str(canonical_reference_id),
+    )
+    assert not any(
+        "test-robot-automation" in annotation
+        for annotation in canonical_before["_source"].get("annotations", [])
+    )
 
     # Now resolve the decouple via the manual endpoint: point to the real canonical.
     resolve_response = await destiny_client_v1.post(
@@ -678,6 +698,11 @@ async def test_duplicate_change(  # noqa: PLR0913
     assert str(duplicate_reference.id) not in es_ids
     assert str(canonical_reference_id) in es_ids
     assert str(non_duplicate_reference_id) in es_ids
+    es_sources = {hit["_id"]: hit["_source"] for hit in es_result["hits"]["hits"]}
+    assert any(
+        "test-robot-automation" in annotation
+        for annotation in es_sources[str(canonical_reference_id)]["annotations"]
+    )
 
 
 async def test_deduplication_shortcut(  # noqa: PLR0913

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -282,3 +282,190 @@ async def test_pending_enhancement_unique_index_fails_fast_on_duplicates(
         await run_migration(db_url, "9b2f1c4d7e83")
 
     await engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("migration_id", ["9b2f1c4d7e83"])
+async def test_duplicate_decision_provenance_migration_classifies_known_manual_eef(
+    db_at_migration: str,
+) -> None:
+    """Classify verified EEF manual decisions without guessing other history."""
+    engine = create_async_engine(db_at_migration, future=True)
+    now = datetime.datetime.now(datetime.UTC)
+    eef_record_id, other_record_id = str(uuid7()), str(uuid7())
+    eef_batch_id, other_batch_id = str(uuid7()), str(uuid7())
+    canonical_target_id = str(uuid7())
+    (
+        manual_eef_canonical_id,
+        manual_eef_duplicate_id,
+        manual_eef_inactive_id,
+        automatic_eef_id,
+        unsearchable_eef_id,
+        other_id,
+    ) = (str(uuid7()) for _ in range(6))
+
+    async with engine.begin() as conn:
+        await conn.execute(
+            sa.text(
+                "INSERT INTO reference (id, visibility, created_at, updated_at) "
+                "VALUES (:id, 'public', :now, :now)"
+            ),
+            {"id": canonical_target_id, "now": now},
+        )
+        for record_id, source_name in (
+            (eef_record_id, "eef-eppi-review-export-2026"),
+            (other_record_id, "openalex"),
+        ):
+            await conn.execute(
+                sa.text(
+                    "INSERT INTO import_record "
+                    "(id, searched_at, processor_name, processor_version, "
+                    "expected_reference_count, source_name, status, created_at, "
+                    "updated_at) VALUES "
+                    "(:id, :now, 'test', '1', 1, :source, 'completed', :now, :now)"
+                ),
+                {"id": record_id, "source": source_name, "now": now},
+            )
+        for batch_id, record_id in (
+            (eef_batch_id, eef_record_id),
+            (other_batch_id, other_record_id),
+        ):
+            await conn.execute(
+                sa.text(
+                    "INSERT INTO import_batch "
+                    "(id, import_record_id, storage_url, created_at, updated_at) "
+                    "VALUES (:id, :record_id, :url, :now, :now)"
+                ),
+                {
+                    "id": batch_id,
+                    "record_id": record_id,
+                    "url": f"https://example.com/{batch_id}",
+                    "now": now,
+                },
+            )
+
+        # (decision id, batch, detail, determination, canonical, active)
+        decisions = (
+            (manual_eef_canonical_id, eef_batch_id, None, "canonical", None, True),
+            (
+                manual_eef_duplicate_id,
+                eef_batch_id,
+                None,
+                "duplicate",
+                canonical_target_id,
+                True,
+            ),
+            (manual_eef_inactive_id, eef_batch_id, None, "canonical", None, False),
+            (
+                automatic_eef_id,
+                eef_batch_id,
+                "Automatic decision",
+                "canonical",
+                None,
+                True,
+            ),
+            (unsearchable_eef_id, eef_batch_id, None, "unsearchable", None, True),
+            (other_id, other_batch_id, None, "canonical", None, True),
+        )
+        for (
+            decision_id,
+            batch_id,
+            detail,
+            determination,
+            canonical_id,
+            active,
+        ) in decisions:
+            reference_id = str(uuid7())
+            await conn.execute(
+                sa.text(
+                    "INSERT INTO import_result "
+                    "(id, import_batch_id, status, reference_id, created_at, "
+                    "updated_at) "
+                    "VALUES (:id, :batch_id, 'imported', :reference_id, :now, :now)"
+                ),
+                {
+                    "id": str(uuid7()),
+                    "batch_id": batch_id,
+                    "reference_id": reference_id,
+                    "now": now,
+                },
+            )
+            await conn.execute(
+                sa.text(
+                    "INSERT INTO reference_duplicate_decision "
+                    "(id, reference_id, active_decision, candidate_canonical_ids, "
+                    "duplicate_determination, canonical_reference_id, detail, "
+                    "created_at, updated_at) "
+                    "VALUES (:id, :reference_id, :active, '{}', :determination, "
+                    ":canonical_id, :detail, :now, :now)"
+                ),
+                {
+                    "id": decision_id,
+                    "reference_id": reference_id,
+                    "active": active,
+                    "determination": determination,
+                    "canonical_id": canonical_id,
+                    "detail": detail,
+                    "now": now,
+                },
+            )
+
+    await run_migration(db_at_migration, "6df1b2b092ed")
+
+    async with engine.begin() as conn:
+        result = await conn.execute(
+            sa.text(
+                "SELECT id, decision_authority, decision_trigger "
+                "FROM reference_duplicate_decision"
+            )
+        )
+        provenance = {
+            str(row.id): (row.decision_authority, row.decision_trigger)
+            for row in result
+        }
+
+    classified, untouched = ("person", "migration"), ("unclassified", "unclassified")
+    # Both determinations in the predicate, and activeness is deliberately ignored.
+    assert provenance[manual_eef_canonical_id] == classified
+    assert provenance[manual_eef_duplicate_id] == classified
+    assert provenance[manual_eef_inactive_id] == classified
+    # Each excluded for a different clause: detail, determination, source.
+    assert provenance[automatic_eef_id] == untouched
+    assert provenance[unsearchable_eef_id] == untouched
+    assert provenance[other_id] == untouched
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("migration_id", ["9b2f1c4d7e83"])
+async def test_duplicate_decision_provenance_accepts_pre_migration_inserts(
+    db_at_migration: str,
+) -> None:
+    """A rolling deploy keeps the old revision inserting without the new columns."""
+    engine = create_async_engine(db_at_migration, future=True)
+    await run_migration(db_at_migration, "6df1b2b092ed")
+
+    now = datetime.datetime.now(datetime.UTC)
+    decision_id = str(uuid7())
+    async with engine.begin() as conn:
+        await conn.execute(
+            sa.text(
+                "INSERT INTO reference_duplicate_decision "
+                "(id, reference_id, active_decision, candidate_canonical_ids, "
+                "duplicate_determination, created_at, updated_at) "
+                "VALUES (:id, :reference_id, true, '{}', 'canonical', :now, :now)"
+            ),
+            {"id": decision_id, "reference_id": str(uuid7()), "now": now},
+        )
+        provenance = (
+            await conn.execute(
+                sa.text(
+                    "SELECT decision_authority, decision_trigger "
+                    "FROM reference_duplicate_decision WHERE id = :id"
+                ),
+                {"id": decision_id},
+            )
+        ).one()
+
+    assert provenance == ("unclassified", "unclassified")
+    await engine.dispose()

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -424,7 +424,8 @@ async def test_duplicate_decision_provenance_migration_classifies_known_manual_e
             for row in result
         }
 
-    classified, untouched = ("person", "migration"), ("unclassified", "unclassified")
+    classified = ("person", "manual_api")
+    untouched = ("unclassified", "unclassified")
     # Both determinations in the predicate, and activeness is deliberately ignored.
     assert provenance[manual_eef_canonical_id] == classified
     assert provenance[manual_eef_duplicate_id] == classified

--- a/tests/routers/test_references.py
+++ b/tests/routers/test_references.py
@@ -33,6 +33,8 @@ from app.core.exceptions import (
 )
 from app.domain.references import routes as references
 from app.domain.references.models.models import (
+    DuplicateDecisionAuthority,
+    DuplicateDecisionTrigger,
     DuplicateDetermination,
     EnhancementRequestSearchStatus,
     EnhancementRequestStatus,
@@ -1338,6 +1340,8 @@ async def test_make_duplicate_decisions_mark_canonical_and_duplicate(
     assert results[0]["outcome"] == "canonical"
     assert results[0]["active_decision"] is True
     assert results[0]["canonical_reference_id"] is None
+    assert results[0]["decision_authority"] == DuplicateDecisionAuthority.PERSON
+    assert results[0]["decision_trigger"] == DuplicateDecisionTrigger.MANUAL_API
 
     response = await client.post(
         "/v1/references/duplicate-decisions/",

--- a/tests/unit/domain/references/models/test_models.py
+++ b/tests/unit/domain/references/models/test_models.py
@@ -6,13 +6,16 @@ from uuid import uuid7
 
 import destiny_sdk
 import pytest
+from pydantic import ValidationError
 
 from app.core.exceptions import SDKToDomainError
 from app.domain.references.models.models import (
     CandidateCanonicalSearchFields,
+    DuplicateDetermination,
     Enhancement,
     FullTextEnhancement,
     GenericExternalIdentifier,
+    ReferenceDuplicateDecision,
 )
 from app.domain.references.models.validators import ReferenceCreateResult
 from app.domain.references.services.anti_corruption_service import (
@@ -193,3 +196,42 @@ async def test_canonical_search_fields_searchable():
     search_fields.publication_year = None
 
     assert not search_fields.is_searchable
+
+
+@pytest.mark.parametrize(
+    ("duplicate_determination", "canonical_reference_id"),
+    [
+        (DuplicateDetermination.EXACT_DUPLICATE, None),
+        (DuplicateDetermination.DUPLICATE, None),
+        (DuplicateDetermination.PENDING, uuid7()),
+        (DuplicateDetermination.CANONICAL, uuid7()),
+    ],
+)
+def test_duplicate_decision_rejects_mismatched_canonical_reference(
+    duplicate_determination, canonical_reference_id
+):
+    """The model is the only guard left on this pairing after the registrars split."""
+    with pytest.raises(ValidationError, match="canonical_reference_id must be"):
+        ReferenceDuplicateDecision(
+            reference_id=uuid7(),
+            duplicate_determination=duplicate_determination,
+            canonical_reference_id=canonical_reference_id,
+        )
+
+
+def test_duplicate_decision_allows_decoupled_with_or_without_canonical():
+    """DECOUPLED may retain a proposed canonical for later review."""
+    canonical_id = uuid7()
+
+    with_canonical = ReferenceDuplicateDecision(
+        reference_id=uuid7(),
+        duplicate_determination=DuplicateDetermination.DECOUPLED,
+        canonical_reference_id=canonical_id,
+    )
+    without_canonical = ReferenceDuplicateDecision(
+        reference_id=uuid7(),
+        duplicate_determination=DuplicateDetermination.DECOUPLED,
+    )
+
+    assert with_canonical.canonical_reference_id == canonical_id
+    assert without_canonical.canonical_reference_id is None

--- a/tests/unit/domain/references/services/test_deduplication_service.py
+++ b/tests/unit/domain/references/services/test_deduplication_service.py
@@ -13,6 +13,8 @@ from app.domain.references.models.models import (
     Candidate,
     CandidateSelectionDiagnostics,
     CandidateSelectionResult,
+    DuplicateDecisionAuthority,
+    DuplicateDecisionTrigger,
     DuplicateDetermination,
     ExternalIdentifierType,
     InputSearchability,
@@ -257,7 +259,7 @@ async def test_find_exact_duplicate_updated_enhancement(
 
 
 @pytest.mark.asyncio
-async def test_register_duplicate_decision_for_reference_happy_path(
+async def test_register_pending_import_decision(
     reference, anti_corruption_service, fake_uow, fake_repository
 ):
     service = DeduplicationService(
@@ -265,13 +267,18 @@ async def test_register_duplicate_decision_for_reference_happy_path(
         fake_uow(reference_duplicate_decisions=fake_repository()),
         fake_uow(),
     )
-    result = await service.register_duplicate_decision_for_reference(reference.id)
+    result = await service.register_pending_import_decision(reference.id)
     assert result.reference_id == reference.id
     assert result.duplicate_determination == DuplicateDetermination.PENDING
+    assert result.decision_authority == DuplicateDecisionAuthority.SYSTEM
+    assert result.decision_trigger == DuplicateDecisionTrigger.IMPORT
+    assert result.canonical_reference_id is None
+    # Inactive is what makes the direct insert safe: it displaces nothing.
+    assert not result.active_decision
 
 
 @pytest.mark.asyncio
-async def test_register_duplicate_decision_invalid_combination(
+async def test_register_exact_duplicate_import_decision(
     reference, anti_corruption_service, fake_uow, fake_repository
 ):
     service = DeduplicationService(
@@ -279,12 +286,18 @@ async def test_register_duplicate_decision_invalid_combination(
         fake_uow(reference_duplicate_decisions=fake_repository()),
         fake_uow(),
     )
-    with pytest.raises(DeduplicationValueError):
-        await service.register_duplicate_decision_for_reference(
-            reference.id,
-            duplicate_determination=DuplicateDetermination.EXACT_DUPLICATE,
-            canonical_reference_id=None,
-        )
+    canonical_id = uuid7()
+
+    result = await service.register_exact_duplicate_import_decision(
+        reference.id, canonical_id
+    )
+
+    assert result.reference_id == reference.id
+    assert result.duplicate_determination == DuplicateDetermination.EXACT_DUPLICATE
+    assert result.canonical_reference_id == canonical_id
+    assert result.decision_authority == DuplicateDecisionAuthority.SYSTEM
+    assert result.decision_trigger == DuplicateDecisionTrigger.IMPORT
+    assert result.active_decision
 
 
 @pytest.mark.asyncio
@@ -529,6 +542,192 @@ async def test_map_duplicate_decision_reports_matching_active_decision_unchanged
     out_decision = await dec_repo.get_by_pk(out_decision.id)
     assert out_decision.active_decision
     assert out_decision.duplicate_determination == DuplicateDetermination.DUPLICATE
+
+
+@pytest.mark.asyncio
+async def test_map_duplicate_decision_retains_person_active_decision(
+    fake_uow, fake_repository, anti_corruption_service
+):
+    canonical = MagicMock(spec=Reference)
+    canonical.id = uuid7()
+    canonical.is_canonical = True
+
+    reference = MagicMock(spec=Reference)
+    reference.id = uuid7()
+    reference.has_duplicates = False
+    active_decision = ReferenceDuplicateDecision(
+        reference_id=reference.id,
+        duplicate_determination=DuplicateDetermination.CANONICAL,
+        active_decision=True,
+        decision_authority=DuplicateDecisionAuthority.PERSON,
+        decision_trigger=DuplicateDecisionTrigger.MANUAL_API,
+    )
+    reference.duplicate_decision = active_decision
+    proposal = ReferenceDuplicateDecision(
+        reference_id=reference.id,
+        duplicate_determination=DuplicateDetermination.DUPLICATE,
+        canonical_reference_id=canonical.id,
+        detail="Automatic assessment reason.",
+        decision_authority=DuplicateDecisionAuthority.SYSTEM,
+        decision_trigger=DuplicateDecisionTrigger.EXPLICIT_RERUN,
+    )
+
+    decision_repo = fake_repository([active_decision, proposal])
+    service = DeduplicationService(
+        anti_corruption_service,
+        fake_uow(
+            references=fake_repository([reference, canonical]),
+            reference_duplicate_decisions=decision_repo,
+        ),
+        fake_uow(),
+    )
+
+    result, decision_changed, previous = await service.map_duplicate_decision(proposal)
+
+    assert result.duplicate_determination == DuplicateDetermination.DECOUPLED
+    assert result.canonical_reference_id == canonical.id
+    assert "Proposed determination: duplicate." in result.detail
+    assert "Automatic assessment reason." in result.detail
+    assert not result.active_decision
+    assert active_decision.active_decision
+    assert decision_changed is False
+    assert previous is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "unclassified_determination",
+    [
+        DuplicateDetermination.CANONICAL,
+        DuplicateDetermination.UNSEARCHABLE,
+    ],
+)
+async def test_map_duplicate_decision_replaces_unclassified_active_decision(
+    unclassified_determination, fake_uow, fake_repository, anti_corruption_service
+):
+    canonical = MagicMock(spec=Reference)
+    canonical.id = uuid7()
+    canonical.is_canonical = True
+
+    reference = MagicMock(spec=Reference)
+    reference.id = uuid7()
+    reference.has_duplicates = False
+    active_decision = ReferenceDuplicateDecision(
+        reference_id=reference.id,
+        duplicate_determination=unclassified_determination,
+        active_decision=True,
+    )
+    reference.duplicate_decision = active_decision
+    proposal = ReferenceDuplicateDecision(
+        reference_id=reference.id,
+        duplicate_determination=DuplicateDetermination.DUPLICATE,
+        canonical_reference_id=canonical.id,
+        decision_authority=DuplicateDecisionAuthority.SYSTEM,
+        decision_trigger=DuplicateDecisionTrigger.IMPORT,
+    )
+
+    service = DeduplicationService(
+        anti_corruption_service,
+        fake_uow(
+            references=fake_repository([reference, canonical]),
+            reference_duplicate_decisions=fake_repository([active_decision, proposal]),
+        ),
+        fake_uow(),
+    )
+
+    result, decision_changed, previous = await service.map_duplicate_decision(proposal)
+
+    assert result.duplicate_determination == DuplicateDetermination.DUPLICATE
+    assert result.active_decision
+    assert not active_decision.active_decision
+    assert decision_changed is True
+    assert previous is active_decision
+
+
+@pytest.mark.asyncio
+async def test_map_duplicate_decision_deactivates_blocked_proposal(
+    fake_uow, fake_repository, anti_corruption_service
+):
+    """A proposal built active must not stay active once decoupled, or it
+    collides with the retained decision on the one-active-decision index.
+    """
+    canonical = MagicMock(spec=Reference)
+    canonical.id = uuid7()
+    canonical.is_canonical = True
+
+    reference = MagicMock(spec=Reference)
+    reference.id = uuid7()
+    reference.has_duplicates = False
+    active_decision = ReferenceDuplicateDecision(
+        reference_id=reference.id,
+        duplicate_determination=DuplicateDetermination.CANONICAL,
+        active_decision=True,
+        decision_authority=DuplicateDecisionAuthority.PERSON,
+        decision_trigger=DuplicateDecisionTrigger.MANUAL_API,
+    )
+    reference.duplicate_decision = active_decision
+    proposal = ReferenceDuplicateDecision(
+        reference_id=reference.id,
+        duplicate_determination=DuplicateDetermination.DUPLICATE,
+        canonical_reference_id=canonical.id,
+        active_decision=True,
+        decision_authority=DuplicateDecisionAuthority.SYSTEM,
+        decision_trigger=DuplicateDecisionTrigger.IMPORT,
+    )
+
+    service = DeduplicationService(
+        anti_corruption_service,
+        fake_uow(
+            references=fake_repository([reference, canonical]),
+            reference_duplicate_decisions=fake_repository([active_decision, proposal]),
+        ),
+        fake_uow(),
+    )
+
+    result, _, _ = await service.map_duplicate_decision(proposal)
+
+    assert result.duplicate_determination == DuplicateDetermination.DECOUPLED
+    assert not result.active_decision
+    assert active_decision.active_decision
+
+
+@pytest.mark.asyncio
+async def test_map_duplicate_decision_blocks_identical_automatic_result(
+    fake_uow, fake_repository, anti_corruption_service
+):
+    reference = MagicMock(spec=Reference)
+    reference.id = uuid7()
+    reference.has_duplicates = False
+    active_decision = ReferenceDuplicateDecision(
+        reference_id=reference.id,
+        duplicate_determination=DuplicateDetermination.CANONICAL,
+        active_decision=True,
+        decision_authority=DuplicateDecisionAuthority.PERSON,
+        decision_trigger=DuplicateDecisionTrigger.MANUAL_API,
+    )
+    reference.duplicate_decision = active_decision
+    proposal = ReferenceDuplicateDecision(
+        reference_id=reference.id,
+        duplicate_determination=DuplicateDetermination.CANONICAL,
+        decision_authority=DuplicateDecisionAuthority.SYSTEM,
+        decision_trigger=DuplicateDecisionTrigger.IMPORT,
+    )
+    service = DeduplicationService(
+        anti_corruption_service,
+        fake_uow(
+            references=fake_repository([reference]),
+            reference_duplicate_decisions=fake_repository([active_decision, proposal]),
+        ),
+        fake_uow(),
+    )
+
+    result, decision_changed, previous = await service.map_duplicate_decision(proposal)
+
+    assert result.duplicate_determination == DuplicateDetermination.DECOUPLED
+    assert active_decision.active_decision
+    assert not result.active_decision
+    assert decision_changed is False
+    assert previous is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/domain/references/services/test_deduplication_service.py
+++ b/tests/unit/domain/references/services/test_deduplication_service.py
@@ -569,7 +569,7 @@ async def test_map_duplicate_decision_retains_person_active_decision(
         canonical_reference_id=canonical.id,
         detail="Automatic assessment reason.",
         decision_authority=DuplicateDecisionAuthority.SYSTEM,
-        decision_trigger=DuplicateDecisionTrigger.EXPLICIT_RERUN,
+        decision_trigger=DuplicateDecisionTrigger.INVOKE_API,
     )
 
     decision_repo = fake_repository([active_decision, proposal])

--- a/tests/unit/domain/references/test_service.py
+++ b/tests/unit/domain/references/test_service.py
@@ -91,7 +91,7 @@ async def test_get_reference_not_found(fake_repository, fake_uow):
 
 
 @pytest.mark.asyncio
-async def test_add_pending_duplicate_decisions_records_explicit_rerun(
+async def test_register_pending_invoke_api_decisions_records_provenance(
     fake_repository, fake_uow
 ):
     decision_repo = fake_repository()
@@ -102,7 +102,7 @@ async def test_add_pending_duplicate_decisions_records_explicit_rerun(
     )
     reference_ids = [uuid7(), uuid7()]
 
-    decisions = await service.add_pending_duplicate_decisions_for_reference_ids(
+    decisions = await service.register_pending_invoke_api_decisions(
         ReferenceIds(reference_ids=reference_ids)
     )
 
@@ -112,7 +112,7 @@ async def test_add_pending_duplicate_decisions_records_explicit_rerun(
         for decision in decisions
     )
     assert all(
-        decision.decision_trigger == DuplicateDecisionTrigger.EXPLICIT_RERUN
+        decision.decision_trigger == DuplicateDecisionTrigger.INVOKE_API
         for decision in decisions
     )
 

--- a/tests/unit/domain/references/test_service.py
+++ b/tests/unit/domain/references/test_service.py
@@ -18,6 +18,8 @@ from app.core.exceptions import (
 from app.domain.references.models.models import (
     CandidateSelectionDiagnostics,
     CandidateSelectionResult,
+    DuplicateDecisionAuthority,
+    DuplicateDecisionTrigger,
     DuplicateDetermination,
     Enhancement,
     EnhancementRequest,
@@ -29,6 +31,7 @@ from app.domain.references.models.models import (
     PendingEnhancementStatus,
     Reference,
     ReferenceDuplicateDecision,
+    ReferenceIds,
     ReferenceWithChangeset,
     RetrievalPolicyName,
     RobotAutomationPercolationResult,
@@ -85,6 +88,33 @@ async def test_get_reference_not_found(fake_repository, fake_uow):
     dummy_id = uuid7()
     with pytest.raises(SQLNotFoundError):
         await service.get_reference(dummy_id)
+
+
+@pytest.mark.asyncio
+async def test_add_pending_duplicate_decisions_records_explicit_rerun(
+    fake_repository, fake_uow
+):
+    decision_repo = fake_repository()
+    service = ReferenceService(
+        ReferenceAntiCorruptionService(fake_repository()),
+        fake_uow(reference_duplicate_decisions=decision_repo),
+        fake_uow(),
+    )
+    reference_ids = [uuid7(), uuid7()]
+
+    decisions = await service.add_pending_duplicate_decisions_for_reference_ids(
+        ReferenceIds(reference_ids=reference_ids)
+    )
+
+    assert {decision.reference_id for decision in decisions} == set(reference_ids)
+    assert all(
+        decision.decision_authority == DuplicateDecisionAuthority.SYSTEM
+        for decision in decisions
+    )
+    assert all(
+        decision.decision_trigger == DuplicateDecisionTrigger.EXPLICIT_RERUN
+        for decision in decisions
+    )
 
 
 @pytest.fixture
@@ -493,9 +523,14 @@ async def test_ingest_reference(
     with (
         patch.object(
             service._deduplication_service,  # noqa: SLF001
-            "register_duplicate_decision_for_reference",
+            "register_pending_import_decision",
             AsyncMock(return_value=dummy_decision),
-        ) as mock_register,
+        ) as mock_register_pending,
+        patch.object(
+            service._deduplication_service,  # noqa: SLF001
+            "register_exact_duplicate_import_decision",
+            AsyncMock(return_value=dummy_decision),
+        ) as mock_register_exact,
         patch.object(service, "_merge_reference", AsyncMock()) as mock_merge,
         patch.object(
             service._anti_corruption_service,  # noqa: SLF001
@@ -513,10 +548,18 @@ async def test_ingest_reference(
     ):
         result = await service.ingest_reference("{}", 1, AsyncMock())
         mock_find.assert_awaited_once()
-        mock_register.assert_awaited_once()
         if should_merge:
+            mock_register_pending.assert_awaited_once_with(
+                reference_id=mock_reference.id
+            )
+            mock_register_exact.assert_not_awaited()
             mock_merge.assert_awaited_once_with(mock_reference)
         else:
+            mock_register_exact.assert_awaited_once_with(
+                reference_id=mock_reference.id,
+                canonical_reference_id=find_exact_duplicate_return.id,
+            )
+            mock_register_pending.assert_not_awaited()
             mock_merge.assert_not_awaited()
         assert getattr(result, "duplicate_decision_id", None) == expected_decision_id
 

--- a/uv.lock
+++ b/uv.lock
@@ -705,7 +705,7 @@ test = [
 
 [[package]]
 name = "destiny-sdk"
-version = "0.14.1"
+version = "0.14.2"
 source = { editable = "libs/sdk" }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
Closes #582.

Scope and Complete-when were edited today to protect `person` only, matching the Outcome they
had contradicted; see the comment on the issue if you read it before that. The backfill
therefore carries the protection alone, so a manual decision it fails to identify is
replaceable, which raises the stakes on the #752 population and #771's identifier capture.

### Beyond the issue

- Splits `register_duplicate_decision_for_reference` into `register_pending_import_decision` and
  `register_exact_duplicate_import_decision`. Behaviour preserving; the two callers always wrote
  different shapes through one parameterised method.
- SDK 0.14.2 adds both fields to `MakeDuplicateDecisionResult`, defaulted so a newer client still
  parses an older server.
- Server defaults on the new NOT NULL columns are permanent rather than dropped after the
  backfill: deploy and migrate are unordered jobs, so an old revision keeps inserting without
  these columns while the migration runs.

### Known limits

- `enhancement` is defined as a trigger but nothing writes it, since no path creates
  enhancement-triggered decisions today.
- The guard covers `map_duplicate_decision`, and the import registrars insert directly. Safe
  because those rows are either inactive or belong to a reference never stored, but nothing
  enforces the invariant that anything replacing an active decision goes through the mapper.

### Validation performed

- Ran the migration against a local database rolled back one revision. The backfill reclassified
  exactly 1,664 rows, matching a production audit of the manual population.
- Live run over two references, one `person` and one `unclassified`, both holding an active
  canonical decision. The proposal against the person decision landed inactive as `decoupled`
  with the original still active; against the unclassified one, the same path deactivated the
  old row and became active. One path, opposite outcomes.
- Removed the server defaults temporarily and confirmed an insert omitting the new columns
  fails, then restored them.
- Unit, integration and e2e suites green, pre-commit clean, docs build clean.

Three e2e deduplication tests set their prior decision through the manual API, so the guard now
intercepts ahead of the graph-shape branches they were written against. One of them asserted a
manual canonical being replaced by an automatic duplicate, which is the behaviour this change
removes; it is renamed and rewritten to assert the protection. The graph-shape branches keep
their unit coverage, where the active decision carries no authority.
