### PR TITLE
Container app job alerts

### DIFF
--- a/infra/app/alerts.tf
+++ b/infra/app/alerts.tf
@@ -13,6 +13,8 @@ resource "azurerm_logic_app_workflow" "slack_alerts" {
   tags = local.minimum_resource_tags
 }
 
+# --- Metrics Alerts ---
+
 resource "azurerm_logic_app_trigger_http_request" "slack_alerts" {
   count = local.env.alerts_enabled && var.alert_slack_webhook_url != "" ? 1 : 0
 
@@ -95,99 +97,6 @@ resource "azurerm_logic_app_action_http" "post_to_slack" {
   BODY
 }
 
-resource "azurerm_logic_app_workflow" "slack_log_alerts" {
-  count = local.env.alerts_enabled && var.alert_slack_webhook_url != "" ? 1 : 0
-
-  name                = "${local.name}-slack-log-alerts"
-  location            = azurerm_resource_group.this.location
-  resource_group_name = azurerm_resource_group.this.name
-
-  tags = local.minimum_resource_tags
-}
-
-resource "azurerm_logic_app_trigger_http_request" "slack_log_alerts" {
-  count = local.env.alerts_enabled && var.alert_slack_webhook_url != "" ? 1 : 0
-
-  name         = "azure-monitor-webhook"
-  logic_app_id = azurerm_logic_app_workflow.slack_log_alerts[0].id
-
-  # schema: https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-common-schema
-  schema = <<-SCHEMA
-    {
-      "type": "object",
-      "properties": {
-        "schemaId": { "type": "string" },
-        "data": {
-          "type": "object",
-          "properties": {
-            "essentials": {
-              "type": "object",
-              "properties": {
-                "alertRule": { "type": "string" },
-                "severity": { "type": "string" },
-                "monitorCondition": { "type": "string" },
-                "description": { "type": "string" },
-                "firedDateTime": { "type": "string" },
-                "alertTargetIDs": { "type": "array" }
-              }
-            },
-            "alertContext": { "type": "object" }
-          }
-        }
-      }
-    }
-  SCHEMA
-}
-
-resource "azurerm_logic_app_action_http" "post_log_alert_to_slack" {
-  count = local.env.alerts_enabled && var.alert_slack_webhook_url != "" ? 1 : 0
-
-  name         = "post-log-alert-to-slack"
-  logic_app_id = azurerm_logic_app_workflow.slack_log_alerts[0].id
-  method       = "POST"
-  uri          = var.alert_slack_webhook_url
-
-  headers = {
-    "Content-Type" = "application/json"
-  }
-
-  # body: https://api.slack.com/block-kit
-  # expressions: https://learn.microsoft.com/en-us/azure/logic-apps/workflow-definition-language-functions-reference
-  body = <<-BODY
-    {
-      "blocks": [
-        {
-          "type": "header",
-          "text": {
-            "type": "plain_text",
-            "text": "@{if(equals(triggerBody()?['data']?['essentials']?['monitorCondition'], 'Resolved'), '✅ RESOLVED', '❌ FAILURE')} @{first(triggerBody()?['data']?['alertContext']?['condition']?['allOf'][0]?['dimensions'])?['value']}",
-            "emoji": true
-          }
-        },
-        {
-          "type": "section",
-          "fields": [
-            { "type": "mrkdwn", "text": "*Status:*\n@{triggerBody()?['data']?['essentials']?['monitorCondition']}" },
-            { "type": "mrkdwn", "text": "*Matching events:*\n@{triggerBody()?['data']?['alertContext']?['condition']?['allOf'][0]?['metricValue']}" }
-          ]
-        },
-        {
-          "type": "section",
-          "text": { "type": "mrkdwn", "text": "*Description:*\n@{triggerBody()?['data']?['essentials']?['description']}" }
-        },
-        {
-          "type": "section",
-          "text": { "type": "mrkdwn", "text": "<@{triggerBody()?['data']?['alertContext']?['condition']?['allOf'][0]?['linkToFilteredSearchResultsUI']}|🔍 View matching logs>    <https://portal.azure.com/#@${data.azurerm_subscription.current.tenant_id}/resource@{first(triggerBody()?['data']?['essentials']?['alertTargetIDs'])}|📋 View resource>" }
-        },
-        {
-          "type": "context",
-          "elements": [{ "type": "mrkdwn", "text": "@{triggerBody()?['data']?['essentials']?['alertRule']} · fired at @{triggerBody()?['data']?['essentials']?['firedDateTime']}" }]
-        }
-      ]
-    }
-  BODY
-}
-
 resource "azurerm_monitor_action_group" "alerts" {
   count = local.env.alerts_enabled ? 1 : 0
 
@@ -212,35 +121,6 @@ resource "azurerm_monitor_action_group" "alerts" {
       name                    = "slack-via-logic-app"
       resource_id             = azurerm_logic_app_workflow.slack_alerts[0].id
       callback_url            = azurerm_logic_app_trigger_http_request.slack_alerts[0].callback_url
-      use_common_alert_schema = true
-    }
-  }
-}
-
-resource "azurerm_monitor_action_group" "log_alerts" {
-  count = local.env.alerts_enabled ? 1 : 0
-
-  name                = "${local.name}-log-alerts-ag"
-  resource_group_name = azurerm_resource_group.this.name
-  short_name          = "logalerts"
-
-  tags = local.minimum_resource_tags
-
-  dynamic "email_receiver" {
-    for_each = var.alert_email_recipients
-    content {
-      name                    = "email-${email_receiver.key}"
-      email_address           = email_receiver.value
-      use_common_alert_schema = true
-    }
-  }
-
-  dynamic "logic_app_receiver" {
-    for_each = var.alert_slack_webhook_url != "" ? [1] : []
-    content {
-      name                    = "slack-via-logic-app"
-      resource_id             = azurerm_logic_app_workflow.slack_log_alerts[0].id
-      callback_url            = azurerm_logic_app_trigger_http_request.slack_log_alerts[0].callback_url
       use_common_alert_schema = true
     }
   }
@@ -483,10 +363,157 @@ resource "azurerm_monitor_metric_alert" "tasks_restart_count" {
   }
 }
 
-# Scoped to the workspace rather than the jobs: _ResourceId is empty on
-# ContainerAppSystemLogs_CL rows, so a resource-scoped rule would match nothing.
-# Hooray.
-# "FailedMount" and "FailedToRetrieveImagePullSecret" are also purposefully excluded
+resource "azurerm_monitor_metric_alert" "ui_restart_count" {
+  count = local.env.alerts_enabled ? 1 : 0
+
+  name                = "${local.name}-ui-restart-count"
+  resource_group_name = azurerm_resource_group.this.name
+  scopes              = [module.container_app_ui.container_app_id]
+  description         = "Alert when UI container restart count exceeds 3"
+  severity            = 1 # error
+  frequency           = "PT1M"
+  window_size         = "PT5M"
+
+  tags = local.minimum_resource_tags
+
+  criteria {
+    metric_namespace = "Microsoft.App/containerApps"
+    metric_name      = "RestartCount"
+    aggregation      = "Maximum"
+    operator         = "GreaterThan"
+    threshold        = 3
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.alerts[0].id
+  }
+}
+
+# --- Log Analytics Search Alerts ---
+
+resource "azurerm_logic_app_workflow" "slack_log_alerts" {
+  count = local.env.alerts_enabled && var.alert_slack_webhook_url != "" ? 1 : 0
+
+  name                = "${local.name}-slack-log-alerts"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+
+  tags = local.minimum_resource_tags
+}
+
+resource "azurerm_logic_app_trigger_http_request" "slack_log_alerts" {
+  count = local.env.alerts_enabled && var.alert_slack_webhook_url != "" ? 1 : 0
+
+  name         = "azure-monitor-webhook"
+  logic_app_id = azurerm_logic_app_workflow.slack_log_alerts[0].id
+
+  # schema: https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-common-schema
+  schema = <<-SCHEMA
+    {
+      "type": "object",
+      "properties": {
+        "schemaId": { "type": "string" },
+        "data": {
+          "type": "object",
+          "properties": {
+            "essentials": {
+              "type": "object",
+              "properties": {
+                "alertRule": { "type": "string" },
+                "severity": { "type": "string" },
+                "monitorCondition": { "type": "string" },
+                "description": { "type": "string" },
+                "firedDateTime": { "type": "string" },
+                "alertTargetIDs": { "type": "array" }
+              }
+            },
+            "alertContext": { "type": "object" }
+          }
+        }
+      }
+    }
+  SCHEMA
+}
+
+resource "azurerm_logic_app_action_http" "post_log_alert_to_slack" {
+  count = local.env.alerts_enabled && var.alert_slack_webhook_url != "" ? 1 : 0
+
+  name         = "post-log-alert-to-slack"
+  logic_app_id = azurerm_logic_app_workflow.slack_log_alerts[0].id
+  method       = "POST"
+  uri          = var.alert_slack_webhook_url
+
+  headers = {
+    "Content-Type" = "application/json"
+  }
+
+  # body: https://api.slack.com/block-kit
+  # expressions: https://learn.microsoft.com/en-us/azure/logic-apps/workflow-definition-language-functions-reference
+  body = <<-BODY
+    {
+      "blocks": [
+        {
+          "type": "header",
+          "text": {
+            "type": "plain_text",
+            "text": "@{if(equals(triggerBody()?['data']?['essentials']?['monitorCondition'], 'Resolved'), '✅ RESOLVED', '❌ FAILURE')} @{first(triggerBody()?['data']?['alertContext']?['condition']?['allOf'][0]?['dimensions'])?['value']}",
+            "emoji": true
+          }
+        },
+        {
+          "type": "section",
+          "fields": [
+            { "type": "mrkdwn", "text": "*Status:*\n@{triggerBody()?['data']?['essentials']?['monitorCondition']}" },
+            { "type": "mrkdwn", "text": "*Matching events:*\n@{triggerBody()?['data']?['alertContext']?['condition']?['allOf'][0]?['metricValue']}" }
+          ]
+        },
+        {
+          "type": "section",
+          "text": { "type": "mrkdwn", "text": "*Description:*\n@{triggerBody()?['data']?['essentials']?['description']}" }
+        },
+        {
+          "type": "section",
+          "text": { "type": "mrkdwn", "text": "<@{triggerBody()?['data']?['alertContext']?['condition']?['allOf'][0]?['linkToFilteredSearchResultsUI']}|🔍 View matching logs>    <https://portal.azure.com/#@${data.azurerm_subscription.current.tenant_id}/resource@{first(triggerBody()?['data']?['essentials']?['alertTargetIDs'])}|📋 View resource>" }
+        },
+        {
+          "type": "context",
+          "elements": [{ "type": "mrkdwn", "text": "@{triggerBody()?['data']?['essentials']?['alertRule']} · fired at @{triggerBody()?['data']?['essentials']?['firedDateTime']}" }]
+        }
+      ]
+    }
+  BODY
+}
+
+resource "azurerm_monitor_action_group" "log_alerts" {
+  count = local.env.alerts_enabled ? 1 : 0
+
+  name                = "${local.name}-log-alerts-ag"
+  resource_group_name = azurerm_resource_group.this.name
+  short_name          = "logalerts"
+
+  tags = local.minimum_resource_tags
+
+  dynamic "email_receiver" {
+    for_each = var.alert_email_recipients
+    content {
+      name                    = "email-${email_receiver.key}"
+      email_address           = email_receiver.value
+      use_common_alert_schema = true
+    }
+  }
+
+  dynamic "logic_app_receiver" {
+    for_each = var.alert_slack_webhook_url != "" ? [1] : []
+    content {
+      name                    = "slack-via-logic-app"
+      resource_id             = azurerm_logic_app_workflow.slack_log_alerts[0].id
+      callback_url            = azurerm_logic_app_trigger_http_request.slack_log_alerts[0].callback_url
+      use_common_alert_schema = true
+    }
+  }
+}
+
+# "FailedMount" and "FailedToRetrieveImagePullSecret" are purposefully excluded
 # from the alert as these do not appear to stop the container app job running successfully
 # and would be unactionable alert noise.
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "job_failure_events" {
@@ -539,31 +566,5 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "job_failure_events" {
 
   action {
     action_groups = [azurerm_monitor_action_group.log_alerts[0].id]
-  }
-}
-
-resource "azurerm_monitor_metric_alert" "ui_restart_count" {
-  count = local.env.alerts_enabled ? 1 : 0
-
-  name                = "${local.name}-ui-restart-count"
-  resource_group_name = azurerm_resource_group.this.name
-  scopes              = [module.container_app_ui.container_app_id]
-  description         = "Alert when UI container restart count exceeds 3"
-  severity            = 1 # error
-  frequency           = "PT1M"
-  window_size         = "PT5M"
-
-  tags = local.minimum_resource_tags
-
-  criteria {
-    metric_namespace = "Microsoft.App/containerApps"
-    metric_name      = "RestartCount"
-    aggregation      = "Maximum"
-    operator         = "GreaterThan"
-    threshold        = 3
-  }
-
-  action {
-    action_group_id = azurerm_monitor_action_group.alerts[0].id
   }
 }

--- a/infra/app/alerts.tf
+++ b/infra/app/alerts.tf
@@ -95,6 +95,101 @@ resource "azurerm_logic_app_action_http" "post_to_slack" {
   BODY
 }
 
+# Log search alerts get their own logic app rather than sharing post_to_slack. The
+# payloads differ enough that one shared body would need conditionals on every field,
+# and keeping them apart means changes here can't break the metric alerts.
+resource "azurerm_logic_app_workflow" "slack_log_alerts" {
+  count = local.env.alerts_enabled && var.alert_slack_webhook_url != "" ? 1 : 0
+
+  name                = "${local.name}-slack-log-alerts"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+
+  tags = local.minimum_resource_tags
+}
+
+resource "azurerm_logic_app_trigger_http_request" "slack_log_alerts" {
+  count = local.env.alerts_enabled && var.alert_slack_webhook_url != "" ? 1 : 0
+
+  name         = "azure-monitor-webhook"
+  logic_app_id = azurerm_logic_app_workflow.slack_log_alerts[0].id
+
+  # schema: https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-common-schema
+  schema = <<-SCHEMA
+    {
+      "type": "object",
+      "properties": {
+        "schemaId": { "type": "string" },
+        "data": {
+          "type": "object",
+          "properties": {
+            "essentials": {
+              "type": "object",
+              "properties": {
+                "alertRule": { "type": "string" },
+                "severity": { "type": "string" },
+                "monitorCondition": { "type": "string" },
+                "description": { "type": "string" },
+                "firedDateTime": { "type": "string" }
+              }
+            },
+            "alertContext": { "type": "object" }
+          }
+        }
+      }
+    }
+  SCHEMA
+}
+
+resource "azurerm_logic_app_action_http" "post_log_alert_to_slack" {
+  count = local.env.alerts_enabled && var.alert_slack_webhook_url != "" ? 1 : 0
+
+  name         = "post-log-alert-to-slack"
+  logic_app_id = azurerm_logic_app_workflow.slack_log_alerts[0].id
+  method       = "POST"
+  uri          = var.alert_slack_webhook_url
+
+  headers = {
+    "Content-Type" = "application/json"
+  }
+
+  # body: https://api.slack.com/block-kit
+  # expressions: https://learn.microsoft.com/en-us/azure/logic-apps/workflow-definition-language-functions-reference
+  body = <<-BODY
+    {
+      "blocks": [
+        {
+          "type": "header",
+          "text": {
+            "type": "plain_text",
+            "text": "@{if(equals(triggerBody()?['data']?['essentials']?['monitorCondition'], 'Resolved'), '✅ RESOLVED', '❌ JOB FAILURE')} @{first(triggerBody()?['data']?['alertContext']?['condition']?['allOf'][0]?['dimensions'])?['value']}",
+            "emoji": true
+          }
+        },
+        {
+          "type": "section",
+          "fields": [
+            { "type": "mrkdwn", "text": "*Status:*\n@{triggerBody()?['data']?['essentials']?['monitorCondition']}" },
+            { "type": "mrkdwn", "text": "*Matching events:*\n@{triggerBody()?['data']?['alertContext']?['condition']?['allOf'][0]?['metricValue']}" }
+          ]
+        },
+        {
+          "type": "section",
+          "text": { "type": "mrkdwn", "text": "*Description:*\n@{triggerBody()?['data']?['essentials']?['description']}" }
+        },
+        {
+          "type": "section",
+          "text": { "type": "mrkdwn", "text": "<@{triggerBody()?['data']?['alertContext']?['condition']?['allOf'][0]?['linkToFilteredSearchResultsUI']}|🔍 View matching logs>    <https://portal.azure.com/#resource/subscriptions/${data.azurerm_subscription.current.subscription_id}/resourceGroups/${azurerm_resource_group.this.name}/providers/Microsoft.App/jobs/@{first(triggerBody()?['data']?['alertContext']?['condition']?['allOf'][0]?['dimensions'])?['value']}|📋 Job execution history>" }
+        },
+        {
+          "type": "context",
+          "elements": [{ "type": "mrkdwn", "text": "@{triggerBody()?['data']?['essentials']?['alertRule']} · fired at @{triggerBody()?['data']?['essentials']?['firedDateTime']}" }]
+        }
+      ]
+    }
+  BODY
+}
+
 resource "azurerm_monitor_action_group" "alerts" {
   count = local.env.alerts_enabled ? 1 : 0
 
@@ -119,6 +214,37 @@ resource "azurerm_monitor_action_group" "alerts" {
       name                    = "slack-via-logic-app"
       resource_id             = azurerm_logic_app_workflow.slack_alerts[0].id
       callback_url            = azurerm_logic_app_trigger_http_request.slack_alerts[0].callback_url
+      use_common_alert_schema = true
+    }
+  }
+}
+
+# Routes to the log-alert logic app instead. Alert rules choose their Slack card by
+# choosing an action group, since an action group notifies every receiver it holds.
+resource "azurerm_monitor_action_group" "log_alerts" {
+  count = local.env.alerts_enabled ? 1 : 0
+
+  name                = "${local.name}-log-alerts-ag"
+  resource_group_name = azurerm_resource_group.this.name
+  short_name          = "logalerts"
+
+  tags = local.minimum_resource_tags
+
+  dynamic "email_receiver" {
+    for_each = var.alert_email_recipients
+    content {
+      name                    = "email-${email_receiver.key}"
+      email_address           = email_receiver.value
+      use_common_alert_schema = true
+    }
+  }
+
+  dynamic "logic_app_receiver" {
+    for_each = var.alert_slack_webhook_url != "" ? [1] : []
+    content {
+      name                    = "slack-via-logic-app"
+      resource_id             = azurerm_logic_app_workflow.slack_log_alerts[0].id
+      callback_url            = azurerm_logic_app_trigger_http_request.slack_log_alerts[0].callback_url
       use_common_alert_schema = true
     }
   }
@@ -389,15 +515,21 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "job_failure_events" {
       | where Type_s != "Normal"
         and JobName_s != ""
         and Reason_s !in ("FailedMount", "FailedToRetrieveImagePullSecret")
-      | summarize AlertCount = count()
+      | summarize AlertCount = count() by JobName_s
     KQL
 
-    # Aggregating the measure column, not the row count: the query returns a row
-    # with AlertCount = 0 when nothing matches, so counting rows would always fire.
     time_aggregation_method = "Total"
     metric_measure_column   = "AlertCount"
     operator                = "GreaterThan"
     threshold               = 0
+
+    # Splitting on the job name gives each job its own alert instance and puts the
+    # name in the payload.
+    dimension {
+      name     = "JobName_s"
+      operator = "Include"
+      values   = ["*"]
+    }
 
     failing_periods {
       number_of_evaluation_periods             = 1
@@ -406,7 +538,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "job_failure_events" {
   }
 
   action {
-    action_groups = [azurerm_monitor_action_group.alerts[0].id]
+    action_groups = [azurerm_monitor_action_group.log_alerts[0].id]
   }
 }
 

--- a/infra/app/alerts.tf
+++ b/infra/app/alerts.tf
@@ -461,10 +461,7 @@ resource "azurerm_logic_app_action_http" "post_log_alert_to_slack" {
         },
         {
           "type": "section",
-          "fields": [
-            { "type": "mrkdwn", "text": "*Status:*\n@{triggerBody()?['data']?['essentials']?['monitorCondition']}" },
-            { "type": "mrkdwn", "text": "*Alert Events:*\n@{if(equals(triggerBody()?['data']?['essentials']?['monitorCondition'], 'Resolved'), '0', string(triggerBody()?['data']?['alertContext']?['condition']?['allOf']?[0]?['metricValue']))}" }
-          ]
+          "fields": [{ "type": "mrkdwn", "text": "*Status:*\n@{triggerBody()?['data']?['essentials']?['monitorCondition']}" }]
         },
         {
           "type": "section",

--- a/infra/app/alerts.tf
+++ b/infra/app/alerts.tf
@@ -377,7 +377,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "job_failure_events" {
   description         = "Alert when container app jobs emit warning or error system log events"
   severity            = 1 # error
 
-  evaluation_frequency    = "PT15M"
+  evaluation_frequency    = "PT5M"
   window_duration         = "PT15M"
   auto_mitigation_enabled = true
 

--- a/infra/app/alerts.tf
+++ b/infra/app/alerts.tf
@@ -580,13 +580,18 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "job_error_logs" {
   tags = local.minimum_resource_tags
 
   criteria {
+    # Returning the lines within 10s of a failure
     query = <<-KQL
+      let failures = ContainerAppConsoleLogs_CL
+        | where ContainerJobName_s != ""
+        | extend Level = coalesce(extract(@"level=(\w+)", 1, Log_s), extract(@"\[(\w+)\s*\]", 1, Log_s))
+        | where Level in ("error", "critical")
+          or Log_s has "Traceback (most recent call last)"
+        | summarize FirstFailure = min(TimeGenerated), LastFailure = max(TimeGenerated) by ContainerGroupName_s;
       ContainerAppConsoleLogs_CL
-      | where ContainerJobName_s != ""
-      | extend Level = coalesce(extract(@"level=(\w+)", 1, Log_s), extract(@"\[(\w+)\s*\]", 1, Log_s))
-      | where Level in ("error", "critical")
-        or Log_s has "Traceback (most recent call last)"
-      | project TimeGenerated, ContainerJobName_s, Level, Log_s
+      | join kind=inner failures on ContainerGroupName_s
+      | where TimeGenerated between (FirstFailure - 10s .. LastFailure + 10s)
+      | project TimeGenerated, ContainerJobName_s, ContainerGroupName_s, Log_s
     KQL
 
     time_aggregation_method = "Count"

--- a/infra/app/alerts.tf
+++ b/infra/app/alerts.tf
@@ -95,9 +95,6 @@ resource "azurerm_logic_app_action_http" "post_to_slack" {
   BODY
 }
 
-# Log search alerts get their own logic app rather than sharing post_to_slack. The
-# payloads differ enough that one shared body would need conditionals on every field,
-# and keeping them apart means changes here can't break the metric alerts.
 resource "azurerm_logic_app_workflow" "slack_log_alerts" {
   count = local.env.alerts_enabled && var.alert_slack_webhook_url != "" ? 1 : 0
 
@@ -130,7 +127,8 @@ resource "azurerm_logic_app_trigger_http_request" "slack_log_alerts" {
                 "severity": { "type": "string" },
                 "monitorCondition": { "type": "string" },
                 "description": { "type": "string" },
-                "firedDateTime": { "type": "string" }
+                "firedDateTime": { "type": "string" },
+                "alertTargetIDs": { "type": "array" }
               }
             },
             "alertContext": { "type": "object" }
@@ -162,7 +160,7 @@ resource "azurerm_logic_app_action_http" "post_log_alert_to_slack" {
           "type": "header",
           "text": {
             "type": "plain_text",
-            "text": "@{if(equals(triggerBody()?['data']?['essentials']?['monitorCondition'], 'Resolved'), '✅ RESOLVED', '❌ JOB FAILURE')} @{first(triggerBody()?['data']?['alertContext']?['condition']?['allOf'][0]?['dimensions'])?['value']}",
+            "text": "@{if(equals(triggerBody()?['data']?['essentials']?['monitorCondition'], 'Resolved'), '✅ RESOLVED', '❌ FAILURE')} @{first(triggerBody()?['data']?['alertContext']?['condition']?['allOf'][0]?['dimensions'])?['value']}",
             "emoji": true
           }
         },
@@ -179,7 +177,7 @@ resource "azurerm_logic_app_action_http" "post_log_alert_to_slack" {
         },
         {
           "type": "section",
-          "text": { "type": "mrkdwn", "text": "<@{triggerBody()?['data']?['alertContext']?['condition']?['allOf'][0]?['linkToFilteredSearchResultsUI']}|🔍 View matching logs>    <https://portal.azure.com/#resource/subscriptions/${data.azurerm_subscription.current.subscription_id}/resourceGroups/${azurerm_resource_group.this.name}/providers/Microsoft.App/jobs/@{first(triggerBody()?['data']?['alertContext']?['condition']?['allOf'][0]?['dimensions'])?['value']}|📋 Job execution history>" }
+          "text": { "type": "mrkdwn", "text": "<@{triggerBody()?['data']?['alertContext']?['condition']?['allOf'][0]?['linkToFilteredSearchResultsUI']}|🔍 View matching logs>    <https://portal.azure.com/#@${data.azurerm_subscription.current.tenant_id}/resource@{first(triggerBody()?['data']?['essentials']?['alertTargetIDs'])}|📋 View resource>" }
         },
         {
           "type": "context",
@@ -219,8 +217,6 @@ resource "azurerm_monitor_action_group" "alerts" {
   }
 }
 
-# Routes to the log-alert logic app instead. Alert rules choose their Slack card by
-# choosing an action group, since an action group notifies every receiver it holds.
 resource "azurerm_monitor_action_group" "log_alerts" {
   count = local.env.alerts_enabled ? 1 : 0
 
@@ -500,7 +496,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "job_failure_events" {
   resource_group_name = azurerm_resource_group.this.name
   location            = azurerm_resource_group.this.location
   scopes              = [data.azurerm_log_analytics_workspace.container_apps.id]
-  description         = "Alert when container app jobs emit warning or error system log events"
+  description         = "A container app job in ${var.environment} has failed."
   severity            = 1 # error
 
   evaluation_frequency    = "PT5M"
@@ -510,21 +506,25 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "job_failure_events" {
   tags = local.minimum_resource_tags
 
   criteria {
+    # The rows carry no _ResourceId, so rebuild the job's ARM ID and hand it to
+    # resource_id_column. Retargets the alert from the workspace onto
+    # the job itself.
     query = <<-KQL
       ContainerAppSystemLogs_CL
       | where Type_s != "Normal"
         and JobName_s != ""
         and Reason_s !in ("FailedMount", "FailedToRetrieveImagePullSecret")
-      | summarize AlertCount = count() by JobName_s
+      | extend ResourceId = tolower(strcat("/subscriptions/${data.azurerm_subscription.current.subscription_id}/resourceGroups/${azurerm_resource_group.this.name}/providers/Microsoft.App/jobs/", JobName_s))
+      | project TimeGenerated, JobName_s, Reason_s, Log_s, ResourceId
     KQL
 
-    time_aggregation_method = "Total"
-    metric_measure_column   = "AlertCount"
+    time_aggregation_method = "Count"
     operator                = "GreaterThan"
     threshold               = 0
+    resource_id_column      = "ResourceId"
 
-    # Splitting on the job name gives each job its own alert instance and puts the
-    # name in the payload.
+    # Splitting on the job name gives each job its own alert instance, puts the name
+    # in the payload.
     dimension {
       name     = "JobName_s"
       operator = "Include"

--- a/infra/app/alerts.tf
+++ b/infra/app/alerts.tf
@@ -562,3 +562,52 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "job_failure_events" {
     action_groups = [azurerm_monitor_action_group.log_alerts[0].id]
   }
 }
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "job_error_logs" {
+  count = local.env.alerts_enabled ? 1 : 0
+
+  name                = "${local.name}-job-error-logs"
+  resource_group_name = azurerm_resource_group.this.name
+  location            = azurerm_resource_group.this.location
+  scopes              = [data.azurerm_log_analytics_workspace.container_apps.id]
+  description         = "A container app job in ${var.environment} has logged an error."
+  severity            = 1 # error
+
+  evaluation_frequency    = "PT1M"
+  window_duration         = "PT5M"
+  auto_mitigation_enabled = true
+
+  tags = local.minimum_resource_tags
+
+  criteria {
+    query = <<-KQL
+      ContainerAppConsoleLogs_CL
+      | where ContainerJobName_s != ""
+      | extend Level = coalesce(extract(@"level=(\w+)", 1, Log_s), extract(@"\[(\w+)\s*\]", 1, Log_s))
+      | where Level in ("error", "critical")
+        or Log_s has "Traceback (most recent call last)"
+      | project TimeGenerated, ContainerJobName_s, Level, Log_s
+    KQL
+
+    time_aggregation_method = "Count"
+    operator                = "GreaterThan"
+    threshold               = 0
+
+    # Splitting on the job name gives each job its own alert instance, puts the name
+    # in the payload.
+    dimension {
+      name     = "ContainerJobName_s"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    failing_periods {
+      number_of_evaluation_periods             = 1
+      minimum_failing_periods_to_trigger_alert = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.log_alerts[0].id]
+  }
+}

--- a/infra/app/alerts.tf
+++ b/infra/app/alerts.tf
@@ -455,7 +455,7 @@ resource "azurerm_logic_app_action_http" "post_log_alert_to_slack" {
           "type": "header",
           "text": {
             "type": "plain_text",
-            "text": "@{if(equals(triggerBody()?['data']?['essentials']?['monitorCondition'], 'Resolved'), '✅ RESOLVED', '❌ FAILURE')} @{first(triggerBody()?['data']?['alertContext']?['condition']?['allOf'][0]?['dimensions'])?['value']}",
+            "text": "@{if(equals(triggerBody()?['data']?['essentials']?['monitorCondition'], 'Resolved'), '✅ RESOLVED', '❌ FAILURE')} @{first(triggerBody()?['data']?['alertContext']?['condition']?['allOf']?[0]?['dimensions'])?['value']}",
             "emoji": true
           }
         },
@@ -463,7 +463,7 @@ resource "azurerm_logic_app_action_http" "post_log_alert_to_slack" {
           "type": "section",
           "fields": [
             { "type": "mrkdwn", "text": "*Status:*\n@{triggerBody()?['data']?['essentials']?['monitorCondition']}" },
-            { "type": "mrkdwn", "text": "*Alert Events:*\n@{if(equals(triggerBody()?['data']?['essentials']?['monitorCondition'], 'Resolved'), '0', string(triggerBody()?['data']?['alertContext']?['condition']?['allOf'][0]?['metricValue']))}" }
+            { "type": "mrkdwn", "text": "*Alert Events:*\n@{if(equals(triggerBody()?['data']?['essentials']?['monitorCondition'], 'Resolved'), '0', string(triggerBody()?['data']?['alertContext']?['condition']?['allOf']?[0]?['metricValue']))}" }
           ]
         },
         {
@@ -472,7 +472,7 @@ resource "azurerm_logic_app_action_http" "post_log_alert_to_slack" {
         },
         {
           "type": "section",
-          "text": { "type": "mrkdwn", "text": "<@{triggerBody()?['data']?['alertContext']?['condition']?['allOf'][0]?['linkToFilteredSearchResultsUI']}|🔍 View matching logs>" }
+          "text": { "type": "mrkdwn", "text": "<@{triggerBody()?['data']?['alertContext']?['condition']?['allOf']?[0]?['linkToFilteredSearchResultsUI']}|🔍 View matching logs>" }
         },
         {
           "type": "context",
@@ -639,7 +639,7 @@ resource "azurerm_logic_app_action_custom" "filter_execution_name" {
       "type": "Query",
       "runAfter": {},
       "inputs": {
-        "from": "@coalesce(triggerBody()?['data']?['alertContext']?['condition']?['allOf'][0]?['dimensions'], json('[]'))",
+        "from": "@coalesce(triggerBody()?['data']?['alertContext']?['condition']?['allOf']?[0]?['dimensions'], json('[]'))",
         "where": "@equals(item()?['name'], 'executionName')"
       }
     }

--- a/infra/app/alerts.tf
+++ b/infra/app/alerts.tf
@@ -512,57 +512,6 @@ resource "azurerm_monitor_action_group" "log_alerts" {
   }
 }
 
-# "FailedMount" and "FailedToRetrieveImagePullSecret" are purposefully excluded
-# from the alert as these do not appear to stop the container app job running successfully
-# and would be unactionable alert noise.
-resource "azurerm_monitor_scheduled_query_rules_alert_v2" "job_failure_events" {
-  count = local.env.alerts_enabled ? 1 : 0
-
-  name                = "${local.name}-job-failure-events"
-  resource_group_name = azurerm_resource_group.this.name
-  location            = azurerm_resource_group.this.location
-  scopes              = [data.azurerm_log_analytics_workspace.container_apps.id]
-  description         = "A container app job in ${var.environment} has failed."
-  severity            = 1 # error
-
-  evaluation_frequency    = "PT1M"
-  window_duration         = "PT5M"
-  auto_mitigation_enabled = true
-
-  tags = local.minimum_resource_tags
-
-  criteria {
-    query = <<-KQL
-      ContainerAppSystemLogs_CL
-      | where Type_s != "Normal"
-        and JobName_s != ""
-        and Reason_s !in ("FailedMount", "FailedToRetrieveImagePullSecret")
-      | project TimeGenerated, JobName_s, Reason_s, Log_s
-    KQL
-
-    time_aggregation_method = "Count"
-    operator                = "GreaterThan"
-    threshold               = 0
-
-    # Splitting on the job name gives each job its own alert instance, puts the name
-    # in the payload.
-    dimension {
-      name     = "JobName_s"
-      operator = "Include"
-      values   = ["*"]
-    }
-
-    failing_periods {
-      number_of_evaluation_periods             = 1
-      minimum_failing_periods_to_trigger_alert = 1
-    }
-  }
-
-  action {
-    action_groups = [azurerm_monitor_action_group.log_alerts[0].id]
-  }
-}
-
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "job_error_logs" {
   count = local.env.alerts_enabled ? 1 : 0
 
@@ -614,5 +563,227 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "job_error_logs" {
 
   action {
     action_groups = [azurerm_monitor_action_group.log_alerts[0].id]
+  }
+}
+
+# --- Container App Job Execution Alerts ---
+
+locals {
+  job_failure_alert_targets = merge(
+    {
+      "es-index-migrator" = azurerm_container_app_job.es_index_migrator.id
+      "db-migrator"       = azurerm_container_app_job.database_migrator.id
+    },
+    {
+      for key, job in azurerm_container_app_job.scheduled_jobs :
+      replace(key, "_", "-") => job.id
+    },
+  )
+}
+
+resource "azurerm_logic_app_workflow" "slack_job_alerts" {
+  count = local.env.alerts_enabled && var.alert_slack_webhook_url != "" ? 1 : 0
+
+  name                = "${local.name}-slack-job-alerts"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+
+  tags = local.minimum_resource_tags
+}
+
+resource "azurerm_logic_app_trigger_http_request" "slack_job_alerts" {
+  count = local.env.alerts_enabled && var.alert_slack_webhook_url != "" ? 1 : 0
+
+  name         = "azure-monitor-webhook"
+  logic_app_id = azurerm_logic_app_workflow.slack_job_alerts[0].id
+
+  # schema: https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-common-schema
+  schema = <<-SCHEMA
+    {
+      "type": "object",
+      "properties": {
+        "schemaId": { "type": "string" },
+        "data": {
+          "type": "object",
+          "properties": {
+            "essentials": {
+              "type": "object",
+              "properties": {
+                "alertRule": { "type": "string" },
+                "severity": { "type": "string" },
+                "monitorCondition": { "type": "string" },
+                "description": { "type": "string" },
+                "firedDateTime": { "type": "string" },
+                "alertTargetIDs": { "type": "array" },
+                "configurationItems": { "type": "array" }
+              }
+            },
+            "alertContext": { "type": "object" }
+          }
+        }
+      }
+    }
+  SCHEMA
+}
+
+# The alert splits on two dimensions, so the execution name has to be selected by name
+# rather than by position.
+resource "azurerm_logic_app_action_custom" "filter_execution_name" {
+  count = local.env.alerts_enabled && var.alert_slack_webhook_url != "" ? 1 : 0
+
+  name         = "filter_execution_name"
+  logic_app_id = azurerm_logic_app_workflow.slack_job_alerts[0].id
+
+  body = <<-BODY
+    {
+      "type": "Query",
+      "runAfter": {},
+      "inputs": {
+        "from": "@coalesce(triggerBody()?['data']?['alertContext']?['condition']?['allOf'][0]?['dimensions'], json('[]'))",
+        "where": "@equals(item()?['name'], 'executionName')"
+      }
+    }
+  BODY
+}
+
+# Resolved notification carries no information. Instances still
+# auto-mitigate in the portal; they just don't post nonsense to slack.
+resource "azurerm_logic_app_action_custom" "post_job_alert_to_slack" {
+  count = local.env.alerts_enabled && var.alert_slack_webhook_url != "" ? 1 : 0
+
+  name         = "post_job_alert_to_slack"
+  logic_app_id = azurerm_logic_app_workflow.slack_job_alerts[0].id
+
+  # body: https://api.slack.com/block-kit
+  # expressions: https://learn.microsoft.com/en-us/azure/logic-apps/workflow-definition-language-functions-reference
+  body = <<-BODY
+    {
+      "type": "If",
+      "runAfter": {
+        "${azurerm_logic_app_action_custom.filter_execution_name[0].name}": ["Succeeded"]
+      },
+      "expression": {
+        "not": {
+          "equals": [
+            "@triggerBody()?['data']?['essentials']?['monitorCondition']",
+            "Resolved"
+          ]
+        }
+      },
+      "actions": {
+        "post_to_slack": {
+          "type": "Http",
+          "runAfter": {},
+          "inputs": {
+            "method": "POST",
+            "uri": "${var.alert_slack_webhook_url}",
+            "headers": { "Content-Type": "application/json" },
+            "body": {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "❌ JOB EXECUTION FAILED",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    { "type": "mrkdwn", "text": "*Job:*\n@{first(triggerBody()?['data']?['essentials']?['configurationItems'])}" },
+                    { "type": "mrkdwn", "text": "*Environment:*\n${var.environment}" }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": { "type": "mrkdwn", "text": "*Execution:*\n`@{first(body('${azurerm_logic_app_action_custom.filter_execution_name[0].name}'))?['value']}`" }
+                },
+                {
+                  "type": "section",
+                  "text": { "type": "mrkdwn", "text": "<https://portal.azure.com/#resource@{first(triggerBody()?['data']?['essentials']?['alertTargetIDs'])}/executionHistory|🔍 View execution history>" }
+                },
+                {
+                  "type": "context",
+                  "elements": [{ "type": "mrkdwn", "text": "@{triggerBody()?['data']?['essentials']?['alertRule']} · fired at @{triggerBody()?['data']?['essentials']?['firedDateTime']}" }]
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  BODY
+}
+
+resource "azurerm_monitor_action_group" "job_alerts" {
+  count = local.env.alerts_enabled ? 1 : 0
+
+  name                = "${local.name}-job-alerts-ag"
+  resource_group_name = azurerm_resource_group.this.name
+  short_name          = "jobalerts"
+
+  tags = local.minimum_resource_tags
+
+  dynamic "email_receiver" {
+    for_each = var.alert_email_recipients
+    content {
+      name                    = "email-${email_receiver.key}"
+      email_address           = email_receiver.value
+      use_common_alert_schema = true
+    }
+  }
+
+  dynamic "logic_app_receiver" {
+    for_each = var.alert_slack_webhook_url != "" ? [1] : []
+    content {
+      name                    = "slack-via-logic-app"
+      resource_id             = azurerm_logic_app_workflow.slack_job_alerts[0].id
+      callback_url            = azurerm_logic_app_trigger_http_request.slack_job_alerts[0].callback_url
+      use_common_alert_schema = true
+    }
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "job_execution_failed" {
+  for_each = local.env.alerts_enabled ? local.job_failure_alert_targets : {}
+
+  name                = "${local.name}-job-execution-failed-${each.key}"
+  resource_group_name = azurerm_resource_group.this.name
+  scopes              = [each.value]
+  description         = "A ${each.key} job execution in ${var.environment} has failed."
+  severity            = 1 # error
+  frequency           = "PT1M"
+  window_size         = "PT5M"
+  auto_mitigate       = true
+
+  tags = local.minimum_resource_tags
+
+  criteria {
+    metric_namespace = "Microsoft.App/jobs"
+    metric_name      = "Executions"
+    aggregation      = "Total"
+    operator         = "GreaterThan"
+    threshold        = 0
+
+    dimension {
+      name     = "state"
+      operator = "Include"
+      values   = ["Failed"]
+    }
+
+    # Splitting on the execution name gives each failed execution its own alert
+    # instance, and puts the name in the payload.
+    dimension {
+      name     = "executionName"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    skip_metric_validation = true
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.job_alerts[0].id
   }
 }

--- a/infra/app/alerts.tf
+++ b/infra/app/alerts.tf
@@ -525,8 +525,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "job_failure_events" {
   description         = "A container app job in ${var.environment} has failed."
   severity            = 1 # error
 
-  evaluation_frequency    = "PT5M"
-  window_duration         = "PT15M"
+  evaluation_frequency    = "PT1M"
+  window_duration         = "PT5M"
   auto_mitigation_enabled = true
 
   tags = local.minimum_resource_tags

--- a/infra/app/alerts.tf
+++ b/infra/app/alerts.tf
@@ -1,3 +1,8 @@
+data "azurerm_log_analytics_workspace" "container_apps" {
+  name                = module.container_app.container_app_env_name
+  resource_group_name = azurerm_resource_group.this.name
+}
+
 resource "azurerm_logic_app_workflow" "slack_alerts" {
   count = local.env.alerts_enabled && var.alert_slack_webhook_url != "" ? 1 : 0
 
@@ -353,6 +358,55 @@ resource "azurerm_monitor_metric_alert" "tasks_restart_count" {
 
   action {
     action_group_id = azurerm_monitor_action_group.alerts[0].id
+  }
+}
+
+# Scoped to the workspace rather than the jobs: _ResourceId is empty on
+# ContainerAppSystemLogs_CL rows, so a resource-scoped rule would match nothing.
+# Hooray.
+# "FailedMount" and "FailedToRetrieveImagePullSecret" are also purposefully excluded
+# from the alert as these do not appear to stop the container app job running successfully
+# and would be unactionable alert noise.
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "job_failure_events" {
+  count = local.env.alerts_enabled ? 1 : 0
+
+  name                = "${local.name}-job-failure-events"
+  resource_group_name = azurerm_resource_group.this.name
+  location            = azurerm_resource_group.this.location
+  scopes              = [data.azurerm_log_analytics_workspace.container_apps.id]
+  description         = "Alert when container app jobs emit warning or error system log events"
+  severity            = 1 # error
+
+  evaluation_frequency    = "PT15M"
+  window_duration         = "PT15M"
+  auto_mitigation_enabled = true
+
+  tags = local.minimum_resource_tags
+
+  criteria {
+    query = <<-KQL
+      ContainerAppSystemLogs_CL
+      | where Type_s != "Normal"
+        and JobName_s != ""
+        and Reason_s !in ("FailedMount", "FailedToRetrieveImagePullSecret")
+      | summarize AlertCount = count()
+    KQL
+
+    # Aggregating the measure column, not the row count: the query returns a row
+    # with AlertCount = 0 when nothing matches, so counting rows would always fire.
+    time_aggregation_method = "Total"
+    metric_measure_column   = "AlertCount"
+    operator                = "GreaterThan"
+    threshold               = 0
+
+    failing_periods {
+      number_of_evaluation_periods             = 1
+      minimum_failing_periods_to_trigger_alert = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.alerts[0].id]
   }
 }
 

--- a/infra/app/alerts.tf
+++ b/infra/app/alerts.tf
@@ -423,8 +423,7 @@ resource "azurerm_logic_app_trigger_http_request" "slack_log_alerts" {
                 "severity": { "type": "string" },
                 "monitorCondition": { "type": "string" },
                 "description": { "type": "string" },
-                "firedDateTime": { "type": "string" },
-                "alertTargetIDs": { "type": "array" }
+                "firedDateTime": { "type": "string" }
               }
             },
             "alertContext": { "type": "object" }
@@ -473,7 +472,7 @@ resource "azurerm_logic_app_action_http" "post_log_alert_to_slack" {
         },
         {
           "type": "section",
-          "text": { "type": "mrkdwn", "text": "<@{triggerBody()?['data']?['alertContext']?['condition']?['allOf'][0]?['linkToFilteredSearchResultsUI']}|🔍 View matching logs>    <https://portal.azure.com/#@${data.azurerm_subscription.current.tenant_id}/resource@{first(triggerBody()?['data']?['essentials']?['alertTargetIDs'])}|📋 View resource>" }
+          "text": { "type": "mrkdwn", "text": "<@{triggerBody()?['data']?['alertContext']?['condition']?['allOf'][0]?['linkToFilteredSearchResultsUI']}|🔍 View matching logs>" }
         },
         {
           "type": "context",
@@ -533,22 +532,17 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "job_failure_events" {
   tags = local.minimum_resource_tags
 
   criteria {
-    # The rows carry no _ResourceId, so rebuild the job's ARM ID and hand it to
-    # resource_id_column. Retargets the alert from the workspace onto
-    # the job itself.
     query = <<-KQL
       ContainerAppSystemLogs_CL
       | where Type_s != "Normal"
         and JobName_s != ""
         and Reason_s !in ("FailedMount", "FailedToRetrieveImagePullSecret")
-      | extend ResourceId = tolower(strcat("/subscriptions/${data.azurerm_subscription.current.subscription_id}/resourceGroups/${azurerm_resource_group.this.name}/providers/Microsoft.App/jobs/", JobName_s))
-      | project TimeGenerated, JobName_s, Reason_s, Log_s, ResourceId
+      | project TimeGenerated, JobName_s, Reason_s, Log_s
     KQL
 
     time_aggregation_method = "Count"
     operator                = "GreaterThan"
     threshold               = 0
-    resource_id_column      = "ResourceId"
 
     # Splitting on the job name gives each job its own alert instance, puts the name
     # in the payload.

--- a/infra/app/alerts.tf
+++ b/infra/app/alerts.tf
@@ -463,7 +463,7 @@ resource "azurerm_logic_app_action_http" "post_log_alert_to_slack" {
           "type": "section",
           "fields": [
             { "type": "mrkdwn", "text": "*Status:*\n@{triggerBody()?['data']?['essentials']?['monitorCondition']}" },
-            { "type": "mrkdwn", "text": "*Matching events:*\n@{triggerBody()?['data']?['alertContext']?['condition']?['allOf'][0]?['metricValue']}" }
+            { "type": "mrkdwn", "text": "*Alert Events:*\n@{if(equals(triggerBody()?['data']?['essentials']?['monitorCondition'], 'Resolved'), '0', string(triggerBody()?['data']?['alertContext']?['condition']?['allOf'][0]?['metricValue']))}" }
           ]
         },
         {

--- a/infra/app/locals.tf
+++ b/infra/app/locals.tf
@@ -16,13 +16,7 @@ locals {
       db_ha_enabled   = false
       db_sku_name     = "GP_Standard_D2ds_v4"
 
-      alerts_enabled          = true
-      db_storage_warning_pct  = 70
-      db_storage_critical_pct = 85
-      db_cpu_warning_pct      = 80
-      db_cpu_critical_pct     = 90
-      db_memory_warning_pct   = 80
-      db_memory_critical_pct  = 90
+      alerts_enabled = false
 
       db_log_retention_days         = 30
       db_logfiles_retention_days    = 3

--- a/infra/app/locals.tf
+++ b/infra/app/locals.tf
@@ -16,7 +16,13 @@ locals {
       db_ha_enabled   = false
       db_sku_name     = "GP_Standard_D2ds_v4"
 
-      alerts_enabled = false
+      alerts_enabled          = true
+      db_storage_warning_pct  = 70
+      db_storage_critical_pct = 85
+      db_cpu_warning_pct      = 80
+      db_cpu_critical_pct     = 90
+      db_memory_warning_pct   = 80
+      db_memory_critical_pct  = 90
 
       db_log_retention_days         = 30
       db_logfiles_retention_days    = 3


### PR DESCRIPTION
## Context

Closes #866 

Introduce alerting on container app job failures, one on execution failures and one on container app console logs. 

## What's Changed?
* Have added an alert for failing container app job executions that provides the job execution name in slack 
    * This replaced an earlier attempt to do an alert with a direct link to failing systems logs, which was too noisy (see [slack thread](https://covidence.slack.com/archives/C0998FP5743/p1786314471377389) if curious)
    * Alert example https://covidence.slack.com/archives/C0998FP5743/p1786317696596409
* Have added an alert that returns a container app console log failure
    * This includes a link to all log lines 10s before and 10s after the failure happens.
    * Alert example https://covidence.slack.com/archives/C0998FP5743/p1786072361930959
* The console alert will capture any new container app jobs manually, while the metric alert will catch any new jobs added using our scheduling terraform, but will need manual jobs added to it).
* We now have a separate slack flow for posting log search alerts to our alerting channels as well as a custom slack flow for posting container app job metrics alerts. 
    * This appropriately formats log search alerts and includes links to the relevant logs when they fire, as well as including execution name in the body of the metrics-based alert
    * Have accepted some duplication in terraform here to avoid long long strings of conditional formatting in the body of the slack message in terraform. It was getting out of hand and wholly unreadable. I also prioritized having the most useful alerts in slack possible instead of trying to limit the amount of terraform. 

I will do a follow up PR to rename the metrics alert resources to match the log metrics resources naming convention, e.g. `slack_alerts` -> `slack_metric_alerts`. I didn't want to muddy the diff and terraform plan/applies here. 

I will also revert the turning on of alerts in dev before merging.

## Some explicit decisions to improve diagnostics

* Log searchs alerts set the Resource they alert on to the _log analytics workspace_ the search is run against. 
   * This prevents us linking from slack alert -> affected job without manual brittle construction of resource urls that we shove into the alert body. I've elected to leave direct job resource links off the slack alerts in favour of logging links that actually work
   * Overriding the resource id breaks logging urls 
* Alert Events on the console logs alert will be high - it includes all of the related log lines, whereas with the system logs alert it should group slightly better. This is due to the fact that we are returning enough log lines from the alert query to immediately provide diagnostic information, otherwise if the alert is triggered off a "Traceback" match, you will get the single Traceback line with no additional info and this isn't particular actionable. 
    * There's potentially more conditional faff we could do in the slack alert body, but this was starting to feel like a rabbithole so I've left it alone.    
* We **do not** alert if a scheduled job fails to schedule in a way that does not trigger an execution. This felt like a huge rabbithole for minimal value, we are not broadly impacted if an expiry of pending enhancements does not run. 

## If you want to click something and/or test

Feel free to trigger failures in the development environment to test things out, for example you can run a start command with a non-existent image to get a console log alert. 

```
az containerapp job start \
  -g rg-destiny-repository-development \
  -n expire-pending-enhancements-deve \
  --container-name expire-pending-enhancements-deve \
  --image destinyevidenceregistry.azurecr.io/destiny-repository:91ebf3c \
  --command "/bin/echo" \
  --args "level=error manual alert test"
```

It creates an alert like here https://covidence.slack.com/archives/C0998FP5743/p1786072361930959
