### PR TITLE
Build the deduplication assessment path

### DIFF
--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -648,6 +648,10 @@ class DeduplicationError(DestinyRepositoryError):
         super().__init__(detail)
 
 
+class DeduplicationNotFoundError(NotFoundError, DeduplicationError):
+    """A deduplication input could not be found or hydrated."""
+
+
 class DeduplicationValueError(DeduplicationError, ValueError):
     """An exception for when a value provided to deduplication is invalid."""
 

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -1191,6 +1191,40 @@ class DeduplicationAssessment(BaseModel):
     unscorable_candidate_ids: list[UUID] = Field(default_factory=list)
 
 
+# The enhancement types the Deduper compares. Abstracts are excluded because its
+# scoring weights are configured without them, so sending one is wasted payload.
+SCORED_ENHANCEMENT_TYPES = (EnhancementType.BIBLIOGRAPHIC,)
+
+
+class DeduplicationPaper(ProjectedBaseModel):
+    """
+    The record shape the Deduper scores, built here rather than by the toolkit.
+
+    Mirrors the toolkit's ``Paper`` constructor so it can be handed over as
+    ``model_dump(exclude_none=True)``. Carries the fields the checked-in weights
+    score, plus identifiers and volume, which are unweighted today.
+    """
+
+    doi: destiny_sdk.identifiers.DOIIdentifier | None = None
+    openalex_id: destiny_sdk.identifiers.OpenAlexIdentifier | None = None
+    pubmed_id: destiny_sdk.identifiers.PubMedIdentifier | None = None
+    title: str | None = None
+    authors: list[destiny_sdk.enhancements.Authorship] | None = None
+    year: int | None = None
+    journal: str | None = None
+    pages: str | None = None
+    volume: str | None = None
+    issue: str | None = None
+
+    @model_validator(mode="after")
+    def validate_not_empty(self) -> Self:
+        """Reject an empty paper, which is the toolkit's own rejection too."""
+        if all(value is None for value in self.model_dump().values()):
+            msg = "A deduplication paper needs at least one populated field"
+            raise ValueError(msg)
+        return self
+
+
 class LinkedDataProjection(ProjectedBaseModel):
     """Result of projecting a LinkedDataEnhancement into flat searchable fields."""
 

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -18,6 +18,7 @@ from pydantic import (
     ConfigDict,
     Field,
     HttpUrl,
+    JsonValue,
     PositiveInt,
     StringConstraints,
     TypeAdapter,
@@ -952,10 +953,20 @@ class CandidateSelectionInput(BaseModel):
         default_factory=list,
         description="Identifiers to union with the Elasticsearch candidates.",
     )
+    excluded_reference_id: UUID | None = Field(
+        default=None,
+        description="Reference ID to exclude from inline candidate selection.",
+    )
 
     @model_validator(mode="after")
     def validate_exactly_one_input_mode(self) -> Self:
         """Require exactly one of reference_id or inline candidate-search fields."""
+        if self.reference_id is not None and self.excluded_reference_id is not None:
+            msg = (
+                "excluded_reference_id applies to inline input; the reference_id "
+                "mode already excludes its own reference."
+            )
+            raise ValueError(msg)
         has_reference_id = self.reference_id is not None
         has_inline = bool(
             self.title or self.authors or self.publication_year or self.identifiers
@@ -1092,6 +1103,92 @@ class CandidateSelectionResult(BaseModel):
     input_searchability: InputSearchability
     diagnostics: CandidateSelectionDiagnostics
     candidates: list[Candidate] = Field(default_factory=list)
+
+
+class DeduplicationFieldStatus(StrEnum):
+    """How the values for one scored field relate across a reference pair."""
+
+    MATCH = auto()
+    """Both values are present and match."""
+    MISMATCH = auto()
+    """Both values are present and differ."""
+    MISSING_INCOMING = auto()
+    """Only the incoming value is missing."""
+    MISSING_CANDIDATE = auto()
+    """Only the candidate value is missing."""
+    MISSING_BOTH = auto()
+    """Both values are missing."""
+
+
+class DeduplicationFieldComparison(BaseModel):
+    """Compared values, availability and score for one Deduper field."""
+
+    incoming_value: JsonValue | None = None
+    candidate_value: JsonValue | None = None
+    status: DeduplicationFieldStatus
+    score: float | None = None
+
+
+class DeduplicationPairResult(BaseModel):
+    """Structured evidence returned by a Deduper adapter for one pair."""
+
+    probability: float | None = Field(default=None, ge=0, le=1)
+    field_comparisons: dict[str, DeduplicationFieldComparison] = Field(
+        default_factory=dict
+    )
+    early_stop_reason: str | None = None
+    doi_mismatch_adjusted: bool = False
+    suggested_label: str | None = None
+    unscorable_reason: str | None = None
+
+    @model_validator(mode="after")
+    def validate_scoring_state(self) -> Self:
+        """Require either a probability or an unscorable reason."""
+        if (self.probability is None) == (self.unscorable_reason is None):
+            msg = "Exactly one of probability or unscorable_reason is required"
+            raise ValueError(msg)
+        return self
+
+
+class DeduperMetadata(BaseModel):
+    """Identity and effective configuration of one loaded Deduper."""
+
+    package_version: str
+    configuration_hash: str
+    threshold: float = Field(ge=0, le=1)
+    effective_configuration: dict[str, JsonValue] = Field(default_factory=dict)
+
+
+class ScoredDeduplicationCandidate(BaseModel):
+    """One retrieved candidate and the Deduper evidence for its pair."""
+
+    candidate: Candidate
+    pair_result: DeduplicationPairResult
+    clears_threshold: bool | None
+
+
+class DeduplicationAssessmentOutcome(StrEnum):
+    """Reference-level proposal produced from all threshold-clearing pairs."""
+
+    PROPOSE_CANONICAL = auto()
+    """Every pair scored below threshold and the input was searchable."""
+    PROPOSE_DUPLICATE = auto()
+    """Every pair was scored and exactly one candidate cleared the threshold."""
+    NO_PROPOSAL = auto()
+    """The input was unsearchable, scoring was incomplete, or matches conflicted."""
+
+
+class DeduplicationAssessment(BaseModel):
+    """Read-only candidate retrieval and pair-scoring result for one reference."""
+
+    incoming_reference_id: UUID
+    candidate_selection: CandidateSelectionResult
+    deduper: DeduperMetadata
+    scored_candidates: list[ScoredDeduplicationCandidate] = Field(default_factory=list)
+    outcome: DeduplicationAssessmentOutcome
+    proposed_duplicate_of_id: UUID | None = None
+    threshold_clearing_candidate_ids: list[UUID] = Field(default_factory=list)
+    unscorable_candidate_ids: list[UUID] = Field(default_factory=list)
 
 
 class LinkedDataProjection(ProjectedBaseModel):

--- a/app/domain/references/models/projections.py
+++ b/app/domain/references/models/projections.py
@@ -9,13 +9,16 @@ import destiny_sdk
 from app.core.exceptions import ProjectionError
 from app.domain.base import GenericProjection
 from app.domain.references.models.models import (
+    SCORED_ENHANCEMENT_TYPES,
     CandidateCanonicalSearchFields,
     CandidateIdentifier,
     CandidateReference,
+    DeduplicationPaper,
     Enhancement,
     EnhancementRequest,
     EnhancementRequestStatus,
     EnhancementType,
+    ExternalIdentifierType,
     PendingEnhancementStatus,
     Reference,
     ReferenceSearchFields,
@@ -264,6 +267,112 @@ class CandidateReferenceProjection(GenericProjection[CandidateReference]):
                 for linked in (reference.identifiers or [])
             ],
         )
+
+
+def _scored_contents_by_priority_untimed_lowest(
+    reference: Reference,
+) -> list[destiny_sdk.enhancements.BibliographicMetadataEnhancement]:
+    """
+    Order scored enhancement contents by increasing priority.
+
+    Supplied references are built in memory and carry no ``created_at``, which the
+    shared sort rejects, so those hold input order below anything stored.
+    """
+    scored = [
+        enhancement
+        for enhancement in reference.enhancements or []
+        if enhancement.content.enhancement_type in SCORED_ENHANCEMENT_TYPES
+    ]
+    untimed = [enhancement for enhancement in scored if not enhancement.created_at]
+    timed = [enhancement for enhancement in scored if enhancement.created_at]
+    ordered = untimed + _priority_sorted_enhancements(reference.id, timed)
+    # isinstance narrows what the enum filter above already selected; it is not a
+    # second policy on which types are scored.
+    return [
+        enhancement.content
+        for enhancement in ordered
+        if isinstance(
+            enhancement.content,
+            destiny_sdk.enhancements.BibliographicMetadataEnhancement,
+        )
+    ]
+
+
+class DeduplicationPaperProjection(GenericProjection[DeduplicationPaper]):
+    """Projection from a reference to the record shape the Deduper scores."""
+
+    @classmethod
+    def get_from_reference(cls, reference: Reference) -> DeduplicationPaper:
+        """
+        Project a hydrated reference into Deduper-scoreable fields.
+
+        :param reference: The reference to project from.
+        :type reference: app.domain.references.models.models.Reference
+        :raises ProjectionError: If nothing scoreable projects.
+        :return: The projected paper.
+        :rtype: DeduplicationPaper
+        """
+        try:
+            identifiers = {
+                linked.identifier.identifier_type: linked.identifier
+                for linked in (reference.identifiers or [])
+            }
+            doi = identifiers.get(ExternalIdentifierType.DOI)
+            open_alex = identifiers.get(ExternalIdentifierType.OPEN_ALEX)
+            pubmed = identifiers.get(ExternalIdentifierType.PM_ID)
+
+            title, year, journal, pages, volume, issue = (None,) * 6
+            authors: list[destiny_sdk.enhancements.Authorship] | None = None
+
+            for content in _scored_contents_by_priority_untimed_lowest(reference):
+                # Hydrate if present on this enhancement, otherwise keep prior value
+                title = content.title or title
+                # Stored order is the citation sequence; reordering would lose it
+                authors = content.authorship or authors
+                year = (
+                    content.publication_year
+                    or (
+                        content.publication_date.year
+                        if content.publication_date
+                        else None
+                    )
+                    or year
+                )
+                if venue := content.publication_venue:
+                    journal = venue.display_name or journal
+                if pagination := content.pagination:
+                    volume = pagination.volume or volume
+                    issue = pagination.issue or issue
+                    pages = cls._page_range(pagination) or pages
+
+            return DeduplicationPaper(
+                doi=doi
+                if isinstance(doi, destiny_sdk.identifiers.DOIIdentifier)
+                else None,
+                openalex_id=open_alex
+                if isinstance(open_alex, destiny_sdk.identifiers.OpenAlexIdentifier)
+                else None,
+                pubmed_id=pubmed
+                if isinstance(pubmed, destiny_sdk.identifiers.PubMedIdentifier)
+                else None,
+                title=title,
+                authors=authors,
+                year=year,
+                journal=journal,
+                pages=pages,
+                volume=volume,
+                issue=issue,
+            )
+        except Exception as exc:
+            msg = "Failed to project DeduplicationPaper from Reference"
+            raise ProjectionError(msg) from exc
+
+    @staticmethod
+    def _page_range(pagination: destiny_sdk.enhancements.Pagination) -> str | None:
+        """Join both endpoints, or nothing: one endpoint is a page number."""
+        if pagination.first_page and pagination.last_page:
+            return f"{pagination.first_page}-{pagination.last_page}"
+        return None
 
 
 class ReferenceRisProjection(GenericProjection[RisRecord]):

--- a/app/domain/references/repository.py
+++ b/app/domain/references/repository.py
@@ -6,7 +6,8 @@ from collections.abc import AsyncGenerator, Collection, Mapping, Sequence
 from typing import Any, ClassVar, Literal
 from uuid import UUID
 
-from elasticsearch import AsyncElasticsearch
+import elastic_transport
+from elasticsearch import ApiError, AsyncElasticsearch
 from elasticsearch.dsl import AsyncSearch, Q
 from elasticsearch.dsl.query import Bool, MatchAll, Prefix, Query, Range, Term, Terms
 from elasticsearch.dsl.response import Response
@@ -27,6 +28,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.core.config import get_settings
+from app.core.exceptions import ESError
 from app.core.telemetry.attributes import Attributes, trace_attribute
 from app.core.telemetry.repository import (
     trace_repository_generator,
@@ -266,6 +268,15 @@ class ReferenceSQLRepository(
         return [
             db_reference.to_domain(preload=preload) for db_reference in db_references
         ]
+
+
+_TOO_MANY_REQUESTS = 429
+_SERVER_ERROR = 500
+
+
+def _is_transient_es_status(status: int) -> bool:
+    """Whether an Elasticsearch status is worth surfacing as infrastructure failure."""
+    return status >= _SERVER_ERROR or status == _TOO_MANY_REQUESTS
 
 
 class ReferenceESRepository(
@@ -802,7 +813,17 @@ class ReferenceESRepository(
         if track_total_hits:
             search = search.extra(track_total_hits=True)
 
-        response = await search.execute()
+        try:
+            response = await search.execute()
+        except elastic_transport.TransportError as exc:
+            msg = f"Candidate search could not reach Elasticsearch: {exc}"
+            raise ESError(msg) from exc
+        except ApiError as exc:
+            # A 4xx means this query is malformed, which is a defect and stays fatal.
+            if not _is_transient_es_status(exc.meta.status):
+                raise
+            msg = f"Candidate search unavailable ({exc.meta.status}): {exc}"
+            raise ESError(msg) from exc
 
         hits = sorted(
             [

--- a/app/domain/references/services/anti_corruption_service.py
+++ b/app/domain/references/services/anti_corruption_service.py
@@ -95,17 +95,6 @@ class ReferenceAntiCorruptionService(GenericAntiCorruptionService):
         self, reference: RedactedReference
     ) -> destiny_sdk.references.Reference:
         """Convert the reference to a Reference SDK model."""
-        return await self._reference_to_sdk(reference)
-
-    async def internal_reference_to_sdk(
-        self, reference: Reference
-    ) -> destiny_sdk.references.Reference:
-        """Convert an unredacted reference for internal use, never an API response."""
-        return await self._reference_to_sdk(reference)
-
-    async def _reference_to_sdk(
-        self, reference: Reference
-    ) -> destiny_sdk.references.Reference:
         try:
             enhancements = [
                 await self.enhancement_to_sdk(enhancement)

--- a/app/domain/references/services/anti_corruption_service.py
+++ b/app/domain/references/services/anti_corruption_service.py
@@ -95,6 +95,17 @@ class ReferenceAntiCorruptionService(GenericAntiCorruptionService):
         self, reference: RedactedReference
     ) -> destiny_sdk.references.Reference:
         """Convert the reference to a Reference SDK model."""
+        return await self._reference_to_sdk(reference)
+
+    async def internal_reference_to_sdk(
+        self, reference: Reference
+    ) -> destiny_sdk.references.Reference:
+        """Convert an unredacted reference for internal use, never an API response."""
+        return await self._reference_to_sdk(reference)
+
+    async def _reference_to_sdk(
+        self, reference: Reference
+    ) -> destiny_sdk.references.Reference:
         try:
             enhancements = [
                 await self.enhancement_to_sdk(enhancement)

--- a/app/domain/references/services/deduplication_assessment_service.py
+++ b/app/domain/references/services/deduplication_assessment_service.py
@@ -4,7 +4,6 @@ from collections.abc import Awaitable, Callable
 from typing import Protocol
 from uuid import UUID
 
-import destiny_sdk
 from pydantic import ValidationError
 from sqlalchemy.exc import InterfaceError, OperationalError
 
@@ -29,10 +28,8 @@ from app.domain.references.models.models import (
 )
 from app.domain.references.models.projections import CandidateReferenceProjection
 from app.domain.references.services.access_control_service import (
+    RedactedReference,
     ReferenceAccessControlService,
-)
-from app.domain.references.services.anti_corruption_service import (
-    ReferenceAntiCorruptionService,
 )
 
 CandidateSelector = Callable[
@@ -71,8 +68,8 @@ class PairScorer(Protocol):
 
     async def score_pair(
         self,
-        incoming: destiny_sdk.references.Reference,
-        candidate: destiny_sdk.references.Reference,
+        incoming: RedactedReference,
+        candidate: RedactedReference,
     ) -> DeduplicationPairResult:
         """Score one incoming-reference and candidate pair."""
         ...
@@ -86,39 +83,34 @@ class DeduplicationAssessmentService:
         *,
         candidate_selector: CandidateSelector,
         reference_reader: ReferenceReader,
-        anti_corruption_service: ReferenceAntiCorruptionService,
         pair_scorer: PairScorer,
     ) -> None:
         """Initialize the service with read-only assessment dependencies."""
         self._candidate_selector = candidate_selector
         self._reference_reader = reference_reader
-        self._anti_corruption_service = anti_corruption_service
         self._pair_scorer = pair_scorer
         # Entitlements are deliberately empty: the scorer compares bibliographic
         # fields, so nothing here may reach full text.
         self._access_control_service = ReferenceAccessControlService()
 
-    async def _to_scorer_view(
-        self, reference: Reference
-    ) -> destiny_sdk.references.Reference:
-        """Convert a reference to the least-privileged SDK view the scorer sees."""
-        return await self._anti_corruption_service.reference_to_sdk(
-            self._access_control_service.redact_reference(reference)
-        )
+    def _to_scorer_view(self, reference: Reference) -> RedactedReference:
+        """Reduce a reference to the least-privileged view the scorer sees."""
+        return self._access_control_service.redact_reference(reference)
 
     @staticmethod
-    def _scored_view(
-        reference: destiny_sdk.references.Reference,
-    ) -> destiny_sdk.references.Reference:
+    def _scored_view(reference: RedactedReference) -> RedactedReference:
         """Present only the enhancement types the Deduper compares."""
-        return reference.model_copy(
-            update={
-                "enhancements": [
-                    enhancement
-                    for enhancement in reference.enhancements or []
-                    if enhancement.content.enhancement_type in SCORED_ENHANCEMENT_TYPES
-                ]
-            }
+        return RedactedReference(
+            reference.model_copy(
+                update={
+                    "enhancements": [
+                        enhancement
+                        for enhancement in reference.enhancements or []
+                        if enhancement.content.enhancement_type
+                        in SCORED_ENHANCEMENT_TYPES
+                    ]
+                }
+            )
         )
 
     async def _hydrate_one(self, reference_id: UUID) -> Reference:
@@ -140,7 +132,6 @@ class DeduplicationAssessmentService:
     ) -> DeduplicationAssessment:
         """Assess a stored reference from one hydrated input snapshot."""
         reference = await self._hydrate_one(reference_id)
-        incoming = await self._to_scorer_view(reference)
         candidate_reference = CandidateReferenceProjection.get_from_reference(reference)
         # A reference can project to nothing searchable, which the input model
         # rejects. Convert it rather than let a bare ValidationError escape.
@@ -156,7 +147,7 @@ class DeduplicationAssessmentService:
             msg = f"Cannot build a candidate query for {reference_id}: {exc}"
             raise DeduplicationValueError(msg) from exc
         return await self._assess(
-            incoming,
+            reference,
             selection_input,
             retrieval_policy=retrieval_policy,
             k=k,
@@ -164,14 +155,14 @@ class DeduplicationAssessmentService:
 
     async def evaluate_supplied(
         self,
-        incoming: destiny_sdk.references.Reference,
+        incoming: Reference,
         selection_input: CandidateSelectionInput,
         *,
         retrieval_policy: RetrievalPolicyName | None = None,
         k: int | None = None,
     ) -> DeduplicationAssessment:
         """
-        Assess a frozen SDK reference against a query the runner built.
+        Assess an unimported supplied reference against a query the runner built.
 
         The caller owns the query payload because it decides which fields and
         identifiers the record presents, and sets ``excluded_reference_id`` when the
@@ -186,16 +177,16 @@ class DeduplicationAssessmentService:
 
     async def _assess(
         self,
-        incoming: destiny_sdk.references.Reference,
+        incoming: Reference,
         selection_input: CandidateSelectionInput,
         *,
         retrieval_policy: RetrievalPolicyName | None,
         k: int | None,
     ) -> DeduplicationAssessment:
         """Find, hydrate and score every candidate under one assessment."""
-        # Filter here rather than per entrypoint: a supplied record carries whatever
+        # Reduce here rather than per entrypoint: a supplied record carries whatever
         # its dataset held, and both sides must reach the scorer alike.
-        incoming = self._scored_view(incoming)
+        scored_incoming = self._scored_view(self._to_scorer_view(incoming))
         try:
             candidate_selection = await self._candidate_selector(
                 CandidateSelectionRequest(
@@ -247,11 +238,11 @@ class DeduplicationAssessmentService:
         scorer_metadata = self._pair_scorer.metadata.model_copy(deep=True)
         threshold = scorer_metadata.threshold
         for candidate in candidate_selection.candidates:
-            candidate_sdk = self._scored_view(
-                await self._to_scorer_view(candidates_by_id[candidate.reference_id])
+            candidate_view = self._scored_view(
+                self._to_scorer_view(candidates_by_id[candidate.reference_id])
             )
             pair_result = await self._pair_scorer.score_pair(
-                incoming=incoming, candidate=candidate_sdk
+                incoming=scored_incoming, candidate=candidate_view
             )
             clears_threshold = (
                 pair_result.probability >= threshold

--- a/app/domain/references/services/deduplication_assessment_service.py
+++ b/app/domain/references/services/deduplication_assessment_service.py
@@ -12,8 +12,10 @@ from app.core.exceptions import (
     DeduplicationNotFoundError,
     DeduplicationValueError,
     ESError,
+    ProjectionError,
 )
 from app.domain.references.models.models import (
+    SCORED_ENHANCEMENT_TYPES,
     CandidateSelectionInput,
     CandidateSelectionRequest,
     CandidateSelectionResult,
@@ -21,14 +23,16 @@ from app.domain.references.models.models import (
     DeduplicationAssessment,
     DeduplicationAssessmentOutcome,
     DeduplicationPairResult,
-    EnhancementType,
+    DeduplicationPaper,
     Reference,
     RetrievalPolicyName,
     ScoredDeduplicationCandidate,
 )
-from app.domain.references.models.projections import CandidateReferenceProjection
+from app.domain.references.models.projections import (
+    CandidateReferenceProjection,
+    DeduplicationPaperProjection,
+)
 from app.domain.references.services.access_control_service import (
-    RedactedReference,
     ReferenceAccessControlService,
 )
 
@@ -40,9 +44,9 @@ CandidateSelector = Callable[
 # Malformed queries and programming defects stay fatal, not one failed row per input.
 INFRASTRUCTURE_ERRORS = (ESError, OperationalError, InterfaceError)
 
-# The enhancement types the Deduper compares. Abstracts are excluded because its
-# scoring weights are configured without them, so sending one is wasted payload.
-SCORED_ENHANCEMENT_TYPES = (EnhancementType.BIBLIOGRAPHIC,)
+# Stored on the pair result, so it stays flat: the candidate id already travels
+# beside it on the scored candidate and in the unscorable id list.
+UNPROJECTABLE_CANDIDATE_REASON = "Candidate could not be projected for scoring."
 
 
 class ReferenceReader(Protocol):
@@ -68,8 +72,8 @@ class PairScorer(Protocol):
 
     async def score_pair(
         self,
-        incoming: RedactedReference,
-        candidate: RedactedReference,
+        incoming: DeduplicationPaper,
+        candidate: DeduplicationPaper,
     ) -> DeduplicationPairResult:
         """Score one incoming-reference and candidate pair."""
         ...
@@ -93,25 +97,16 @@ class DeduplicationAssessmentService:
         # fields, so nothing here may reach full text.
         self._access_control_service = ReferenceAccessControlService()
 
-    def _to_scorer_view(self, reference: Reference) -> RedactedReference:
+    def _to_scorer_paper(self, reference: Reference) -> DeduplicationPaper:
         """Reduce a reference to the least-privileged view the scorer sees."""
-        return self._access_control_service.redact_reference(reference)
-
-    @staticmethod
-    def _scored_view(reference: RedactedReference) -> RedactedReference:
-        """Present only the enhancement types the Deduper compares."""
-        return RedactedReference(
-            reference.model_copy(
-                update={
-                    "enhancements": [
-                        enhancement
-                        for enhancement in reference.enhancements or []
-                        if enhancement.content.enhancement_type
-                        in SCORED_ENHANCEMENT_TYPES
-                    ]
-                }
-            )
-        )
+        redacted = self._access_control_service.redact_reference(reference)
+        try:
+            return DeduplicationPaperProjection.get_from_reference(redacted)
+        except ProjectionError as exc:
+            # ``from exc`` keeps the projection failure as the cause, so the message
+            # does not need to restate it.
+            msg = f"Cannot build a deduplication paper for {reference.id}"
+            raise DeduplicationValueError(msg) from exc
 
     async def _hydrate_one(self, reference_id: UUID) -> Reference:
         """Read one stored reference, treating an empty result as not-found."""
@@ -186,7 +181,7 @@ class DeduplicationAssessmentService:
         """Find, hydrate and score every candidate under one assessment."""
         # Reduce here rather than per entrypoint: a supplied record carries whatever
         # its dataset held, and both sides must reach the scorer alike.
-        scored_incoming = self._scored_view(self._to_scorer_view(incoming))
+        scored_incoming = self._to_scorer_paper(incoming)
         try:
             candidate_selection = await self._candidate_selector(
                 CandidateSelectionRequest(
@@ -238,12 +233,20 @@ class DeduplicationAssessmentService:
         scorer_metadata = self._pair_scorer.metadata.model_copy(deep=True)
         threshold = scorer_metadata.threshold
         for candidate in candidate_selection.candidates:
-            candidate_view = self._scored_view(
-                self._to_scorer_view(candidates_by_id[candidate.reference_id])
-            )
-            pair_result = await self._pair_scorer.score_pair(
-                incoming=scored_incoming, candidate=candidate_view
-            )
+            try:
+                candidate_paper = self._to_scorer_paper(
+                    candidates_by_id[candidate.reference_id]
+                )
+            except DeduplicationValueError:
+                # One unprojectable candidate is not a failed assessment; it is a
+                # candidate the Deduper was never given a chance to score.
+                pair_result = DeduplicationPairResult(
+                    unscorable_reason=UNPROJECTABLE_CANDIDATE_REASON
+                )
+            else:
+                pair_result = await self._pair_scorer.score_pair(
+                    incoming=scored_incoming, candidate=candidate_paper
+                )
             clears_threshold = (
                 pair_result.probability >= threshold
                 if pair_result.probability is not None

--- a/app/domain/references/services/deduplication_assessment_service.py
+++ b/app/domain/references/services/deduplication_assessment_service.py
@@ -1,0 +1,248 @@
+"""Read-only orchestration for deep-deduplication assessments."""
+
+from collections.abc import Awaitable, Callable
+from typing import Protocol
+from uuid import UUID
+
+import destiny_sdk
+
+from app.core.exceptions import (
+    DeduplicationError,
+    DeduplicationNotFoundError,
+    DeduplicationValueError,
+)
+from app.domain.references.models.models import (
+    CandidateSelectionInput,
+    CandidateSelectionRequest,
+    CandidateSelectionResult,
+    DeduperMetadata,
+    DeduplicationAssessment,
+    DeduplicationAssessmentOutcome,
+    DeduplicationPairResult,
+    EnhancementType,
+    Reference,
+    RetrievalPolicyName,
+    ScoredDeduplicationCandidate,
+)
+from app.domain.references.models.projections import CandidateReferenceProjection
+from app.domain.references.services.anti_corruption_service import (
+    ReferenceAntiCorruptionService,
+)
+
+CandidateSelector = Callable[
+    [CandidateSelectionRequest], Awaitable[CandidateSelectionResult]
+]
+
+
+class ReferenceReader(Protocol):
+    """Reference reads required by assessment orchestration."""
+
+    async def get_hydrated(
+        self,
+        reference_ids: list[UUID],
+        enhancement_types: list[str] | None = None,
+        external_identifier_types: list[str] | None = None,
+    ) -> list[Reference]:
+        """Read full references with optional relationship filters."""
+        ...
+
+
+class PairScorer(Protocol):
+    """Pair-scoring contract implemented by a stand-in or toolkit adapter."""
+
+    @property
+    def metadata(self) -> DeduperMetadata:
+        """Return the scorer identity and fixed configuration."""
+        ...
+
+    async def score_pair(
+        self,
+        incoming: destiny_sdk.references.Reference,
+        candidate: destiny_sdk.references.Reference,
+    ) -> DeduplicationPairResult:
+        """Score one incoming-reference and candidate pair."""
+        ...
+
+
+class DeduplicationAssessmentService:
+    """Evaluate references without access to decision or side-effect writers."""
+
+    def __init__(
+        self,
+        *,
+        candidate_selector: CandidateSelector,
+        reference_reader: ReferenceReader,
+        anti_corruption_service: ReferenceAntiCorruptionService,
+        pair_scorer: PairScorer,
+    ) -> None:
+        """Initialize the service with read-only assessment dependencies."""
+        self._candidate_selector = candidate_selector
+        self._reference_reader = reference_reader
+        self._anti_corruption_service = anti_corruption_service
+        self._pair_scorer = pair_scorer
+
+    async def evaluate(
+        self,
+        reference_id: UUID,
+        *,
+        retrieval_policy: RetrievalPolicyName | None = None,
+        k: int | None = None,
+    ) -> DeduplicationAssessment:
+        """Assess a stored reference from one hydrated input snapshot."""
+        hydrated = await self._reference_reader.get_hydrated(
+            [reference_id], enhancement_types=[EnhancementType.BIBLIOGRAPHIC]
+        )
+        if not hydrated:
+            msg = f"Could not hydrate incoming deduplication reference: {reference_id}"
+            raise DeduplicationNotFoundError(msg)
+        reference = hydrated[0]
+        incoming = await self._anti_corruption_service.internal_reference_to_sdk(
+            reference
+        )
+        candidate_reference = CandidateReferenceProjection.get_from_reference(reference)
+        return await self._assess(
+            incoming,
+            CandidateSelectionInput(
+                title=candidate_reference.title,
+                authors=candidate_reference.authors,
+                publication_year=candidate_reference.publication_year,
+                identifiers=candidate_reference.identifiers,
+                excluded_reference_id=reference_id,
+            ),
+            retrieval_policy=retrieval_policy,
+            k=k,
+        )
+
+    async def evaluate_supplied(
+        self,
+        incoming: destiny_sdk.references.Reference,
+        selection_input: CandidateSelectionInput,
+        *,
+        retrieval_policy: RetrievalPolicyName | None = None,
+        k: int | None = None,
+    ) -> DeduplicationAssessment:
+        """
+        Assess a frozen SDK reference against a query the runner built.
+
+        The caller owns the query payload because it decides which fields and
+        identifiers the record presents, and sets ``excluded_reference_id`` when the
+        record is already held so it cannot be retrieved as its own candidate.
+        """
+        return await self._assess(
+            incoming,
+            selection_input,
+            retrieval_policy=retrieval_policy,
+            k=k,
+        )
+
+    async def _assess(
+        self,
+        incoming: destiny_sdk.references.Reference,
+        selection_input: CandidateSelectionInput,
+        *,
+        retrieval_policy: RetrievalPolicyName | None,
+        k: int | None,
+    ) -> DeduplicationAssessment:
+        """Find, hydrate and score every candidate under one assessment."""
+        candidate_selection = await self._candidate_selector(
+            CandidateSelectionRequest(
+                input=selection_input,
+                retrieval_policy=retrieval_policy,
+                k=k,
+                hydrate=False,
+            )
+        )
+
+        if any(
+            candidate.reference_id == incoming.id
+            for candidate in candidate_selection.candidates
+        ):
+            msg = f"Cannot assess reference as a duplicate of itself: {incoming.id}"
+            raise DeduplicationValueError(msg)
+
+        candidate_ids = [
+            candidate.reference_id for candidate in candidate_selection.candidates
+        ]
+        candidates_by_id: dict[UUID, Reference] = {}
+        if candidate_ids:
+            # Only the fields the scorer compares. Loading every type would also
+            # sign a URL per full-text enhancement, on a path that never reads one.
+            hydrated = await self._reference_reader.get_hydrated(
+                candidate_ids, enhancement_types=[EnhancementType.BIBLIOGRAPHIC]
+            )
+            candidates_by_id = {candidate.id: candidate for candidate in hydrated}
+            missing_ids = [
+                candidate_id
+                for candidate_id in candidate_ids
+                if candidate_id not in candidates_by_id
+            ]
+            if missing_ids:
+                missing = ", ".join(str(missing_id) for missing_id in missing_ids)
+                msg = f"Could not hydrate deduplication candidates: {missing}"
+                raise DeduplicationError(msg)
+
+        scored_candidates = []
+        threshold_clearing_ids = []
+        unscorable_ids = []
+        scorer_metadata = self._pair_scorer.metadata.model_copy(deep=True)
+        threshold = scorer_metadata.threshold
+        for candidate in candidate_selection.candidates:
+            candidate_sdk = (
+                await self._anti_corruption_service.internal_reference_to_sdk(
+                    candidates_by_id[candidate.reference_id]
+                )
+            )
+            pair_result = await self._pair_scorer.score_pair(
+                incoming=incoming, candidate=candidate_sdk
+            )
+            clears_threshold = (
+                pair_result.probability >= threshold
+                if pair_result.probability is not None
+                else None
+            )
+            scored_candidates.append(
+                ScoredDeduplicationCandidate(
+                    candidate=candidate,
+                    pair_result=pair_result,
+                    clears_threshold=clears_threshold,
+                )
+            )
+            if clears_threshold is True:
+                threshold_clearing_ids.append(candidate.reference_id)
+            elif clears_threshold is None:
+                unscorable_ids.append(candidate.reference_id)
+
+        outcome, proposed_duplicate_of_id = self._summarise(
+            threshold_clearing_ids,
+            unscorable_ids,
+            input_searchable=candidate_selection.input_searchability.searchable,
+        )
+        return DeduplicationAssessment(
+            incoming_reference_id=incoming.id,
+            candidate_selection=candidate_selection,
+            deduper=scorer_metadata,
+            scored_candidates=scored_candidates,
+            outcome=outcome,
+            proposed_duplicate_of_id=proposed_duplicate_of_id,
+            threshold_clearing_candidate_ids=threshold_clearing_ids,
+            unscorable_candidate_ids=unscorable_ids,
+        )
+
+    @staticmethod
+    def _summarise(
+        threshold_clearing_ids: list[UUID],
+        unscorable_ids: list[UUID],
+        *,
+        input_searchable: bool,
+    ) -> tuple[DeduplicationAssessmentOutcome, UUID | None]:
+        """Summarise the candidate set without applying acting-policy guards."""
+        if unscorable_ids or len(threshold_clearing_ids) > 1:
+            return DeduplicationAssessmentOutcome.NO_PROPOSAL, None
+        if threshold_clearing_ids:
+            return (
+                DeduplicationAssessmentOutcome.PROPOSE_DUPLICATE,
+                threshold_clearing_ids[0],
+            )
+        if not input_searchable:
+            return DeduplicationAssessmentOutcome.NO_PROPOSAL, None
+        return DeduplicationAssessmentOutcome.PROPOSE_CANONICAL, None

--- a/app/domain/references/services/deduplication_assessment_service.py
+++ b/app/domain/references/services/deduplication_assessment_service.py
@@ -121,6 +121,16 @@ class DeduplicationAssessmentService:
             }
         )
 
+    async def _hydrate_one(self, reference_id: UUID) -> Reference:
+        """Read one stored reference, treating an empty result as not-found."""
+        hydrated = await self._reference_reader.get_hydrated(
+            [reference_id], enhancement_types=list(SCORED_ENHANCEMENT_TYPES)
+        )
+        if not hydrated:
+            msg = f"Could not hydrate incoming deduplication reference: {reference_id}"
+            raise DeduplicationNotFoundError(msg)
+        return hydrated[0]
+
     async def evaluate(
         self,
         reference_id: UUID,
@@ -129,13 +139,7 @@ class DeduplicationAssessmentService:
         k: int | None = None,
     ) -> DeduplicationAssessment:
         """Assess a stored reference from one hydrated input snapshot."""
-        hydrated = await self._reference_reader.get_hydrated(
-            [reference_id], enhancement_types=list(SCORED_ENHANCEMENT_TYPES)
-        )
-        if not hydrated:
-            msg = f"Could not hydrate incoming deduplication reference: {reference_id}"
-            raise DeduplicationNotFoundError(msg)
-        reference = hydrated[0]
+        reference = await self._hydrate_one(reference_id)
         incoming = await self._to_scorer_view(reference)
         candidate_reference = CandidateReferenceProjection.get_from_reference(reference)
         # A reference can project to nothing searchable, which the input model

--- a/app/domain/references/services/deduplication_assessment_service.py
+++ b/app/domain/references/services/deduplication_assessment_service.py
@@ -5,6 +5,7 @@ from typing import Protocol
 from uuid import UUID
 
 import destiny_sdk
+from pydantic import ValidationError
 from sqlalchemy.exc import InterfaceError, OperationalError
 
 from app.core.exceptions import (
@@ -27,6 +28,9 @@ from app.domain.references.models.models import (
     ScoredDeduplicationCandidate,
 )
 from app.domain.references.models.projections import CandidateReferenceProjection
+from app.domain.references.services.access_control_service import (
+    ReferenceAccessControlService,
+)
 from app.domain.references.services.anti_corruption_service import (
     ReferenceAntiCorruptionService,
 )
@@ -38,6 +42,10 @@ CandidateSelector = Callable[
 # Repository errors and connectivity DBAPI failures are per-record infrastructure.
 # Malformed queries and programming defects stay fatal, not one failed row per input.
 INFRASTRUCTURE_ERRORS = (ESError, OperationalError, InterfaceError)
+
+# The enhancement types the Deduper compares. Abstracts are excluded because its
+# scoring weights are configured without them, so sending one is wasted payload.
+SCORED_ENHANCEMENT_TYPES = (EnhancementType.BIBLIOGRAPHIC,)
 
 
 class ReferenceReader(Protocol):
@@ -86,6 +94,32 @@ class DeduplicationAssessmentService:
         self._reference_reader = reference_reader
         self._anti_corruption_service = anti_corruption_service
         self._pair_scorer = pair_scorer
+        # Entitlements are deliberately empty: the scorer compares bibliographic
+        # fields, so nothing here may reach full text.
+        self._access_control_service = ReferenceAccessControlService()
+
+    async def _to_scorer_view(
+        self, reference: Reference
+    ) -> destiny_sdk.references.Reference:
+        """Convert a reference to the least-privileged SDK view the scorer sees."""
+        return await self._anti_corruption_service.reference_to_sdk(
+            self._access_control_service.redact_reference(reference)
+        )
+
+    @staticmethod
+    def _scored_view(
+        reference: destiny_sdk.references.Reference,
+    ) -> destiny_sdk.references.Reference:
+        """Present only the enhancement types the Deduper compares."""
+        return reference.model_copy(
+            update={
+                "enhancements": [
+                    enhancement
+                    for enhancement in reference.enhancements or []
+                    if enhancement.content.enhancement_type in SCORED_ENHANCEMENT_TYPES
+                ]
+            }
+        )
 
     async def evaluate(
         self,
@@ -96,25 +130,30 @@ class DeduplicationAssessmentService:
     ) -> DeduplicationAssessment:
         """Assess a stored reference from one hydrated input snapshot."""
         hydrated = await self._reference_reader.get_hydrated(
-            [reference_id], enhancement_types=[EnhancementType.BIBLIOGRAPHIC]
+            [reference_id], enhancement_types=list(SCORED_ENHANCEMENT_TYPES)
         )
         if not hydrated:
             msg = f"Could not hydrate incoming deduplication reference: {reference_id}"
             raise DeduplicationNotFoundError(msg)
         reference = hydrated[0]
-        incoming = await self._anti_corruption_service.internal_reference_to_sdk(
-            reference
-        )
+        incoming = await self._to_scorer_view(reference)
         candidate_reference = CandidateReferenceProjection.get_from_reference(reference)
-        return await self._assess(
-            incoming,
-            CandidateSelectionInput(
+        # A reference can project to nothing searchable, which the input model
+        # rejects. Convert it rather than let a bare ValidationError escape.
+        try:
+            selection_input = CandidateSelectionInput(
                 title=candidate_reference.title,
                 authors=candidate_reference.authors,
                 publication_year=candidate_reference.publication_year,
                 identifiers=candidate_reference.identifiers,
                 excluded_reference_id=reference_id,
-            ),
+            )
+        except ValidationError as exc:
+            msg = f"Cannot build a candidate query for {reference_id}: {exc}"
+            raise DeduplicationValueError(msg) from exc
+        return await self._assess(
+            incoming,
+            selection_input,
             retrieval_policy=retrieval_policy,
             k=k,
         )
@@ -150,6 +189,9 @@ class DeduplicationAssessmentService:
         k: int | None,
     ) -> DeduplicationAssessment:
         """Find, hydrate and score every candidate under one assessment."""
+        # Filter here rather than per entrypoint: a supplied record carries whatever
+        # its dataset held, and both sides must reach the scorer alike.
+        incoming = self._scored_view(incoming)
         try:
             candidate_selection = await self._candidate_selector(
                 CandidateSelectionRequest(
@@ -179,7 +221,7 @@ class DeduplicationAssessmentService:
             # sign a URL per full-text enhancement, on a path that never reads one.
             try:
                 hydrated = await self._reference_reader.get_hydrated(
-                    candidate_ids, enhancement_types=[EnhancementType.BIBLIOGRAPHIC]
+                    candidate_ids, enhancement_types=list(SCORED_ENHANCEMENT_TYPES)
                 )
             except INFRASTRUCTURE_ERRORS as exc:
                 msg = f"Candidate hydration failed ({type(exc).__name__}): {exc}"
@@ -201,10 +243,8 @@ class DeduplicationAssessmentService:
         scorer_metadata = self._pair_scorer.metadata.model_copy(deep=True)
         threshold = scorer_metadata.threshold
         for candidate in candidate_selection.candidates:
-            candidate_sdk = (
-                await self._anti_corruption_service.internal_reference_to_sdk(
-                    candidates_by_id[candidate.reference_id]
-                )
+            candidate_sdk = self._scored_view(
+                await self._to_scorer_view(candidates_by_id[candidate.reference_id])
             )
             pair_result = await self._pair_scorer.score_pair(
                 incoming=incoming, candidate=candidate_sdk

--- a/app/domain/references/services/deduplication_assessment_service.py
+++ b/app/domain/references/services/deduplication_assessment_service.py
@@ -94,8 +94,6 @@ class DeduplicationAssessmentService:
     @staticmethod
     def _to_scorer_paper(reference: Reference) -> DeduplicationPaper:
         """Project a reference into the record the scorer compares."""
-        # No access-control redaction: a paper's fields are an allowlist, so it
-        # already excludes everything redaction would have dropped.
         try:
             return DeduplicationPaperProjection.get_from_reference(reference)
         except ProjectionError as exc:

--- a/app/domain/references/services/deduplication_assessment_service.py
+++ b/app/domain/references/services/deduplication_assessment_service.py
@@ -32,9 +32,6 @@ from app.domain.references.models.projections import (
     CandidateReferenceProjection,
     DeduplicationPaperProjection,
 )
-from app.domain.references.services.access_control_service import (
-    ReferenceAccessControlService,
-)
 
 CandidateSelector = Callable[
     [CandidateSelectionRequest], Awaitable[CandidateSelectionResult]
@@ -93,15 +90,14 @@ class DeduplicationAssessmentService:
         self._candidate_selector = candidate_selector
         self._reference_reader = reference_reader
         self._pair_scorer = pair_scorer
-        # Entitlements are deliberately empty: the scorer compares bibliographic
-        # fields, so nothing here may reach full text.
-        self._access_control_service = ReferenceAccessControlService()
 
-    def _to_scorer_paper(self, reference: Reference) -> DeduplicationPaper:
-        """Reduce a reference to the least-privileged view the scorer sees."""
-        redacted = self._access_control_service.redact_reference(reference)
+    @staticmethod
+    def _to_scorer_paper(reference: Reference) -> DeduplicationPaper:
+        """Project a reference into the record the scorer compares."""
+        # No access-control redaction: a paper's fields are an allowlist, so it
+        # already excludes everything redaction would have dropped.
         try:
-            return DeduplicationPaperProjection.get_from_reference(redacted)
+            return DeduplicationPaperProjection.get_from_reference(reference)
         except ProjectionError as exc:
             # ``from exc`` keeps the projection failure as the cause, so the message
             # does not need to restate it.

--- a/app/domain/references/services/deduplication_assessment_service.py
+++ b/app/domain/references/services/deduplication_assessment_service.py
@@ -5,11 +5,13 @@ from typing import Protocol
 from uuid import UUID
 
 import destiny_sdk
+from sqlalchemy.exc import InterfaceError, OperationalError
 
 from app.core.exceptions import (
     DeduplicationError,
     DeduplicationNotFoundError,
     DeduplicationValueError,
+    ESError,
 )
 from app.domain.references.models.models import (
     CandidateSelectionInput,
@@ -32,6 +34,10 @@ from app.domain.references.services.anti_corruption_service import (
 CandidateSelector = Callable[
     [CandidateSelectionRequest], Awaitable[CandidateSelectionResult]
 ]
+
+# Repository errors and connectivity DBAPI failures are per-record infrastructure.
+# Malformed queries and programming defects stay fatal, not one failed row per input.
+INFRASTRUCTURE_ERRORS = (ESError, OperationalError, InterfaceError)
 
 
 class ReferenceReader(Protocol):
@@ -144,14 +150,18 @@ class DeduplicationAssessmentService:
         k: int | None,
     ) -> DeduplicationAssessment:
         """Find, hydrate and score every candidate under one assessment."""
-        candidate_selection = await self._candidate_selector(
-            CandidateSelectionRequest(
-                input=selection_input,
-                retrieval_policy=retrieval_policy,
-                k=k,
-                hydrate=False,
+        try:
+            candidate_selection = await self._candidate_selector(
+                CandidateSelectionRequest(
+                    input=selection_input,
+                    retrieval_policy=retrieval_policy,
+                    k=k,
+                    hydrate=False,
+                )
             )
-        )
+        except INFRASTRUCTURE_ERRORS as exc:
+            msg = f"Candidate retrieval failed ({type(exc).__name__}): {exc}"
+            raise DeduplicationError(msg) from exc
 
         if any(
             candidate.reference_id == incoming.id
@@ -167,9 +177,13 @@ class DeduplicationAssessmentService:
         if candidate_ids:
             # Only the fields the scorer compares. Loading every type would also
             # sign a URL per full-text enhancement, on a path that never reads one.
-            hydrated = await self._reference_reader.get_hydrated(
-                candidate_ids, enhancement_types=[EnhancementType.BIBLIOGRAPHIC]
-            )
+            try:
+                hydrated = await self._reference_reader.get_hydrated(
+                    candidate_ids, enhancement_types=[EnhancementType.BIBLIOGRAPHIC]
+                )
+            except INFRASTRUCTURE_ERRORS as exc:
+                msg = f"Candidate hydration failed ({type(exc).__name__}): {exc}"
+                raise DeduplicationError(msg) from exc
             candidates_by_id = {candidate.id: candidate for candidate in hydrated}
             missing_ids = [
                 candidate_id

--- a/app/domain/references/services/deduplication_service.py
+++ b/app/domain/references/services/deduplication_service.py
@@ -6,7 +6,7 @@ from uuid import UUID
 from opentelemetry import trace
 
 from app.core.config import DedupCandidateScoringConfig, Environment, get_settings
-from app.core.exceptions import DeduplicationValueError
+from app.core.exceptions import DeduplicationError, DeduplicationValueError
 from app.core.telemetry.logger import get_logger
 from app.domain.references.models.models import (
     Candidate,
@@ -313,12 +313,13 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
         )
 
     async def _resolve_candidate_selection_input(
-        self, input_: CandidateSelectionInput
+        self, selection_input: CandidateSelectionInput
     ) -> tuple[CandidateCanonicalSearchFields, UUID | None, list[IdentifierLookup]]:
         """Resolve request input into search fields, a self-id, and id lookups."""
-        if input_.reference_id is not None:
+        if selection_input.reference_id is not None:
             reference = await self.sql_uow.references.get_by_pk(
-                input_.reference_id, preload=["enhancements", "identifiers"]
+                selection_input.reference_id,
+                preload=["enhancements", "identifiers"],
             )
             search_fields = (
                 ReferenceSearchFieldsProjection.get_canonical_candidate_search_fields(
@@ -333,16 +334,16 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
             return search_fields, reference.id, lookups
 
         search_fields = CandidateCanonicalSearchFields(
-            title=input_.title,
-            authors=input_.authors,
-            publication_year=input_.publication_year,
+            title=selection_input.title,
+            authors=selection_input.authors,
+            publication_year=selection_input.publication_year,
         )
         lookups = [
             self._identifier_lookup_from_candidate(identifier)
-            for identifier in input_.identifiers
+            for identifier in selection_input.identifiers
             if identifier.identifier_type in _UNIONABLE_IDENTIFIER_TYPES
         ]
-        return search_fields, None, lookups
+        return search_fields, selection_input.excluded_reference_id, lookups
 
     @staticmethod
     def _identifier_lookup_from_candidate(
@@ -386,7 +387,7 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
                     "Identifier match is a determined duplicate without a canonical "
                     "reference id. This should not happen."
                 )
-                raise RuntimeError(msg)
+                raise DeduplicationError(msg)
             if canonical_id == self_id:
                 continue
             bucket = matches.setdefault(canonical_id, {})

--- a/tests/unit/domain/references/deduplication/test_assessment.py
+++ b/tests/unit/domain/references/deduplication/test_assessment.py
@@ -47,6 +47,7 @@ from tests.factories import (
     BibliographicMetadataEnhancementFactory,
     BooleanAnnotationFactory,
     EnhancementFactory,
+    FullTextEnhancementFactory,
     LinkedExternalIdentifierFactory,
     OpenAlexIdentifierFactory,
     ReferenceFactory,
@@ -91,6 +92,17 @@ def _reference(*, community_bound: bool = False) -> Reference:
         enhancement.reference_id = reference.id
     for identifier in reference.identifiers or []:
         identifier.reference_id = reference.id
+    return reference
+
+
+def _with_full_text(reference: Reference) -> Reference:
+    """Add a full-text enhancement, which no assessment input should carry."""
+    reference.enhancements = [
+        *(reference.enhancements or []),
+        EnhancementFactory.build(
+            content=FullTextEnhancementFactory.build(), reference_id=reference.id
+        ),
+    ]
     return reference
 
 
@@ -505,7 +517,7 @@ async def test_evaluate_empty_unsearchable_union_makes_no_proposal(
 async def test_evaluate_supplied_scores_the_exact_sdk_reference(
     anti_corruption_service,
 ):
-    """The runner's frozen SDK reference reaches the scorer unchanged."""
+    """The runner's SDK reference reaches the scorer without a domain round-trip."""
     incoming = _supplied_reference()
     candidate = _reference()
     supplied_input = CandidateSelectionInput(
@@ -523,9 +535,14 @@ async def test_evaluate_supplied_scores_the_exact_sdk_reference(
     assessment = await service.evaluate_supplied(incoming, supplied_input)
 
     assert assessment.incoming_reference_id == incoming.id
-    assert incoming.enhancements
-    assert incoming.enhancements[0].created_at is None
-    assert pair_scorer.calls[0][0] is incoming
+    scored_incoming = pair_scorer.calls[0][0]
+    assert scored_incoming.id == incoming.id
+    assert scored_incoming.identifiers == incoming.identifiers
+    assert scored_incoming.enhancements == incoming.enhancements
+    # A hydrated reference carries a database timestamp, so a null one here is
+    # what shows the record never went through the domain model.
+    assert scored_incoming.enhancements
+    assert scored_incoming.enhancements[0].created_at is None
     assert selector.await_args.args[0].input == supplied_input
     reader.get_hydrated.assert_awaited_once_with(
         [candidate.id], enhancement_types=[EnhancementType.BIBLIOGRAPHIC]
@@ -656,6 +673,95 @@ async def test_evaluate_fails_when_stored_incoming_cannot_be_hydrated(
         await service.evaluate(reference_id)
 
     assert isinstance(exc_info.value, DeduplicationError)
+    selector.assert_not_awaited()
+    assert pair_scorer.calls == []
+
+
+@pytest.mark.asyncio
+async def test_evaluate_supplied_presents_only_scored_enhancements(
+    anti_corruption_service,
+):
+    """Both entrypoints must show the scorer the same enhancement types."""
+    incoming = _supplied_reference()
+    incoming.enhancements = [
+        *(incoming.enhancements or []),
+        destiny_sdk.enhancements.Enhancement(
+            reference_id=incoming.id,
+            source="evaluation-benchmark",
+            visibility=Visibility.PUBLIC,
+            content=destiny_sdk.enhancements.AbstractContentEnhancement(
+                process=destiny_sdk.enhancements.AbstractProcessType.OTHER,
+                abstract="An abstract the Deduper does not score on.",
+            ),
+        ),
+    ]
+    candidate = _reference()
+    service, _, _, pair_scorer = _build_service(
+        anti_corruption_service,
+        _selection(Candidate(reference_id=candidate.id, rank=1, routes=[])),
+        [candidate],
+        {candidate.id: 0.1},
+    )
+
+    await service.evaluate_supplied(incoming, _supplied_input(incoming))
+
+    scored_incoming, _ = pair_scorer.calls[0]
+    assert [
+        enhancement.content.enhancement_type
+        for enhancement in scored_incoming.enhancements or []
+    ] == [EnhancementType.BIBLIOGRAPHIC]
+
+
+@pytest.mark.asyncio
+async def test_evaluate_withholds_full_text_from_the_scorer():
+    """Redaction, not the hydration filter, is what keeps full text off this path."""
+    sign_url = AsyncMock()
+    anti_corruption_service = ReferenceAntiCorruptionService(sign_url=sign_url)
+    # Community-bound adds an annotation, which redaction keeps and the scored
+    # view drops, so this covers both filters rather than only redaction.
+    incoming = _with_full_text(_reference(community_bound=True))
+    candidate = _with_full_text(_reference(community_bound=True))
+    service, _, reader, pair_scorer = _build_service(
+        anti_corruption_service,
+        _selection(Candidate(reference_id=candidate.id, rank=1, routes=[])),
+        [incoming, candidate],
+        {candidate.id: 0.9},
+    )
+    by_id = {incoming.id: incoming, candidate.id: candidate}
+    # Stand in for a widened hydration filter: return every enhancement regardless.
+    reader.get_hydrated = AsyncMock(
+        side_effect=lambda ids, **_: [by_id[id_] for id_ in ids]
+    )
+
+    await service.evaluate(incoming.id)
+
+    scored_incoming, scored_candidate = pair_scorer.calls[0]
+    for scored in (scored_incoming, scored_candidate):
+        assert [
+            enhancement.content.enhancement_type
+            for enhancement in scored.enhancements or []
+        ] == [EnhancementType.BIBLIOGRAPHIC]
+    sign_url.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_evaluate_fails_when_stored_incoming_has_no_search_fields(
+    anti_corruption_service,
+):
+    # Empty-list kwargs do not stick through the factory, which regenerates both.
+    reference = ReferenceFactory.build(visibility="public").model_copy(
+        update={"enhancements": [], "identifiers": []}
+    )
+    service, selector, _, pair_scorer = _build_service(
+        anti_corruption_service,
+        _selection(),
+        [reference],
+        {},
+    )
+
+    with pytest.raises(DeduplicationError, match=str(reference.id)):
+        await service.evaluate(reference.id)
+
     selector.assert_not_awaited()
     assert pair_scorer.calls == []
 

--- a/tests/unit/domain/references/deduplication/test_assessment.py
+++ b/tests/unit/domain/references/deduplication/test_assessment.py
@@ -1,9 +1,7 @@
 from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid7
 
-import destiny_sdk
 import pytest
-from destiny_sdk.visibility import Visibility
 from sqlalchemy.exc import OperationalError, ProgrammingError
 
 from app.core.exceptions import (
@@ -30,6 +28,7 @@ from app.domain.references.models.models import (
     Reference,
     RetrievalPolicyName,
 )
+from app.domain.references.services.access_control_service import RedactedReference
 from app.domain.references.services.anti_corruption_service import (
     ReferenceAntiCorruptionService,
 )
@@ -43,6 +42,7 @@ from app.persistence.es.persistence import (
     ESSearchTotal,
 )
 from tests.factories import (
+    AbstractContentEnhancementFactory,
     AnnotationEnhancementFactory,
     BibliographicMetadataEnhancementFactory,
     BooleanAnnotationFactory,
@@ -106,28 +106,34 @@ def _with_full_text(reference: Reference) -> Reference:
     return reference
 
 
-def _supplied_reference() -> destiny_sdk.references.Reference:
-    """Build the frozen SDK shape supplied by an evaluation runner."""
-    reference_id = uuid7()
-    return destiny_sdk.references.Reference(
-        id=reference_id,
-        visibility=Visibility.PUBLIC,
-        identifiers=[OpenAlexIdentifierFactory.build()],
-        enhancements=[
-            destiny_sdk.enhancements.Enhancement(
-                reference_id=reference_id,
-                source="evaluation-benchmark",
-                visibility=Visibility.PUBLIC,
-                content=destiny_sdk.enhancements.BibliographicMetadataEnhancement(
-                    title="A supplied reference",
-                ),
-            )
-        ],
+def _supplied_reference() -> Reference:
+    """Build the unimported record an evaluation runner supplies."""
+    reference = ReferenceFactory.build(visibility="public")
+    # Children carry the parent id, matching what reference_from_sdk_file_input
+    # produces for a supplied record.
+    return reference.model_copy(
+        update={
+            "enhancements": [
+                EnhancementFactory.build(
+                    reference_id=reference.id,
+                    source="evaluation-benchmark",
+                    content=BibliographicMetadataEnhancementFactory.build(
+                        title="A supplied reference",
+                    ),
+                )
+            ],
+            "identifiers": [
+                LinkedExternalIdentifierFactory.build(
+                    reference_id=reference.id,
+                    identifier=OpenAlexIdentifierFactory.build(),
+                )
+            ],
+        }
     )
 
 
 def _supplied_input(
-    reference: destiny_sdk.references.Reference,
+    reference: Reference,
     *,
     excluded_reference_id: UUID | None = None,
 ) -> CandidateSelectionInput:
@@ -137,8 +143,8 @@ def _supplied_input(
         authors=["Jane Doe"],
         publication_year=2025,
         identifiers=[
-            CandidateIdentifier.from_specific(identifier)
-            for identifier in (reference.identifiers or [])
+            CandidateIdentifier.from_specific(linked.identifier)
+            for linked in (reference.identifiers or [])
         ],
         excluded_reference_id=excluded_reference_id,
     )
@@ -180,17 +186,12 @@ class FakePairScorer:
             effective_configuration={"weights": "test"},
         )
         self.probabilities = probabilities
-        self.calls: list[
-            tuple[
-                destiny_sdk.references.Reference,
-                destiny_sdk.references.Reference,
-            ]
-        ] = []
+        self.calls: list[tuple[Reference, Reference]] = []
 
     async def score_pair(
         self,
-        incoming: destiny_sdk.references.Reference,
-        candidate: destiny_sdk.references.Reference,
+        incoming: RedactedReference,
+        candidate: RedactedReference,
     ) -> DeduplicationPairResult:
         self.calls.append((incoming, candidate))
         probability = self.probabilities[candidate.id]
@@ -236,7 +237,6 @@ def _forbid_async_methods(target, method_names: tuple[str, ...]):
 
 
 def _build_service(
-    anti_corruption_service,
     selection: CandidateSelectionResult,
     references: list[Reference],
     probabilities: dict[UUID, float | None],
@@ -268,16 +268,13 @@ def _build_service(
     service = DeduplicationAssessmentService(
         candidate_selector=selector,
         reference_reader=reader,
-        anti_corruption_service=anti_corruption_service,
         pair_scorer=pair_scorer,
     )
     return service, selector, reader, pair_scorer
 
 
 @pytest.mark.asyncio
-async def test_evaluate_supplied_scores_identifier_candidate_and_proposes_it(
-    anti_corruption_service,
-):
+async def test_evaluate_supplied_scores_identifier_candidate_and_proposes_it():
     incoming = _supplied_reference()
     candidate = _reference(community_bound=True)
     identifier = candidate.identifiers[0].identifier
@@ -296,7 +293,6 @@ async def test_evaluate_supplied_scores_identifier_candidate_and_proposes_it(
         ],
     )
     service, selector, reader, pair_scorer = _build_service(
-        anti_corruption_service,
         _selection(selected, searchable=False),
         [candidate],
         {candidate.id: 0.91},
@@ -336,9 +332,7 @@ async def test_evaluate_supplied_scores_identifier_candidate_and_proposes_it(
 
 
 @pytest.mark.asyncio
-async def test_evaluate_scores_all_candidates_and_retains_every_threshold_match(
-    anti_corruption_service,
-):
+async def test_evaluate_scores_all_candidates_and_retains_every_threshold_match():
     incoming = _reference()
     candidates = [_reference(), _reference(), _reference()]
     selected = [
@@ -351,7 +345,6 @@ async def test_evaluate_scores_all_candidates_and_retains_every_threshold_match(
         candidates[2].id: 0.85,
     }
     service, selector, _, pair_scorer = _build_service(
-        anti_corruption_service,
         _selection(*selected),
         [incoming, *candidates],
         probabilities,
@@ -377,13 +370,10 @@ async def test_evaluate_scores_all_candidates_and_retains_every_threshold_match(
 
 
 @pytest.mark.asyncio
-async def test_evaluate_stored_reuses_one_snapshot_for_selection_and_scoring(
-    anti_corruption_service,
-):
+async def test_evaluate_stored_reuses_one_snapshot_for_selection_and_scoring():
     incoming = _reference(community_bound=True)
     candidate = _reference()
     service, selector, reader, pair_scorer = _build_service(
-        anti_corruption_service,
         _selection(Candidate(reference_id=candidate.id, rank=1, routes=[])),
         [incoming, candidate],
         {candidate.id: 0.1},
@@ -407,9 +397,7 @@ async def test_evaluate_stored_reuses_one_snapshot_for_selection_and_scoring(
 
 
 @pytest.mark.asyncio
-async def test_evaluate_supplied_rejects_a_candidate_with_the_incoming_id(
-    anti_corruption_service,
-):
+async def test_evaluate_supplied_rejects_a_candidate_with_the_incoming_id():
     incoming = _supplied_reference()
     candidate = _reference()
     candidate.id = incoming.id
@@ -418,7 +406,6 @@ async def test_evaluate_supplied_rejects_a_candidate_with_the_incoming_id(
     for identifier in candidate.identifiers or []:
         identifier.reference_id = incoming.id
     service, _, reader, pair_scorer = _build_service(
-        anti_corruption_service,
         _selection(Candidate(reference_id=incoming.id, rank=1, routes=[])),
         [candidate],
         {incoming.id: 1.0},
@@ -432,9 +419,7 @@ async def test_evaluate_supplied_rejects_a_candidate_with_the_incoming_id(
 
 
 @pytest.mark.asyncio
-async def test_evaluate_supplied_makes_no_proposal_for_any_unscorable_candidate(
-    anti_corruption_service,
-):
+async def test_evaluate_supplied_makes_no_proposal_for_any_unscorable_candidate():
     incoming = _supplied_reference()
     scored_candidate = _reference()
     unscorable_candidate = _reference()
@@ -444,7 +429,6 @@ async def test_evaluate_supplied_makes_no_proposal_for_any_unscorable_candidate(
         for rank, candidate in enumerate(candidates, start=1)
     ]
     service, _, _, _ = _build_service(
-        anti_corruption_service,
         _selection(*selected),
         candidates,
         {
@@ -464,12 +448,9 @@ async def test_evaluate_supplied_makes_no_proposal_for_any_unscorable_candidate(
 
 
 @pytest.mark.asyncio
-async def test_evaluate_empty_searchable_union_proposes_canonical(
-    anti_corruption_service,
-):
+async def test_evaluate_empty_searchable_union_proposes_canonical():
     incoming = _reference()
     service, _, reader, pair_scorer = _build_service(
-        anti_corruption_service,
         _selection(searchable=True),
         [incoming],
         {},
@@ -489,12 +470,9 @@ async def test_evaluate_empty_searchable_union_proposes_canonical(
 
 
 @pytest.mark.asyncio
-async def test_evaluate_empty_unsearchable_union_makes_no_proposal(
-    anti_corruption_service,
-):
+async def test_evaluate_empty_unsearchable_union_makes_no_proposal():
     incoming = _reference()
     service, _, reader, pair_scorer = _build_service(
-        anti_corruption_service,
         _selection(searchable=False),
         [incoming],
         {},
@@ -514,10 +492,8 @@ async def test_evaluate_empty_unsearchable_union_makes_no_proposal(
 
 
 @pytest.mark.asyncio
-async def test_evaluate_supplied_scores_the_exact_sdk_reference(
-    anti_corruption_service,
-):
-    """The runner's SDK reference reaches the scorer without a domain round-trip."""
+async def test_evaluate_supplied_scores_the_runners_own_record():
+    """The runner's own record reaches the scorer without a database read."""
     incoming = _supplied_reference()
     candidate = _reference()
     supplied_input = CandidateSelectionInput(
@@ -526,7 +502,6 @@ async def test_evaluate_supplied_scores_the_exact_sdk_reference(
         publication_year=2025,
     )
     service, selector, reader, pair_scorer = _build_service(
-        anti_corruption_service,
         _selection(Candidate(reference_id=candidate.id, rank=1, routes=[])),
         [candidate],
         {candidate.id: 0.1},
@@ -539,25 +514,19 @@ async def test_evaluate_supplied_scores_the_exact_sdk_reference(
     assert scored_incoming.id == incoming.id
     assert scored_incoming.identifiers == incoming.identifiers
     assert scored_incoming.enhancements == incoming.enhancements
-    # A hydrated reference carries a database timestamp, so a null one here is
-    # what shows the record never went through the domain model.
-    assert scored_incoming.enhancements
-    assert scored_incoming.enhancements[0].created_at is None
     assert selector.await_args.args[0].input == supplied_input
+    # Awaited only for the candidate: the supplied record is never read back.
     reader.get_hydrated.assert_awaited_once_with(
         [candidate.id], enhancement_types=[EnhancementType.BIBLIOGRAPHIC]
     )
 
 
 @pytest.mark.asyncio
-async def test_evaluate_supplied_passes_the_callers_exclusion_through(
-    anti_corruption_service,
-):
+async def test_evaluate_supplied_passes_the_callers_exclusion_through():
     """A held record must not be retrieved as its own candidate."""
     incoming = _supplied_reference()
     held_reference_id = uuid7()
     service, selector, _, _ = _build_service(
-        anti_corruption_service,
         _selection(),
         [],
         {},
@@ -574,14 +543,10 @@ async def test_evaluate_supplied_passes_the_callers_exclusion_through(
 
 
 @pytest.mark.asyncio
-async def test_evaluate_supplied_reports_retrieval_infrastructure_failure_per_record(
-    anti_corruption_service,
-):
+async def test_evaluate_supplied_reports_retrieval_infrastructure_failure_per_record():
     """A retrieval blip the repository already translated is one record's failure."""
     incoming = _supplied_reference()
-    service, selector, _, pair_scorer = _build_service(
-        anti_corruption_service, _selection(), [], {}
-    )
+    service, selector, _, pair_scorer = _build_service(_selection(), [], {})
     selector.side_effect = ESError("candidate search unavailable (503)")
 
     with pytest.raises(DeduplicationError):
@@ -591,14 +556,11 @@ async def test_evaluate_supplied_reports_retrieval_infrastructure_failure_per_re
 
 
 @pytest.mark.asyncio
-async def test_evaluate_supplied_reports_hydration_infrastructure_failure_per_record(
-    anti_corruption_service,
-):
+async def test_evaluate_supplied_reports_hydration_infrastructure_failure_per_record():
     """A database blip while hydrating candidates is also one record's failure."""
     incoming = _supplied_reference()
     candidate = _reference()
     service, _, reader, pair_scorer = _build_service(
-        anti_corruption_service,
         _selection(Candidate(reference_id=candidate.id, rank=1, routes=[])),
         [candidate],
         {candidate.id: 0.9},
@@ -626,12 +588,10 @@ async def test_evaluate_supplied_reports_hydration_infrastructure_failure_per_re
         ),
     ],
 )
-async def test_evaluate_supplied_propagates_defects(anti_corruption_service, error):
+async def test_evaluate_supplied_propagates_defects(error):
     """Only infrastructure failures are localised; a defect still aborts the caller."""
     incoming = _supplied_reference()
-    service, selector, _, _ = _build_service(
-        anti_corruption_service, _selection(), [], {}
-    )
+    service, selector, _, _ = _build_service(_selection(), [], {})
     selector.side_effect = error
 
     with pytest.raises(type(error)):
@@ -639,13 +599,10 @@ async def test_evaluate_supplied_propagates_defects(anti_corruption_service, err
 
 
 @pytest.mark.asyncio
-async def test_evaluate_supplied_fails_when_candidate_union_cannot_be_hydrated(
-    anti_corruption_service,
-):
+async def test_evaluate_supplied_fails_when_candidate_union_cannot_be_hydrated():
     incoming = _supplied_reference()
     missing_id = uuid7()
     service, _, _, pair_scorer = _build_service(
-        anti_corruption_service,
         _selection(Candidate(reference_id=missing_id, rank=1, routes=[])),
         [],
         {missing_id: 0.9},
@@ -658,12 +615,9 @@ async def test_evaluate_supplied_fails_when_candidate_union_cannot_be_hydrated(
 
 
 @pytest.mark.asyncio
-async def test_evaluate_fails_when_stored_incoming_cannot_be_hydrated(
-    anti_corruption_service,
-):
+async def test_evaluate_fails_when_stored_incoming_cannot_be_hydrated():
     reference_id = uuid7()
     service, selector, _, pair_scorer = _build_service(
-        anti_corruption_service,
         _selection(),
         [],
         {},
@@ -678,26 +632,21 @@ async def test_evaluate_fails_when_stored_incoming_cannot_be_hydrated(
 
 
 @pytest.mark.asyncio
-async def test_evaluate_supplied_presents_only_scored_enhancements(
-    anti_corruption_service,
-):
+async def test_evaluate_supplied_presents_only_scored_enhancements():
     """Both entrypoints must show the scorer the same enhancement types."""
     incoming = _supplied_reference()
     incoming.enhancements = [
         *(incoming.enhancements or []),
-        destiny_sdk.enhancements.Enhancement(
+        EnhancementFactory.build(
             reference_id=incoming.id,
             source="evaluation-benchmark",
-            visibility=Visibility.PUBLIC,
-            content=destiny_sdk.enhancements.AbstractContentEnhancement(
-                process=destiny_sdk.enhancements.AbstractProcessType.OTHER,
+            content=AbstractContentEnhancementFactory.build(
                 abstract="An abstract the Deduper does not score on.",
             ),
         ),
     ]
     candidate = _reference()
     service, _, _, pair_scorer = _build_service(
-        anti_corruption_service,
         _selection(Candidate(reference_id=candidate.id, rank=1, routes=[])),
         [candidate],
         {candidate.id: 0.1},
@@ -715,14 +664,11 @@ async def test_evaluate_supplied_presents_only_scored_enhancements(
 @pytest.mark.asyncio
 async def test_evaluate_withholds_full_text_from_the_scorer():
     """Redaction, not the hydration filter, is what keeps full text off this path."""
-    sign_url = AsyncMock()
-    anti_corruption_service = ReferenceAntiCorruptionService(sign_url=sign_url)
     # Community-bound adds an annotation, which redaction keeps and the scored
     # view drops, so this covers both filters rather than only redaction.
     incoming = _with_full_text(_reference(community_bound=True))
     candidate = _with_full_text(_reference(community_bound=True))
     service, _, reader, pair_scorer = _build_service(
-        anti_corruption_service,
         _selection(Candidate(reference_id=candidate.id, rank=1, routes=[])),
         [incoming, candidate],
         {candidate.id: 0.9},
@@ -741,19 +687,15 @@ async def test_evaluate_withholds_full_text_from_the_scorer():
             enhancement.content.enhancement_type
             for enhancement in scored.enhancements or []
         ] == [EnhancementType.BIBLIOGRAPHIC]
-    sign_url.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_evaluate_fails_when_stored_incoming_has_no_search_fields(
-    anti_corruption_service,
-):
+async def test_evaluate_fails_when_stored_incoming_has_no_search_fields():
     # Empty-list kwargs do not stick through the factory, which regenerates both.
     reference = ReferenceFactory.build(visibility="public").model_copy(
         update={"enhancements": [], "identifiers": []}
     )
     service, selector, _, pair_scorer = _build_service(
-        anti_corruption_service,
         _selection(),
         [reference],
         {},
@@ -777,7 +719,7 @@ async def test_evaluate_supplied_runs_real_candidate_union_without_side_effects(
     candidate.identifiers = [
         LinkedExternalIdentifierFactory.build(
             reference_id=candidate.id,
-            identifier=incoming.identifiers[0],
+            identifier=incoming.identifiers[0].identifier,
         )
     ]
     references = fake_repository([candidate])
@@ -817,7 +759,6 @@ async def test_evaluate_supplied_runs_real_candidate_union_without_side_effects(
     assessor = DeduplicationAssessmentService(
         candidate_selector=candidate_service.get_deduplication_candidates,
         reference_reader=references,
-        anti_corruption_service=anti_corruption_service,
         pair_scorer=pair_scorer,
     )
 

--- a/tests/unit/domain/references/deduplication/test_assessment.py
+++ b/tests/unit/domain/references/deduplication/test_assessment.py
@@ -1,3 +1,5 @@
+from collections.abc import Sequence
+from typing import NamedTuple
 from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid7
 
@@ -22,17 +24,19 @@ from app.domain.references.models.models import (
     DeduplicationFieldComparison,
     DeduplicationFieldStatus,
     DeduplicationPairResult,
+    DeduplicationPaper,
     EnhancementType,
     ExternalIdentifierType,
     InputSearchability,
     Reference,
     RetrievalPolicyName,
 )
-from app.domain.references.services.access_control_service import RedactedReference
+from app.domain.references.models.projections import DeduplicationPaperProjection
 from app.domain.references.services.anti_corruption_service import (
     ReferenceAntiCorruptionService,
 )
 from app.domain.references.services.deduplication_assessment_service import (
+    UNPROJECTABLE_CANDIDATE_REASON,
     DeduplicationAssessmentService,
     ReferenceReader,
 )
@@ -172,10 +176,24 @@ def _selection(
     )
 
 
+def _openalex_id(reference: Reference):
+    """Return the OpenAlex identifier the reference factories attach."""
+    return next(
+        linked.identifier
+        for linked in reference.identifiers or []
+        if linked.identifier.identifier_type == ExternalIdentifierType.OPEN_ALEX
+    )
+
+
+class ScoredPair(NamedTuple):
+    incoming: DeduplicationPaper
+    candidate: DeduplicationPaper
+
+
 class FakePairScorer:
     def __init__(
         self,
-        probabilities: dict[UUID, float | None],
+        probabilities: Sequence[float | None],
         *,
         threshold: float = 0.85,
     ) -> None:
@@ -185,16 +203,17 @@ class FakePairScorer:
             threshold=threshold,
             effective_configuration={"weights": "test"},
         )
-        self.probabilities = probabilities
-        self.calls: list[tuple[Reference, Reference]] = []
+        self.probabilities = list(probabilities)
+        self.calls: list[ScoredPair] = []
 
     async def score_pair(
         self,
-        incoming: RedactedReference,
-        candidate: RedactedReference,
+        incoming: DeduplicationPaper,
+        candidate: DeduplicationPaper,
     ) -> DeduplicationPairResult:
-        self.calls.append((incoming, candidate))
-        probability = self.probabilities[candidate.id]
+        self.calls.append(ScoredPair(incoming, candidate))
+        # A paper carries no reference id, so scores are consumed in candidate order.
+        probability = self.probabilities[len(self.calls) - 1]
         if probability is None:
             return DeduplicationPairResult(
                 unscorable_reason="stand-in could not score this pair"
@@ -264,7 +283,10 @@ def _build_service(
     reader = MagicMock(spec=ReferenceReader)
     reader.get_hydrated = AsyncMock(side_effect=get_hydrated)
     selector = AsyncMock(return_value=selection)
-    pair_scorer = FakePairScorer(probabilities)
+    # Translated here so test bodies can keep naming scores per candidate.
+    pair_scorer = FakePairScorer(
+        [probabilities[candidate.reference_id] for candidate in selection.candidates]
+    )
     service = DeduplicationAssessmentService(
         candidate_selector=selector,
         reference_reader=reader,
@@ -277,7 +299,7 @@ def _build_service(
 async def test_evaluate_supplied_scores_identifier_candidate_and_proposes_it():
     incoming = _supplied_reference()
     candidate = _reference(community_bound=True)
-    identifier = candidate.identifiers[0].identifier
+    identifier = _openalex_id(candidate)
     selected = Candidate(
         reference_id=candidate.id,
         rank=1,
@@ -314,7 +336,8 @@ async def test_evaluate_supplied_scores_identifier_candidate_and_proposes_it():
         == 1
     )
     assert len(pair_scorer.calls) == 1
-    assert pair_scorer.calls[0][1].id == candidate.id
+    # A paper has no reference id, so identity travels as the OpenAlex identifier.
+    assert pair_scorer.calls[0].candidate.openalex_id == _openalex_id(candidate)
     reader.get_hydrated.assert_awaited_once_with(
         [candidate.id], enhancement_types=[EnhancementType.BIBLIOGRAPHIC]
     )
@@ -325,8 +348,9 @@ async def test_evaluate_supplied_scores_identifier_candidate_and_proposes_it():
     )
     assert request.k == 7
     assert request.input.reference_id is None
-    assert (
-        request.input.identifiers[0].identifier_type == ExternalIdentifierType.OPEN_ALEX
+    assert any(
+        item.identifier_type == ExternalIdentifierType.OPEN_ALEX
+        for item in request.input.identifiers
     )
     assert assessment.model_dump_json()
 
@@ -358,8 +382,8 @@ async def test_evaluate_scores_all_candidates_and_retains_every_threshold_match(
         candidates[0].id,
         candidates[2].id,
     ]
-    assert [call[1].id for call in pair_scorer.calls] == [
-        candidate.id for candidate in candidates
+    assert [call.candidate.openalex_id for call in pair_scorer.calls] == [
+        _openalex_id(candidate) for candidate in candidates
     ]
     assert [
         scored.candidate.reference_id for scored in assessment.scored_candidates
@@ -381,13 +405,10 @@ async def test_evaluate_stored_reuses_one_snapshot_for_selection_and_scoring():
 
     await service.evaluate(incoming.id)
 
-    scored_incoming = pair_scorer.calls[0][0]
-    assert scored_incoming.enhancements
-    assert {
-        enhancement.content.enhancement_type
-        for enhancement in scored_incoming.enhancements
-    } == {EnhancementType.BIBLIOGRAPHIC}
+    scored_incoming = pair_scorer.calls[0].incoming
     selection_input = selector.await_args.args[0].input
+    # The same snapshot fed both, so the scored title matches the queried one.
+    assert scored_incoming.title == selection_input.title
     assert selection_input.reference_id is None
     assert selection_input.title == "A complete reference"
     assert selection_input.excluded_reference_id == incoming.id
@@ -445,6 +466,51 @@ async def test_evaluate_supplied_makes_no_proposal_for_any_unscorable_candidate(
     assert assessment.unscorable_candidate_ids == [unscorable_candidate.id]
     assert assessment.scored_candidates[0].clears_threshold is True
     assert assessment.scored_candidates[1].clears_threshold is None
+
+
+@pytest.mark.asyncio
+async def test_evaluate_marks_an_unprojectable_candidate_unscorable():
+    incoming = _supplied_reference()
+    # Empty-list kwargs do not stick through the factory, which regenerates both.
+    unprojectable = ReferenceFactory.build(visibility="public").model_copy(
+        update={"enhancements": [], "identifiers": []}
+    )
+    service, _, _, pair_scorer = _build_service(
+        _selection(Candidate(reference_id=unprojectable.id, rank=1, routes=[])),
+        [unprojectable],
+        {unprojectable.id: 0.9},
+    )
+
+    assessment = await service.evaluate_supplied(incoming, _supplied_input(incoming))
+
+    assert assessment.outcome == DeduplicationAssessmentOutcome.NO_PROPOSAL
+    assert assessment.unscorable_candidate_ids == [unprojectable.id]
+    assert (
+        assessment.scored_candidates[0].pair_result.unscorable_reason
+        == UNPROJECTABLE_CANDIDATE_REASON
+    )
+    # The Deduper is never asked to score a pair it could not have been given.
+    assert pair_scorer.calls == []
+
+
+@pytest.mark.asyncio
+async def test_evaluate_supplied_fails_when_incoming_cannot_project():
+    unprojectable = ReferenceFactory.build(visibility="public").model_copy(
+        update={"enhancements": [], "identifiers": []}
+    )
+    candidate = _reference()
+    service, _, _, pair_scorer = _build_service(
+        _selection(Candidate(reference_id=candidate.id, rank=1, routes=[])),
+        [candidate],
+        {candidate.id: 0.9},
+    )
+
+    with pytest.raises(DeduplicationValueError):
+        await service.evaluate_supplied(
+            unprojectable, _supplied_input(_supplied_reference())
+        )
+
+    assert pair_scorer.calls == []
 
 
 @pytest.mark.asyncio
@@ -510,10 +576,8 @@ async def test_evaluate_supplied_scores_the_runners_own_record():
     assessment = await service.evaluate_supplied(incoming, supplied_input)
 
     assert assessment.incoming_reference_id == incoming.id
-    scored_incoming = pair_scorer.calls[0][0]
-    assert scored_incoming.id == incoming.id
-    assert scored_incoming.identifiers == incoming.identifiers
-    assert scored_incoming.enhancements == incoming.enhancements
+    scored_incoming = pair_scorer.calls[0].incoming
+    assert scored_incoming == DeduplicationPaperProjection.get_from_reference(incoming)
     assert selector.await_args.args[0].input == supplied_input
     # Awaited only for the candidate: the supplied record is never read back.
     reader.get_hydrated.assert_awaited_once_with(
@@ -655,17 +719,15 @@ async def test_evaluate_supplied_presents_only_scored_enhancements():
     await service.evaluate_supplied(incoming, _supplied_input(incoming))
 
     scored_incoming, _ = pair_scorer.calls[0]
-    assert [
-        enhancement.content.enhancement_type
-        for enhancement in scored_incoming.enhancements or []
-    ] == [EnhancementType.BIBLIOGRAPHIC]
+    assert scored_incoming.title == "A supplied reference"
+    assert "abstract" not in scored_incoming.model_dump()
 
 
 @pytest.mark.asyncio
 async def test_evaluate_withholds_full_text_from_the_scorer():
-    """Redaction, not the hydration filter, is what keeps full text off this path."""
-    # Community-bound adds an annotation, which redaction keeps and the scored
-    # view drops, so this covers both filters rather than only redaction.
+    """The projection, not the hydration filter, is what keeps full text off this."""
+    # Community-bound adds an annotation, which redaction keeps and the projection
+    # drops, so this covers both filters rather than only redaction.
     incoming = _with_full_text(_reference(community_bound=True))
     candidate = _with_full_text(_reference(community_bound=True))
     service, _, reader, pair_scorer = _build_service(
@@ -681,12 +743,26 @@ async def test_evaluate_withholds_full_text_from_the_scorer():
 
     await service.evaluate(incoming.id)
 
+    # Absence of full text is tautological on a paper, so compare against a
+    # bibliographic-only projection instead.
     scored_incoming, scored_candidate = pair_scorer.calls[0]
-    for scored in (scored_incoming, scored_candidate):
-        assert [
-            enhancement.content.enhancement_type
-            for enhancement in scored.enhancements or []
-        ] == [EnhancementType.BIBLIOGRAPHIC]
+    for scored, reference in (
+        (scored_incoming, incoming),
+        (scored_candidate, candidate),
+    ):
+        bibliographic_only = reference.model_copy(
+            update={
+                "enhancements": [
+                    enhancement
+                    for enhancement in reference.enhancements or []
+                    if enhancement.content.enhancement_type
+                    == EnhancementType.BIBLIOGRAPHIC
+                ]
+            }
+        )
+        assert scored == DeduplicationPaperProjection.get_from_reference(
+            bibliographic_only
+        )
 
 
 @pytest.mark.asyncio
@@ -719,7 +795,7 @@ async def test_evaluate_supplied_runs_real_candidate_union_without_side_effects(
     candidate.identifiers = [
         LinkedExternalIdentifierFactory.build(
             reference_id=candidate.id,
-            identifier=incoming.identifiers[0].identifier,
+            identifier=_openalex_id(incoming),
         )
     ]
     references = fake_repository([candidate])
@@ -755,7 +831,7 @@ async def test_evaluate_supplied_runs_real_candidate_union_without_side_effects(
         sql_uow,
         es_uow,
     )
-    pair_scorer = FakePairScorer({candidate.id: 0.9})
+    pair_scorer = FakePairScorer([0.9])
     assessor = DeduplicationAssessmentService(
         candidate_selector=candidate_service.get_deduplication_candidates,
         reference_reader=references,

--- a/tests/unit/domain/references/deduplication/test_assessment.py
+++ b/tests/unit/domain/references/deduplication/test_assessment.py
@@ -1,0 +1,666 @@
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid7
+
+import destiny_sdk
+import pytest
+from destiny_sdk.visibility import Visibility
+
+from app.core.exceptions import (
+    DeduplicationError,
+    DeduplicationValueError,
+    NotFoundError,
+)
+from app.domain.references.models.models import (
+    Candidate,
+    CandidateIdentifier,
+    CandidateIdentifierRoute,
+    CandidateSelectionDiagnostics,
+    CandidateSelectionInput,
+    CandidateSelectionResult,
+    DeduperMetadata,
+    DeduplicationAssessmentOutcome,
+    DeduplicationFieldComparison,
+    DeduplicationFieldStatus,
+    DeduplicationPairResult,
+    EnhancementType,
+    ExternalIdentifierType,
+    InputSearchability,
+    Reference,
+    RetrievalPolicyName,
+)
+from app.domain.references.services.anti_corruption_service import (
+    ReferenceAntiCorruptionService,
+)
+from app.domain.references.services.deduplication_assessment_service import (
+    DeduplicationAssessmentService,
+    ReferenceReader,
+)
+from app.domain.references.services.deduplication_service import DeduplicationService
+from app.persistence.es.persistence import (
+    CandidateCanonicalSearchResult,
+    ESSearchTotal,
+)
+from tests.factories import (
+    AnnotationEnhancementFactory,
+    BibliographicMetadataEnhancementFactory,
+    BooleanAnnotationFactory,
+    EnhancementFactory,
+    LinkedExternalIdentifierFactory,
+    OpenAlexIdentifierFactory,
+    ReferenceFactory,
+)
+
+
+@pytest.fixture
+def anti_corruption_service() -> ReferenceAntiCorruptionService:
+    return ReferenceAntiCorruptionService(sign_url=AsyncMock())
+
+
+def _reference(*, community_bound: bool = False) -> Reference:
+    enhancements = [
+        EnhancementFactory.build(
+            content=BibliographicMetadataEnhancementFactory.build(
+                title="A complete reference",
+            )
+        )
+    ]
+    if community_bound:
+        enhancements.append(
+            EnhancementFactory.build(
+                content=AnnotationEnhancementFactory.build(
+                    annotations=[
+                        BooleanAnnotationFactory.build(
+                            scheme="community", label="esea", value=True
+                        )
+                    ]
+                )
+            )
+        )
+    reference = ReferenceFactory.build(
+        enhancements=enhancements,
+        identifiers=[
+            LinkedExternalIdentifierFactory.build(
+                identifier=OpenAlexIdentifierFactory.build()
+            )
+        ],
+        visibility="public",
+    )
+    for enhancement in reference.enhancements or []:
+        enhancement.reference_id = reference.id
+    for identifier in reference.identifiers or []:
+        identifier.reference_id = reference.id
+    return reference
+
+
+def _supplied_reference() -> destiny_sdk.references.Reference:
+    """Build the frozen SDK shape supplied by an evaluation runner."""
+    reference_id = uuid7()
+    return destiny_sdk.references.Reference(
+        id=reference_id,
+        visibility=Visibility.PUBLIC,
+        identifiers=[OpenAlexIdentifierFactory.build()],
+        enhancements=[
+            destiny_sdk.enhancements.Enhancement(
+                reference_id=reference_id,
+                source="evaluation-benchmark",
+                visibility=Visibility.PUBLIC,
+                content=destiny_sdk.enhancements.BibliographicMetadataEnhancement(
+                    title="A supplied reference",
+                ),
+            )
+        ],
+    )
+
+
+def _supplied_input(
+    reference: destiny_sdk.references.Reference,
+    *,
+    excluded_reference_id: UUID | None = None,
+) -> CandidateSelectionInput:
+    """Build the query payload a caller supplies alongside its own reference."""
+    return CandidateSelectionInput(
+        title="A complete reference",
+        authors=["Jane Doe"],
+        publication_year=2025,
+        identifiers=[
+            CandidateIdentifier.from_specific(identifier)
+            for identifier in (reference.identifiers or [])
+        ],
+        excluded_reference_id=excluded_reference_id,
+    )
+
+
+def _selection(
+    *candidates: Candidate, searchable: bool = True
+) -> CandidateSelectionResult:
+    return CandidateSelectionResult(
+        retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
+        index_version="reference_v3" if searchable else None,
+        k_requested=10,
+        input_searchability=InputSearchability(
+            searchable=searchable,
+            reason="ok" if searchable else "missing title and authors",
+        ),
+        diagnostics=CandidateSelectionDiagnostics(
+            candidate_count=len(candidates),
+            identifier_returned=sum(
+                any(route.type == "identifier" for route in candidate.routes)
+                for candidate in candidates
+            ),
+        ),
+        candidates=list(candidates),
+    )
+
+
+class FakePairScorer:
+    def __init__(
+        self,
+        probabilities: dict[UUID, float | None],
+        *,
+        threshold: float = 0.85,
+    ) -> None:
+        self.metadata = DeduperMetadata(
+            package_version="fake-1",
+            configuration_hash="test-config",
+            threshold=threshold,
+            effective_configuration={"weights": "test"},
+        )
+        self.probabilities = probabilities
+        self.calls: list[
+            tuple[
+                destiny_sdk.references.Reference,
+                destiny_sdk.references.Reference,
+            ]
+        ] = []
+
+    async def score_pair(
+        self,
+        incoming: destiny_sdk.references.Reference,
+        candidate: destiny_sdk.references.Reference,
+    ) -> DeduplicationPairResult:
+        self.calls.append((incoming, candidate))
+        probability = self.probabilities[candidate.id]
+        if probability is None:
+            return DeduplicationPairResult(
+                unscorable_reason="stand-in could not score this pair"
+            )
+        return DeduplicationPairResult(
+            probability=probability,
+            field_comparisons={
+                "title": DeduplicationFieldComparison(
+                    incoming_value="A complete reference",
+                    candidate_value="A complete reference",
+                    status=DeduplicationFieldStatus.MATCH,
+                    score=1.0,
+                )
+            },
+            suggested_label="duplicate",
+        )
+
+
+SQL_WRITE_METHODS = (
+    "add",
+    "add_bulk",
+    "merge",
+    "update_by_pk",
+    "bulk_update",
+    "bulk_update_by_filter",
+    "delete_by_pk",
+)
+ES_WRITE_METHODS = ("add", "add_bulk", "delete_by_pk")
+
+
+def _forbid_async_methods(target, method_names: tuple[str, ...]):
+    forbidden = {}
+    for method_name in method_names:
+        method = AsyncMock(
+            side_effect=AssertionError(f"assessment called {method_name}")
+        )
+        setattr(target, method_name, method)
+        forbidden[method_name] = method
+    return forbidden
+
+
+def _build_service(
+    anti_corruption_service,
+    selection: CandidateSelectionResult,
+    references: list[Reference],
+    probabilities: dict[UUID, float | None],
+):
+    by_id = {reference.id: reference for reference in references}
+
+    async def get_hydrated(ids, enhancement_types=None, **kwargs):  # noqa: ARG001
+        hydrated = []
+        for id_ in ids:
+            if id_ not in by_id:
+                continue
+            reference = by_id[id_]
+            enhancements = reference.enhancements
+            if enhancement_types and enhancements:
+                enhancements = [
+                    enhancement
+                    for enhancement in enhancements
+                    if enhancement.content.enhancement_type in enhancement_types
+                ]
+            hydrated.append(
+                reference.model_copy(deep=True, update={"enhancements": enhancements})
+            )
+        return hydrated
+
+    reader = MagicMock(spec=ReferenceReader)
+    reader.get_hydrated = AsyncMock(side_effect=get_hydrated)
+    selector = AsyncMock(return_value=selection)
+    pair_scorer = FakePairScorer(probabilities)
+    service = DeduplicationAssessmentService(
+        candidate_selector=selector,
+        reference_reader=reader,
+        anti_corruption_service=anti_corruption_service,
+        pair_scorer=pair_scorer,
+    )
+    return service, selector, reader, pair_scorer
+
+
+@pytest.mark.asyncio
+async def test_evaluate_supplied_scores_identifier_candidate_and_proposes_it(
+    anti_corruption_service,
+):
+    incoming = _supplied_reference()
+    candidate = _reference(community_bound=True)
+    identifier = candidate.identifiers[0].identifier
+    selected = Candidate(
+        reference_id=candidate.id,
+        rank=1,
+        routes=[
+            CandidateIdentifierRoute(
+                matched_identifiers=[
+                    CandidateIdentifier(
+                        identifier=str(identifier.identifier),
+                        identifier_type=ExternalIdentifierType.OPEN_ALEX,
+                    )
+                ]
+            )
+        ],
+    )
+    service, selector, reader, pair_scorer = _build_service(
+        anti_corruption_service,
+        _selection(selected, searchable=False),
+        [candidate],
+        {candidate.id: 0.91},
+    )
+
+    assessment = await service.evaluate_supplied(
+        incoming,
+        _supplied_input(incoming),
+        retrieval_policy=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+        k=7,
+    )
+
+    assert assessment.outcome == DeduplicationAssessmentOutcome.PROPOSE_DUPLICATE
+    assert assessment.proposed_duplicate_of_id == candidate.id
+    assert assessment.threshold_clearing_candidate_ids == [candidate.id]
+    assert assessment.scored_candidates[0].candidate.routes[0].type == "identifier"
+    assert (
+        assessment.scored_candidates[0].pair_result.field_comparisons["title"].score
+        == 1
+    )
+    assert len(pair_scorer.calls) == 1
+    assert pair_scorer.calls[0][1].id == candidate.id
+    reader.get_hydrated.assert_awaited_once_with(
+        [candidate.id], enhancement_types=[EnhancementType.BIBLIOGRAPHIC]
+    )
+    request = selector.await_args.args[0]
+    assert request.hydrate is False
+    assert (
+        request.retrieval_policy == RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1
+    )
+    assert request.k == 7
+    assert request.input.reference_id is None
+    assert (
+        request.input.identifiers[0].identifier_type == ExternalIdentifierType.OPEN_ALEX
+    )
+    assert assessment.model_dump_json()
+
+
+@pytest.mark.asyncio
+async def test_evaluate_scores_all_candidates_and_retains_every_threshold_match(
+    anti_corruption_service,
+):
+    incoming = _reference()
+    candidates = [_reference(), _reference(), _reference()]
+    selected = [
+        Candidate(reference_id=candidate.id, rank=rank, routes=[])
+        for rank, candidate in enumerate(candidates, start=1)
+    ]
+    probabilities = {
+        candidates[0].id: 0.95,
+        candidates[1].id: 0.2,
+        candidates[2].id: 0.85,
+    }
+    service, selector, _, pair_scorer = _build_service(
+        anti_corruption_service,
+        _selection(*selected),
+        [incoming, *candidates],
+        probabilities,
+    )
+
+    assessment = await service.evaluate(incoming.id)
+
+    assert assessment.outcome == DeduplicationAssessmentOutcome.NO_PROPOSAL
+    assert assessment.proposed_duplicate_of_id is None
+    assert assessment.threshold_clearing_candidate_ids == [
+        candidates[0].id,
+        candidates[2].id,
+    ]
+    assert [call[1].id for call in pair_scorer.calls] == [
+        candidate.id for candidate in candidates
+    ]
+    assert [
+        scored.candidate.reference_id for scored in assessment.scored_candidates
+    ] == [candidate.id for candidate in candidates]
+    request_input = selector.await_args.args[0].input
+    assert request_input.reference_id is None
+    assert request_input.excluded_reference_id == incoming.id
+
+
+@pytest.mark.asyncio
+async def test_evaluate_stored_reuses_one_snapshot_for_selection_and_scoring(
+    anti_corruption_service,
+):
+    incoming = _reference(community_bound=True)
+    candidate = _reference()
+    service, selector, reader, pair_scorer = _build_service(
+        anti_corruption_service,
+        _selection(Candidate(reference_id=candidate.id, rank=1, routes=[])),
+        [incoming, candidate],
+        {candidate.id: 0.1},
+    )
+
+    await service.evaluate(incoming.id)
+
+    scored_incoming = pair_scorer.calls[0][0]
+    assert scored_incoming.enhancements
+    assert {
+        enhancement.content.enhancement_type
+        for enhancement in scored_incoming.enhancements
+    } == {EnhancementType.BIBLIOGRAPHIC}
+    selection_input = selector.await_args.args[0].input
+    assert selection_input.reference_id is None
+    assert selection_input.title == "A complete reference"
+    assert selection_input.excluded_reference_id == incoming.id
+    reader.get_hydrated.assert_any_await(
+        [incoming.id], enhancement_types=[EnhancementType.BIBLIOGRAPHIC]
+    )
+
+
+@pytest.mark.asyncio
+async def test_evaluate_supplied_rejects_a_candidate_with_the_incoming_id(
+    anti_corruption_service,
+):
+    incoming = _supplied_reference()
+    candidate = _reference()
+    candidate.id = incoming.id
+    for enhancement in candidate.enhancements or []:
+        enhancement.reference_id = incoming.id
+    for identifier in candidate.identifiers or []:
+        identifier.reference_id = incoming.id
+    service, _, reader, pair_scorer = _build_service(
+        anti_corruption_service,
+        _selection(Candidate(reference_id=incoming.id, rank=1, routes=[])),
+        [candidate],
+        {incoming.id: 1.0},
+    )
+
+    with pytest.raises(DeduplicationValueError, match=str(incoming.id)):
+        await service.evaluate_supplied(incoming, _supplied_input(incoming))
+
+    reader.get_hydrated.assert_not_awaited()
+    assert pair_scorer.calls == []
+
+
+@pytest.mark.asyncio
+async def test_evaluate_supplied_makes_no_proposal_for_any_unscorable_candidate(
+    anti_corruption_service,
+):
+    incoming = _supplied_reference()
+    scored_candidate = _reference()
+    unscorable_candidate = _reference()
+    candidates = [scored_candidate, unscorable_candidate]
+    selected = [
+        Candidate(reference_id=candidate.id, rank=rank, routes=[])
+        for rank, candidate in enumerate(candidates, start=1)
+    ]
+    service, _, _, _ = _build_service(
+        anti_corruption_service,
+        _selection(*selected),
+        candidates,
+        {
+            scored_candidate.id: 0.9,
+            unscorable_candidate.id: None,
+        },
+    )
+
+    assessment = await service.evaluate_supplied(incoming, _supplied_input(incoming))
+
+    assert assessment.outcome == DeduplicationAssessmentOutcome.NO_PROPOSAL
+    assert assessment.proposed_duplicate_of_id is None
+    assert assessment.threshold_clearing_candidate_ids == [scored_candidate.id]
+    assert assessment.unscorable_candidate_ids == [unscorable_candidate.id]
+    assert assessment.scored_candidates[0].clears_threshold is True
+    assert assessment.scored_candidates[1].clears_threshold is None
+
+
+@pytest.mark.asyncio
+async def test_evaluate_empty_searchable_union_proposes_canonical(
+    anti_corruption_service,
+):
+    incoming = _reference()
+    service, _, reader, pair_scorer = _build_service(
+        anti_corruption_service,
+        _selection(searchable=True),
+        [incoming],
+        {},
+    )
+
+    assessment = await service.evaluate(incoming.id)
+
+    assert assessment.outcome == DeduplicationAssessmentOutcome.PROPOSE_CANONICAL
+    assert assessment.proposed_duplicate_of_id is None
+    assert assessment.candidate_selection.input_searchability.searchable is True
+    assert assessment.threshold_clearing_candidate_ids == []
+    assert assessment.scored_candidates == []
+    assert pair_scorer.calls == []
+    reader.get_hydrated.assert_awaited_once_with(
+        [incoming.id], enhancement_types=[EnhancementType.BIBLIOGRAPHIC]
+    )
+
+
+@pytest.mark.asyncio
+async def test_evaluate_empty_unsearchable_union_makes_no_proposal(
+    anti_corruption_service,
+):
+    incoming = _reference()
+    service, _, reader, pair_scorer = _build_service(
+        anti_corruption_service,
+        _selection(searchable=False),
+        [incoming],
+        {},
+    )
+
+    assessment = await service.evaluate(incoming.id)
+
+    assert assessment.outcome == DeduplicationAssessmentOutcome.NO_PROPOSAL
+    assert assessment.proposed_duplicate_of_id is None
+    assert assessment.candidate_selection.input_searchability.searchable is False
+    assert assessment.threshold_clearing_candidate_ids == []
+    assert assessment.scored_candidates == []
+    assert pair_scorer.calls == []
+    reader.get_hydrated.assert_awaited_once_with(
+        [incoming.id], enhancement_types=[EnhancementType.BIBLIOGRAPHIC]
+    )
+
+
+@pytest.mark.asyncio
+async def test_evaluate_supplied_scores_the_exact_sdk_reference(
+    anti_corruption_service,
+):
+    """The runner's frozen SDK reference reaches the scorer unchanged."""
+    incoming = _supplied_reference()
+    candidate = _reference()
+    supplied_input = CandidateSelectionInput(
+        title="A supplied reference",
+        authors=["Jane Doe"],
+        publication_year=2025,
+    )
+    service, selector, reader, pair_scorer = _build_service(
+        anti_corruption_service,
+        _selection(Candidate(reference_id=candidate.id, rank=1, routes=[])),
+        [candidate],
+        {candidate.id: 0.1},
+    )
+
+    assessment = await service.evaluate_supplied(incoming, supplied_input)
+
+    assert assessment.incoming_reference_id == incoming.id
+    assert incoming.enhancements
+    assert incoming.enhancements[0].created_at is None
+    assert pair_scorer.calls[0][0] is incoming
+    assert selector.await_args.args[0].input == supplied_input
+    reader.get_hydrated.assert_awaited_once_with(
+        [candidate.id], enhancement_types=[EnhancementType.BIBLIOGRAPHIC]
+    )
+
+
+@pytest.mark.asyncio
+async def test_evaluate_supplied_passes_the_callers_exclusion_through(
+    anti_corruption_service,
+):
+    """A held record must not be retrieved as its own candidate."""
+    incoming = _supplied_reference()
+    held_reference_id = uuid7()
+    service, selector, _, _ = _build_service(
+        anti_corruption_service,
+        _selection(),
+        [],
+        {},
+    )
+
+    await service.evaluate_supplied(
+        incoming,
+        _supplied_input(incoming, excluded_reference_id=held_reference_id),
+    )
+
+    request_input = selector.await_args.args[0].input
+    assert request_input.reference_id is None
+    assert request_input.excluded_reference_id == held_reference_id
+
+
+@pytest.mark.asyncio
+async def test_evaluate_supplied_fails_when_candidate_union_cannot_be_hydrated(
+    anti_corruption_service,
+):
+    incoming = _supplied_reference()
+    missing_id = uuid7()
+    service, _, _, pair_scorer = _build_service(
+        anti_corruption_service,
+        _selection(Candidate(reference_id=missing_id, rank=1, routes=[])),
+        [],
+        {missing_id: 0.9},
+    )
+
+    with pytest.raises(DeduplicationError, match=str(missing_id)):
+        await service.evaluate_supplied(incoming, _supplied_input(incoming))
+
+    assert pair_scorer.calls == []
+
+
+@pytest.mark.asyncio
+async def test_evaluate_fails_when_stored_incoming_cannot_be_hydrated(
+    anti_corruption_service,
+):
+    reference_id = uuid7()
+    service, selector, _, pair_scorer = _build_service(
+        anti_corruption_service,
+        _selection(),
+        [],
+        {},
+    )
+
+    with pytest.raises(NotFoundError, match=str(reference_id)) as exc_info:
+        await service.evaluate(reference_id)
+
+    assert isinstance(exc_info.value, DeduplicationError)
+    selector.assert_not_awaited()
+    assert pair_scorer.calls == []
+
+
+@pytest.mark.asyncio
+async def test_evaluate_supplied_runs_real_candidate_union_without_side_effects(
+    anti_corruption_service,
+    fake_repository,
+    fake_uow,
+):
+    incoming = _supplied_reference()
+    candidate = _reference(community_bound=True)
+    candidate.identifiers = [
+        LinkedExternalIdentifierFactory.build(
+            reference_id=candidate.id,
+            identifier=incoming.identifiers[0],
+        )
+    ]
+    references = fake_repository([candidate])
+    references.find_with_identifiers = AsyncMock(return_value=[candidate])
+    references.get_hydrated = AsyncMock(return_value=[candidate])
+    forbidden_reference_writes = _forbid_async_methods(references, SQL_WRITE_METHODS)
+    decisions = fake_repository()
+    forbidden_decision_writes = _forbid_async_methods(decisions, SQL_WRITE_METHODS)
+    sql_uow = fake_uow(
+        references=references,
+        reference_duplicate_decisions=decisions,
+    )
+    sql_uow.commit = AsyncMock(
+        side_effect=AssertionError("assessment committed the SQL unit of work")
+    )
+    es_uow = MagicMock()
+    es_references = MagicMock()
+    es_references.get_current_index_name = AsyncMock(return_value="reference_v3")
+    es_references.search_for_candidate_canonicals = AsyncMock(
+        return_value=CandidateCanonicalSearchResult(
+            hits=[],
+            total=ESSearchTotal(value=0, relation="eq"),
+            took_ms=1,
+        )
+    )
+    forbidden_es_writes = _forbid_async_methods(es_references, ES_WRITE_METHODS)
+    es_uow.references = es_references
+    es_uow.commit = AsyncMock(
+        side_effect=AssertionError("assessment committed the ES unit of work")
+    )
+    candidate_service = DeduplicationService(
+        anti_corruption_service,
+        sql_uow,
+        es_uow,
+    )
+    pair_scorer = FakePairScorer({candidate.id: 0.9})
+    assessor = DeduplicationAssessmentService(
+        candidate_selector=candidate_service.get_deduplication_candidates,
+        reference_reader=references,
+        anti_corruption_service=anti_corruption_service,
+        pair_scorer=pair_scorer,
+    )
+
+    assessment = await assessor.evaluate_supplied(incoming, _supplied_input(incoming))
+
+    assert assessment.proposed_duplicate_of_id == candidate.id
+    assert assessment.scored_candidates[0].candidate.routes[0].type == "identifier"
+    assert len(pair_scorer.calls) == 1
+    references.get_hydrated.assert_awaited_once_with(
+        [candidate.id], enhancement_types=[EnhancementType.BIBLIOGRAPHIC]
+    )
+    for method in (
+        *forbidden_reference_writes.values(),
+        *forbidden_decision_writes.values(),
+        *forbidden_es_writes.values(),
+    ):
+        method.assert_not_awaited()
+    sql_uow.commit.assert_not_awaited()
+    es_uow.commit.assert_not_awaited()

--- a/tests/unit/domain/references/deduplication/test_assessment.py
+++ b/tests/unit/domain/references/deduplication/test_assessment.py
@@ -4,10 +4,12 @@ from uuid import UUID, uuid7
 import destiny_sdk
 import pytest
 from destiny_sdk.visibility import Visibility
+from sqlalchemy.exc import OperationalError, ProgrammingError
 
 from app.core.exceptions import (
     DeduplicationError,
     DeduplicationValueError,
+    ESError,
     NotFoundError,
 )
 from app.domain.references.models.models import (
@@ -552,6 +554,71 @@ async def test_evaluate_supplied_passes_the_callers_exclusion_through(
     request_input = selector.await_args.args[0].input
     assert request_input.reference_id is None
     assert request_input.excluded_reference_id == held_reference_id
+
+
+@pytest.mark.asyncio
+async def test_evaluate_supplied_reports_retrieval_infrastructure_failure_per_record(
+    anti_corruption_service,
+):
+    """A retrieval blip the repository already translated is one record's failure."""
+    incoming = _supplied_reference()
+    service, selector, _, pair_scorer = _build_service(
+        anti_corruption_service, _selection(), [], {}
+    )
+    selector.side_effect = ESError("candidate search unavailable (503)")
+
+    with pytest.raises(DeduplicationError):
+        await service.evaluate_supplied(incoming, _supplied_input(incoming))
+
+    assert pair_scorer.calls == []
+
+
+@pytest.mark.asyncio
+async def test_evaluate_supplied_reports_hydration_infrastructure_failure_per_record(
+    anti_corruption_service,
+):
+    """A database blip while hydrating candidates is also one record's failure."""
+    incoming = _supplied_reference()
+    candidate = _reference()
+    service, _, reader, pair_scorer = _build_service(
+        anti_corruption_service,
+        _selection(Candidate(reference_id=candidate.id, rank=1, routes=[])),
+        [candidate],
+        {candidate.id: 0.9},
+    )
+    reader.get_hydrated = AsyncMock(
+        side_effect=OperationalError("SELECT 1", {}, Exception("connection lost"))
+    )
+
+    with pytest.raises(DeduplicationError):
+        await service.evaluate_supplied(incoming, _supplied_input(incoming))
+
+    assert pair_scorer.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [
+        pytest.param(TypeError("selector called with the wrong shape"), id="type"),
+        # A DBAPIError sibling of OperationalError. Catching DBAPIError wholesale
+        # would bury a malformed query as a per-record failure on every input.
+        pytest.param(
+            ProgrammingError("SELECT nope", {}, Exception("column does not exist")),
+            id="malformed-query",
+        ),
+    ],
+)
+async def test_evaluate_supplied_propagates_defects(anti_corruption_service, error):
+    """Only infrastructure failures are localised; a defect still aborts the caller."""
+    incoming = _supplied_reference()
+    service, selector, _, _ = _build_service(
+        anti_corruption_service, _selection(), [], {}
+    )
+    selector.side_effect = error
+
+    with pytest.raises(type(error)):
+        await service.evaluate_supplied(incoming, _supplied_input(incoming))
 
 
 @pytest.mark.asyncio

--- a/tests/unit/domain/references/deduplication/test_assessment.py
+++ b/tests/unit/domain/references/deduplication/test_assessment.py
@@ -110,6 +110,19 @@ def _with_full_text(reference: Reference) -> Reference:
     return reference
 
 
+def _bibliographic_only(reference: Reference) -> Reference:
+    """Reduce a reference to what the scorer is meant to see, for comparison."""
+    return reference.model_copy(
+        update={
+            "enhancements": [
+                enhancement
+                for enhancement in reference.enhancements or []
+                if enhancement.content.enhancement_type == EnhancementType.BIBLIOGRAPHIC
+            ]
+        }
+    )
+
+
 def _supplied_reference() -> Reference:
     """Build the unimported record an evaluation runner supplies."""
     reference = ReferenceFactory.build(visibility="public")
@@ -697,8 +710,8 @@ async def test_evaluate_fails_when_stored_incoming_cannot_be_hydrated():
 
 @pytest.mark.asyncio
 async def test_evaluate_supplied_presents_only_scored_enhancements():
-    """Both entrypoints must show the scorer the same enhancement types."""
-    incoming = _supplied_reference()
+    """A supplied record skips hydration filtering, so only the projection filters."""
+    incoming = _with_full_text(_supplied_reference())
     incoming.enhancements = [
         *(incoming.enhancements or []),
         EnhancementFactory.build(
@@ -720,14 +733,16 @@ async def test_evaluate_supplied_presents_only_scored_enhancements():
 
     scored_incoming, _ = pair_scorer.calls[0]
     assert scored_incoming.title == "A supplied reference"
-    assert "abstract" not in scored_incoming.model_dump()
+    assert scored_incoming == DeduplicationPaperProjection.get_from_reference(
+        _bibliographic_only(incoming)
+    )
 
 
 @pytest.mark.asyncio
 async def test_evaluate_withholds_full_text_from_the_scorer():
     """The projection, not the hydration filter, is what keeps full text off this."""
-    # Community-bound adds an annotation, which redaction keeps and the projection
-    # drops, so this covers both filters rather than only redaction.
+    # Candidates only ever reach the scorer through this path, so the widened
+    # hydration below is the only way to test them against an unfiltered record.
     incoming = _with_full_text(_reference(community_bound=True))
     candidate = _with_full_text(_reference(community_bound=True))
     service, _, reader, pair_scorer = _build_service(
@@ -743,25 +758,13 @@ async def test_evaluate_withholds_full_text_from_the_scorer():
 
     await service.evaluate(incoming.id)
 
-    # Absence of full text is tautological on a paper, so compare against a
-    # bibliographic-only projection instead.
     scored_incoming, scored_candidate = pair_scorer.calls[0]
     for scored, reference in (
         (scored_incoming, incoming),
         (scored_candidate, candidate),
     ):
-        bibliographic_only = reference.model_copy(
-            update={
-                "enhancements": [
-                    enhancement
-                    for enhancement in reference.enhancements or []
-                    if enhancement.content.enhancement_type
-                    == EnhancementType.BIBLIOGRAPHIC
-                ]
-            }
-        )
         assert scored == DeduplicationPaperProjection.get_from_reference(
-            bibliographic_only
+            _bibliographic_only(reference)
         )
 
 

--- a/tests/unit/domain/references/deduplication/test_candidate_search.py
+++ b/tests/unit/domain/references/deduplication/test_candidate_search.py
@@ -1,6 +1,20 @@
 """Tests for service-side candidate author-query construction."""
 
+from unittest.mock import AsyncMock
+
+import pytest
+from elastic_transport import ApiResponseMeta, ConnectionTimeout
+from elastic_transport import ConnectionError as ESConnectionError
+from elasticsearch import ApiError
+from elasticsearch.dsl import AsyncSearch
+
 from app.core.config import DedupCandidateScoringConfig
+from app.core.exceptions import ESError
+from app.domain.references.models.models import (
+    CandidateCanonicalSearchQuery,
+    DuplicateDetermination,
+)
+from app.domain.references.repository import ReferenceESRepository
 from app.domain.references.services.deduplication_service import (
     _candidate_author_terms,
 )
@@ -79,3 +93,61 @@ class TestBuildCandidateAuthorQueries:
         assert "Álvarez" in queries[0]
         assert "李" in queries[1]
         assert "雷" in queries[1]
+
+
+class TestCandidateSearchFailureTranslation:
+    """Transient Elasticsearch failures become ESError; defects stay fatal."""
+
+    @staticmethod
+    def _api_error(status: int) -> ApiError:
+        meta = ApiResponseMeta(
+            status=status, http_version="1.1", headers={}, duration=0.0, node=None
+        )
+        return ApiError("elasticsearch said no", meta=meta, body=None)
+
+    async def _search(self, monkeypatch, error: Exception):
+        async def execute(_self):
+            raise error
+
+        monkeypatch.setattr(AsyncSearch, "execute", execute)
+        repository = ReferenceESRepository(client=AsyncMock())
+        return await repository.search_for_candidate_canonicals(
+            CandidateCanonicalSearchQuery(
+                title="A study",
+                title_fuzziness="AUTO",
+                title_boost=1.0,
+                title_operator="or",
+                title_minimum_should_match="50%",
+                author_terms=("Jane Doe",),
+                author_tie_breaker=0.3,
+                publication_year_range=(2023, 2025),
+                duplicate_determination=DuplicateDetermination.CANONICAL,
+                excluded_reference_id=None,
+            ),
+            k=10,
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "error",
+        [
+            pytest.param(ConnectionTimeout("timed out"), id="timeout"),
+            pytest.param(ESConnectionError("refused"), id="connection"),
+        ],
+    )
+    async def test_transport_failure_becomes_es_error(self, monkeypatch, error):
+        with pytest.raises(ESError):
+            await self._search(monkeypatch, error)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [429, 502, 503, 504])
+    async def test_transient_status_becomes_es_error(self, monkeypatch, status):
+        with pytest.raises(ESError):
+            await self._search(monkeypatch, self._api_error(status))
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [400, 404])
+    async def test_client_error_stays_fatal(self, monkeypatch, status):
+        """A malformed query is a defect: it must not be retried per record."""
+        with pytest.raises(ApiError):
+            await self._search(monkeypatch, self._api_error(status))

--- a/tests/unit/domain/references/deduplication/test_candidate_selection.py
+++ b/tests/unit/domain/references/deduplication/test_candidate_selection.py
@@ -7,7 +7,7 @@ import pytest
 from destiny_sdk.enhancements import Authorship
 from pydantic import ValidationError
 
-from app.core.exceptions import DeduplicationValueError
+from app.core.exceptions import DeduplicationError, DeduplicationValueError
 from app.domain.references.models.models import (
     CandidateElasticsearchRoute,
     CandidateIdentifier,
@@ -116,25 +116,39 @@ def build_service(fake_uow, anti_corruption_service):
 
 
 class TestCandidateSelectionInputValidation:
-    def test_rejects_neither(self):
+    def test_rejects_missing_input_mode(self):
         with pytest.raises(ValidationError):
             CandidateSelectionInput()
 
-    def test_rejects_both(self):
+    def test_rejects_reference_id_with_inline_fields(self):
         with pytest.raises(ValidationError):
             CandidateSelectionInput(reference_id=uuid7(), title="A title")
 
-    def test_accepts_reference_id(self):
-        input_ = CandidateSelectionInput(reference_id=uuid7())
-        assert input_.reference_id is not None
+    def test_accepts_reference_id_input(self):
+        selection_input = CandidateSelectionInput(reference_id=uuid7())
+        assert selection_input.reference_id is not None
 
-    def test_accepts_inline(self):
-        input_ = CandidateSelectionInput(
+    def test_accepts_inline_input(self):
+        selection_input = CandidateSelectionInput(
             title="A title", authors=["Jane"], publication_year=2020
         )
-        assert input_.title == "A title"
+        assert selection_input.title == "A title"
 
-    def test_k_bounds_enforced(self):
+    def test_accepts_inline_with_excluded_reference_id(self):
+        excluded = uuid7()
+
+        selection_input = CandidateSelectionInput(
+            title="A title", excluded_reference_id=excluded
+        )
+
+        assert selection_input.excluded_reference_id == excluded
+
+    def test_rejects_reference_id_with_excluded_reference_id(self):
+        """The reference_id mode already excludes its own reference."""
+        with pytest.raises(ValidationError):
+            CandidateSelectionInput(reference_id=uuid7(), excluded_reference_id=uuid7())
+
+    def test_rejects_k_outside_bounds(self):
         with pytest.raises(ValidationError):
             CandidateSelectionRequest(
                 input=CandidateSelectionInput(reference_id=uuid7()), k=0
@@ -171,7 +185,7 @@ class TestCandidateSelectionInputValidation:
             )
 
 
-def test_unknown_retrieval_policy_rejected_by_request_model():
+def test_request_model_rejects_unknown_retrieval_policy():
     """An unknown policy is rejected when the request is built (a 422 at the API)."""
     with pytest.raises(ValidationError):
         CandidateSelectionRequest(
@@ -183,7 +197,9 @@ def test_unknown_retrieval_policy_rejected_by_request_model():
 
 
 @pytest.mark.asyncio
-async def test_no_year_filter_v1_passes_strategy_and_stamps_policy(build_service):
+async def test_no_year_filter_policy_removes_year_range_and_records_policy(
+    build_service,
+):
     hit = uuid7()
     service, es_refs, _, _ = build_service(
         es_result=_es_result(ESScoreResult(id=hit, score=5.0))
@@ -213,9 +229,7 @@ async def test_no_year_filter_v1_passes_strategy_and_stamps_policy(build_service
 
 
 @pytest.mark.asyncio
-async def test_request_without_overrides_honours_rollback_policy_and_configured_k(
-    build_service, monkeypatch
-):
+async def test_request_defaults_to_configured_policy_and_k(build_service, monkeypatch):
     from app.domain.references.services import deduplication_service as dedup_module
 
     service, es_refs, _, _ = build_service()
@@ -241,7 +255,7 @@ async def test_request_without_overrides_honours_rollback_policy_and_configured_
 
 
 @pytest.mark.asyncio
-async def test_year_optional_policy_searches_missing_year_input(build_service):
+async def test_year_optional_policy_searches_without_publication_year(build_service):
     service, es_refs, _, _ = build_service(
         es_result=_es_result(ESScoreResult(id=uuid7(), score=4.0))
     )
@@ -261,7 +275,7 @@ async def test_year_optional_policy_searches_missing_year_input(build_service):
 
 
 @pytest.mark.asyncio
-async def test_missing_year_input_unsearchable_under_control(build_service):
+async def test_control_policy_marks_input_without_year_unsearchable(build_service):
     service, es_refs, _, _ = build_service()
 
     result = await service.get_deduplication_candidates(
@@ -308,7 +322,7 @@ async def test_inline_input_returns_ranked_es_candidates(build_service):
 
 
 @pytest.mark.asyncio
-async def test_reference_id_input_self_excludes_and_defaults_k(build_service):
+async def test_reference_id_input_excludes_itself_and_uses_configured_k(build_service):
     reference = _searchable_reference()
     hit = uuid7()
     service, es_refs, sql_refs, _ = build_service(
@@ -333,7 +347,65 @@ async def test_reference_id_input_self_excludes_and_defaults_k(build_service):
 
 
 @pytest.mark.asyncio
-async def test_k_override_passed_to_es(build_service):
+async def test_inline_input_excludes_held_reference_from_es_candidates(
+    build_service,
+):
+    excluded = uuid7()
+    service, es_refs, _, _ = build_service()
+
+    await service.get_deduplication_candidates(
+        CandidateSelectionRequest(
+            input=CandidateSelectionInput(
+                title="A study",
+                authors=["Jane Doe"],
+                publication_year=2025,
+                excluded_reference_id=excluded,
+            ),
+            hydrate=False,
+        )
+    )
+
+    query = es_refs.search_for_candidate_canonicals.call_args.args[0]
+    assert query.excluded_reference_id == excluded
+
+
+@pytest.mark.asyncio
+async def test_inline_input_excludes_held_reference_from_identifier_candidates(
+    build_service,
+):
+    doi = DOIIdentifierFactory.build()
+    held = ReferenceFactory.build(visibility="public")
+    held = held.model_copy(
+        update={
+            "identifiers": [
+                LinkedExternalIdentifierFactory.build(
+                    identifier=doi, reference_id=held.id
+                )
+            ]
+        }
+    )
+    service, _, _, _ = build_service(found_references=[held])
+
+    result = await service.get_deduplication_candidates(
+        CandidateSelectionRequest(
+            input=CandidateSelectionInput(
+                identifiers=[
+                    CandidateIdentifier(
+                        identifier_type=ExternalIdentifierType.DOI,
+                        identifier=str(doi.identifier),
+                    )
+                ],
+                excluded_reference_id=held.id,
+            ),
+            hydrate=False,
+        )
+    )
+
+    assert result.candidates == []
+
+
+@pytest.mark.asyncio
+async def test_k_override_is_forwarded_to_elasticsearch(build_service):
     service, es_refs, _, _ = build_service()
 
     result = await service.get_deduplication_candidates(
@@ -352,7 +424,7 @@ async def test_k_override_passed_to_es(build_service):
 
 
 @pytest.mark.asyncio
-async def test_identifier_only_match_ranks_ahead_of_es(build_service):
+async def test_identifier_only_match_ranks_ahead_of_es_candidates(build_service):
     doi = DOIIdentifierFactory.build()
     identifier_ref = ReferenceFactory.build(visibility="public")
     identifier_ref = identifier_ref.model_copy(
@@ -452,7 +524,9 @@ async def test_same_canonical_from_both_routes_is_returned_once(build_service):
 
 
 @pytest.mark.asyncio
-async def test_identifier_match_on_duplicate_resolves_to_canonical(build_service):
+async def test_duplicate_identifier_match_resolves_to_canonical(
+    build_service,
+):
     doi = DOIIdentifierFactory.build()
     canonical_id = uuid7()
     duplicate = ReferenceFactory.build(visibility="public")
@@ -494,7 +568,46 @@ async def test_identifier_match_on_duplicate_resolves_to_canonical(build_service
 
 
 @pytest.mark.asyncio
-async def test_identifier_match_keeps_canonical_with_existing_duplicates_eligible(
+async def test_duplicate_identifier_match_missing_canonical_raises_deduplication_error(
+    build_service,
+):
+    doi = DOIIdentifierFactory.build()
+    duplicate = ReferenceFactory.build(visibility="public")
+    duplicate = duplicate.model_copy(
+        update={
+            "identifiers": [
+                LinkedExternalIdentifierFactory.build(
+                    identifier=doi, reference_id=duplicate.id
+                )
+            ],
+            "duplicate_decision": ReferenceDuplicateDecision(
+                reference_id=duplicate.id,
+                active_decision=True,
+                duplicate_determination=DuplicateDetermination.DUPLICATE,
+                canonical_reference_id=uuid7(),
+            ).model_copy(update={"canonical_reference_id": None}),
+        }
+    )
+    service, _, _, _ = build_service(found_references=[duplicate])
+
+    with pytest.raises(DeduplicationError, match="without a canonical reference id"):
+        await service.get_deduplication_candidates(
+            CandidateSelectionRequest(
+                input=CandidateSelectionInput(
+                    identifiers=[
+                        CandidateIdentifier(
+                            identifier_type=ExternalIdentifierType.DOI,
+                            identifier=str(doi.identifier),
+                        )
+                    ]
+                ),
+                hydrate=False,
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_canonical_identifier_match_remains_eligible_with_existing_duplicates(
     build_service,
 ):
     doi = DOIIdentifierFactory.build()
@@ -537,7 +650,7 @@ async def test_identifier_match_keeps_canonical_with_existing_duplicates_eligibl
 
 
 @pytest.mark.asyncio
-async def test_hydrate_includes_reference_projection(build_service):
+async def test_hydrate_true_includes_candidate_reference_projection(build_service):
     hit = uuid7()
     hydrated = _searchable_reference().model_copy(update={"id": hit})
     service, _, _, _ = build_service(
@@ -600,7 +713,7 @@ async def test_identifier_only_input_matches_when_es_unsearchable(build_service)
     assert result.diagnostics.es_total_hits is None
 
 
-async def test_invalid_identifier_raises(build_service):
+async def test_invalid_identifier_raises_deduplication_value_error(build_service):
     """A malformed identifier value fails normalisation and raises (422 in the API)."""
     service, _, _, _ = build_service()
     with pytest.raises(DeduplicationValueError):
@@ -619,7 +732,7 @@ async def test_invalid_identifier_raises(build_service):
         )
 
 
-async def test_unsearchable_input_returns_empty_200(build_service):
+async def test_unsearchable_input_returns_empty_candidate_result(build_service):
     service, es_refs, _, _ = build_service()
 
     result = await service.get_deduplication_candidates(
@@ -636,7 +749,7 @@ async def test_unsearchable_input_returns_empty_200(build_service):
 
 
 @pytest.mark.asyncio
-async def test_writes_no_duplicate_decision_state(build_service):
+async def test_candidate_selection_does_not_write_duplicate_decisions(build_service):
     service, _, _, decisions = build_service(
         es_result=_es_result(ESScoreResult(id=uuid7(), score=1.0))
     )
@@ -669,7 +782,7 @@ def test_track_total_hits_defaults_true_and_is_overridable():
 
 
 @pytest.mark.asyncio
-async def test_track_total_hits_forwarded_to_es_search(build_service):
+async def test_track_total_hits_is_forwarded_to_elasticsearch(build_service):
     service, es_refs, _, _ = build_service(
         es_result=_es_result(ESScoreResult(id=uuid7(), score=4.0))
     )

--- a/tests/unit/domain/references/deduplication/test_paper_projection.py
+++ b/tests/unit/domain/references/deduplication/test_paper_projection.py
@@ -1,0 +1,273 @@
+from datetime import UTC, datetime
+
+import pytest
+from destiny_sdk.enhancements import AuthorPosition
+
+from app.core.exceptions import ProjectionError
+from app.domain.references.models.models import Reference
+from app.domain.references.models.projections import DeduplicationPaperProjection
+from tests.factories import (
+    AbstractContentEnhancementFactory,
+    AuthorshipFactory,
+    BibliographicMetadataEnhancementFactory,
+    DOIIdentifierFactory,
+    EnhancementFactory,
+    FullTextEnhancementFactory,
+    LinkedExternalIdentifierFactory,
+    LocationEnhancementFactory,
+    LocationFactory,
+    OpenAlexIdentifierFactory,
+    PaginationFactory,
+    PublicationVenueFactory,
+    PubMedIdentifierFactory,
+    ReferenceFactory,
+)
+
+
+def _reference(*, enhancement_contents=None, identifiers=None, **kwargs) -> Reference:
+    """Build a reference whose children carry its id, as stored records do."""
+    reference = ReferenceFactory.build(**kwargs)
+    return reference.model_copy(
+        update={
+            "enhancements": [
+                EnhancementFactory.build(reference_id=reference.id, content=content)
+                for content in (enhancement_contents or [])
+            ],
+            "identifiers": [
+                LinkedExternalIdentifierFactory.build(
+                    reference_id=reference.id, identifier=identifier
+                )
+                for identifier in (identifiers or [])
+            ],
+        }
+    )
+
+
+def test_projects_scored_identifiers():
+    doi = DOIIdentifierFactory.build()
+    open_alex = OpenAlexIdentifierFactory.build()
+    pubmed = PubMedIdentifierFactory.build()
+    reference = _reference(
+        enhancement_contents=[BibliographicMetadataEnhancementFactory.build()],
+        identifiers=[doi, open_alex, pubmed],
+    )
+
+    paper = DeduplicationPaperProjection.get_from_reference(reference)
+
+    assert paper.doi == doi
+    assert paper.openalex_id == open_alex
+    assert paper.pubmed_id == pubmed
+
+
+def test_projects_bibliographic_fields():
+    content = BibliographicMetadataEnhancementFactory.build(
+        title="Trial of a thing",
+        publication_year=2024,
+        publication_venue=PublicationVenueFactory.build(display_name="The Lancet"),
+        pagination=PaginationFactory.build(
+            volume="12", issue="4", first_page="101", last_page="115"
+        ),
+    )
+    reference = _reference(enhancement_contents=[content])
+
+    paper = DeduplicationPaperProjection.get_from_reference(reference)
+
+    assert paper.title == "Trial of a thing"
+    assert paper.year == 2024
+    assert paper.journal == "The Lancet"
+    assert paper.volume == "12"
+    assert paper.issue == "4"
+    assert paper.pages == "101-115"
+
+
+def test_pages_needs_both_endpoints():
+    content = BibliographicMetadataEnhancementFactory.build(
+        pagination=PaginationFactory.build(first_page="101", last_page=None)
+    )
+    reference = _reference(enhancement_contents=[content])
+
+    assert DeduplicationPaperProjection.get_from_reference(reference).pages is None
+
+
+def test_authors_keep_stored_order():
+    # Stored order is the citation sequence. The shared authorship helper
+    # alphabetises within position, which would scramble it.
+    authorship = [
+        AuthorshipFactory.build(
+            display_name="Zoe Alvarez", position=AuthorPosition.FIRST
+        ),
+        AuthorshipFactory.build(
+            display_name="Yusuf Bello", position=AuthorPosition.MIDDLE
+        ),
+        AuthorshipFactory.build(
+            display_name="Alice Crane", position=AuthorPosition.MIDDLE
+        ),
+    ]
+    reference = _reference(
+        enhancement_contents=[
+            BibliographicMetadataEnhancementFactory.build(authorship=authorship)
+        ]
+    )
+
+    paper = DeduplicationPaperProjection.get_from_reference(reference)
+
+    assert [author.display_name for author in paper.authors or []] == [
+        "Zoe Alvarez",
+        "Yusuf Bello",
+        "Alice Crane",
+    ]
+
+
+def test_year_falls_back_to_publication_date():
+    content = BibliographicMetadataEnhancementFactory.build(
+        publication_year=None, publication_date=datetime(2019, 6, 1, tzinfo=UTC).date()
+    )
+    reference = _reference(enhancement_contents=[content])
+
+    assert DeduplicationPaperProjection.get_from_reference(reference).year == 2019
+
+
+def test_ignores_non_bibliographic_enhancements():
+    reference = _reference(
+        enhancement_contents=[
+            BibliographicMetadataEnhancementFactory.build(title="Only this"),
+            AbstractContentEnhancementFactory.build(),
+            FullTextEnhancementFactory.build(),
+        ]
+    )
+
+    paper = DeduplicationPaperProjection.get_from_reference(reference)
+
+    assert paper.title == "Only this"
+    assert "abstract" not in paper.model_dump()
+
+
+def test_venue_never_comes_from_a_location_enhancement():
+    # The toolkit's own converter reads journal, issn, volume and issue out of a
+    # LOCATION extra dict. Sourcing those here instead is the point of this
+    # projection, so a LOCATION carrying venue data must not reach the paper.
+    reference = _reference(
+        enhancement_contents=[
+            BibliographicMetadataEnhancementFactory.build(
+                publication_venue=PublicationVenueFactory.build(
+                    display_name="The Lancet"
+                ),
+                pagination=PaginationFactory.build(volume="12", issue="4"),
+            ),
+            LocationEnhancementFactory.build(
+                locations=[
+                    LocationFactory.build(
+                        extra={
+                            "display_name": "PubMed",
+                            "volume": "999",
+                            "issue": "999",
+                        }
+                    )
+                ]
+            ),
+        ]
+    )
+
+    paper = DeduplicationPaperProjection.get_from_reference(reference)
+
+    assert paper.journal == "The Lancet"
+    assert paper.volume == "12"
+    assert paper.issue == "4"
+
+
+def test_highest_priority_bibliographic_enhancement_wins():
+    reference = ReferenceFactory.build()
+    older = EnhancementFactory.build(
+        reference_id=reference.id,
+        created_at=datetime(2024, 1, 1, tzinfo=UTC),
+        content=BibliographicMetadataEnhancementFactory.build(title="Older title"),
+    )
+    newer = EnhancementFactory.build(
+        reference_id=reference.id,
+        created_at=datetime(2025, 1, 1, tzinfo=UTC),
+        content=BibliographicMetadataEnhancementFactory.build(title="Newer title"),
+    )
+    reference = reference.model_copy(update={"enhancements": [newer, older]})
+
+    paper = DeduplicationPaperProjection.get_from_reference(reference)
+
+    assert paper.title == "Newer title"
+
+
+def test_missing_fields_fall_back_to_a_lower_priority_enhancement():
+    reference = ReferenceFactory.build()
+    older = EnhancementFactory.build(
+        reference_id=reference.id,
+        created_at=datetime(2024, 1, 1, tzinfo=UTC),
+        content=BibliographicMetadataEnhancementFactory.build(
+            title="Older title",
+            publication_venue=PublicationVenueFactory.build(display_name="The Lancet"),
+        ),
+    )
+    newer = EnhancementFactory.build(
+        reference_id=reference.id,
+        created_at=datetime(2025, 1, 1, tzinfo=UTC),
+        content=BibliographicMetadataEnhancementFactory.build(
+            title="Newer title", publication_venue=None
+        ),
+    )
+    reference = reference.model_copy(update={"enhancements": [older, newer]})
+
+    paper = DeduplicationPaperProjection.get_from_reference(reference)
+
+    assert paper.title == "Newer title"
+    assert paper.journal == "The Lancet"
+
+
+def test_projects_supplied_reference_without_created_at():
+    # A supplied record is built in memory, so its enhancements carry no created_at.
+    # The shared priority sort raises RuntimeError on those.
+    reference = ReferenceFactory.build()
+    reference = reference.model_copy(
+        update={
+            "enhancements": [
+                EnhancementFactory.build(
+                    reference_id=reference.id,
+                    created_at=None,
+                    content=BibliographicMetadataEnhancementFactory.build(
+                        title="A supplied reference"
+                    ),
+                )
+            ]
+        }
+    )
+
+    paper = DeduplicationPaperProjection.get_from_reference(reference)
+
+    assert paper.title == "A supplied reference"
+
+
+def test_untimed_enhancements_keep_input_order():
+    reference = ReferenceFactory.build()
+    reference = reference.model_copy(
+        update={
+            "enhancements": [
+                EnhancementFactory.build(
+                    reference_id=reference.id,
+                    created_at=None,
+                    content=BibliographicMetadataEnhancementFactory.build(
+                        title="First"
+                    ),
+                ),
+                EnhancementFactory.build(
+                    reference_id=reference.id,
+                    created_at=None,
+                    content=BibliographicMetadataEnhancementFactory.build(title="Last"),
+                ),
+            ]
+        }
+    )
+
+    assert DeduplicationPaperProjection.get_from_reference(reference).title == "Last"
+
+
+def test_raises_when_nothing_projects():
+    reference = _reference(enhancement_contents=[], identifiers=[])
+
+    with pytest.raises(ProjectionError):
+        DeduplicationPaperProjection.get_from_reference(reference)

--- a/tests/unit/domain/references/models/test_models.py
+++ b/tests/unit/domain/references/models/test_models.py
@@ -11,6 +11,10 @@ from pydantic import ValidationError
 from app.core.exceptions import SDKToDomainError
 from app.domain.references.models.models import (
     CandidateCanonicalSearchFields,
+    DeduperMetadata,
+    DeduplicationFieldComparison,
+    DeduplicationFieldStatus,
+    DeduplicationPairResult,
     DuplicateDetermination,
     Enhancement,
     FullTextEnhancement,
@@ -27,6 +31,49 @@ from tests.factories import (
     EnhancementFactory,
     FullTextEnhancementFactory,
 )
+
+
+def test_deduplication_pair_result_accepts_unscorable_reason_without_probability():
+    result = DeduplicationPairResult(unscorable_reason="insufficient comparable fields")
+
+    assert result.probability is None
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param({}, id="neither"),
+        pytest.param(
+            {
+                "probability": 0.4,
+                "unscorable_reason": "insufficient comparable fields",
+            },
+            id="both",
+        ),
+    ],
+)
+def test_deduplication_pair_result_rejects_ambiguous_scoring_state(data):
+    with pytest.raises(ValueError, match="probability or unscorable_reason"):
+        DeduplicationPairResult(**data)
+
+
+@pytest.mark.parametrize("field_name", ["incoming_value", "candidate_value"])
+def test_deduplication_field_comparison_rejects_non_json_values(field_name):
+    with pytest.raises(ValidationError):
+        DeduplicationFieldComparison(
+            status=DeduplicationFieldStatus.MATCH,
+            **{field_name: object()},
+        )
+
+
+def test_deduper_metadata_rejects_non_json_configuration():
+    with pytest.raises(ValidationError):
+        DeduperMetadata(
+            package_version="fake-1",
+            configuration_hash="test-config",
+            threshold=0.85,
+            effective_configuration={"opaque": object()},
+        )
 
 
 async def test_generic_external_identifier_from_specific_without_other():


### PR DESCRIPTION
## Summary

Build the read-only deep-deduplication assessment path described in #874.

The new service:

- retrieves the complete candidate union from exact-identifier and Elasticsearch routes;
- hydrates stored inputs and candidates with identifiers and bibliographic enhancements only;
- scores every candidate through a `PairScorer` protocol;
- projects both sides of every pair into `DeduplicationPaper`, a repo-owned model built to the shape the deduplication toolkit scores, so no `Reference` crosses the scorer boundary;
- records scorer metadata, retrieval provenance, field-level evidence and threshold outcomes;
- supports supplied domain references for evaluation datasets without importing them first; and
- returns `PROPOSE_CANONICAL`, `PROPOSE_DUPLICATE` or `NO_PROPOSAL` without persisting a duplicate decision or starting background work.

## Assessment rules

- `PROPOSE_CANONICAL`: every pair was scored, none cleared the threshold, and the input was searchable.
- `PROPOSE_DUPLICATE`: every pair was scored and exactly one candidate cleared the threshold.
- `NO_PROPOSAL`: multiple candidates cleared, any pair was unscorable, or a no-match input was not searchable.

Threshold and scorer configuration are captured in the assessment so results remain explainable and reproducible.

## Boundaries

This PR does not decide whether a proposal may be applied. It has no decision-writer dependency and does not update PostgreSQL, Elasticsearch canonical state or background tasks.

The production Deduper adapter is intentionally deferred to #887. Tests and local verification use a `FakePairScorer` implementing the same protocol.

## Verification

- `uv run pytest`
  - 1,108 passed
  - 1 skipped
- `uv run pytest tests/e2e --log-cli-level info`
  - 29 passed
- All applicable pre-commit hooks passed, including Ruff, Ruff format, mypy and vulture.
- Local live verification passed against PostgreSQL, Elasticsearch and MinIO for:
  - a stored-reference duplicate proposal;
  - a self-exclusion/no-match canonical proposal;
  - multiple threshold-clearing candidates producing `NO_PROPOSAL`; and
  - a supplied reference built from the evaluation dataset and read from a MinIO blob.

Closes #874

