### PR TITLE
Build the deduplication evaluation runner

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -645,6 +645,14 @@ class Settings(BaseSettings):
         ),
     )
 
+    evaluation_input_max_byte_size: int = Field(
+        default=256 * 1024**2,
+        description=(
+            "Maximum size in bytes accepted for a deduplication evaluation input. "
+            "Aborts the run before any record is assessed if exceeded."
+        ),
+    )
+
     default_pending_enhancement_lease_duration: datetime.timedelta = Field(
         default=iso8601_duration_adapter.validate_python("PT10M"),
         description=(

--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -666,6 +666,10 @@ class DeduplicationValueError(DeduplicationError, ValueError):
         super().__init__(detail)
 
 
+class EvaluationConfigurationMismatchError(DestinyRepositoryError):
+    """An evaluation run contradicted the configuration its manifest publishes."""
+
+
 class ParseError(DestinyRepositoryError):
     """An exception for when we fail to parse some input."""
 

--- a/app/domain/references/services/deduplication_assessment_service.py
+++ b/app/domain/references/services/deduplication_assessment_service.py
@@ -49,12 +49,14 @@ UNPROJECTABLE_CANDIDATE_REASON = "Candidate could not be projected for scoring."
 class ReferenceReader(Protocol):
     """Reference reads required by assessment orchestration."""
 
-    async def get_hydrated(
+    # Awaitable rather than ``async def``: the latter demands a coroutine, which the
+    # traced repository methods do not declare, and this only ever awaits the result.
+    def get_hydrated(
         self,
         reference_ids: list[UUID],
         enhancement_types: list[str] | None = None,
         external_identifier_types: list[str] | None = None,
-    ) -> list[Reference]:
+    ) -> Awaitable[list[Reference]]:
         """Read full references with optional relationship filters."""
         ...
 

--- a/app/domain/references/services/deduplication_assessment_service.py
+++ b/app/domain/references/services/deduplication_assessment_service.py
@@ -49,8 +49,7 @@ UNPROJECTABLE_CANDIDATE_REASON = "Candidate could not be projected for scoring."
 class ReferenceReader(Protocol):
     """Reference reads required by assessment orchestration."""
 
-    # Awaitable rather than ``async def``: the latter demands a coroutine, which the
-    # traced repository methods do not declare, and this only ever awaits the result.
+    # Awaitable, not ``async def``: traced repository methods don't declare one.
     def get_hydrated(
         self,
         reference_ids: list[UUID],
@@ -111,8 +110,6 @@ class DeduplicationAssessmentService:
         try:
             candidate_paper = self._to_scorer_paper(candidate)
         except DeduplicationValueError:
-            # One unprojectable candidate is not a failed assessment; it is a
-            # candidate the Deduper was never given a chance to score.
             return DeduplicationPairResult(
                 unscorable_reason=UNPROJECTABLE_CANDIDATE_REASON
             )
@@ -121,8 +118,7 @@ class DeduplicationAssessmentService:
                 incoming=incoming, candidate=candidate_paper
             )
         except Exception as exc:
-            # Deliberately broad, unlike the narrow retrieval and hydration
-            # handlers: a third-party scorer's defect is one record's, not the run's.
+            # Broad by design: a scorer's defect fails one record, not the run.
             msg = f"Candidate scoring failed ({type(exc).__name__}): {exc}"
             raise DeduplicationError(msg) from exc
 

--- a/app/domain/references/services/deduplication_assessment_service.py
+++ b/app/domain/references/services/deduplication_assessment_service.py
@@ -104,6 +104,28 @@ class DeduplicationAssessmentService:
             msg = f"Cannot build a deduplication paper for {reference.id}"
             raise DeduplicationValueError(msg) from exc
 
+    async def _score_candidate(
+        self, incoming: DeduplicationPaper, candidate: Reference
+    ) -> DeduplicationPairResult:
+        """Score one pair, or say why the Deduper could not be asked."""
+        try:
+            candidate_paper = self._to_scorer_paper(candidate)
+        except DeduplicationValueError:
+            # One unprojectable candidate is not a failed assessment; it is a
+            # candidate the Deduper was never given a chance to score.
+            return DeduplicationPairResult(
+                unscorable_reason=UNPROJECTABLE_CANDIDATE_REASON
+            )
+        try:
+            return await self._pair_scorer.score_pair(
+                incoming=incoming, candidate=candidate_paper
+            )
+        except Exception as exc:
+            # Deliberately broad, unlike the narrow retrieval and hydration
+            # handlers: a third-party scorer's defect is one record's, not the run's.
+            msg = f"Candidate scoring failed ({type(exc).__name__}): {exc}"
+            raise DeduplicationError(msg) from exc
+
     async def _hydrate_one(self, reference_id: UUID) -> Reference:
         """Read one stored reference, treating an empty result as not-found."""
         hydrated = await self._reference_reader.get_hydrated(
@@ -229,20 +251,9 @@ class DeduplicationAssessmentService:
         scorer_metadata = self._pair_scorer.metadata.model_copy(deep=True)
         threshold = scorer_metadata.threshold
         for candidate in candidate_selection.candidates:
-            try:
-                candidate_paper = self._to_scorer_paper(
-                    candidates_by_id[candidate.reference_id]
-                )
-            except DeduplicationValueError:
-                # One unprojectable candidate is not a failed assessment; it is a
-                # candidate the Deduper was never given a chance to score.
-                pair_result = DeduplicationPairResult(
-                    unscorable_reason=UNPROJECTABLE_CANDIDATE_REASON
-                )
-            else:
-                pair_result = await self._pair_scorer.score_pair(
-                    incoming=scored_incoming, candidate=candidate_paper
-                )
+            pair_result = await self._score_candidate(
+                scored_incoming, candidates_by_id[candidate.reference_id]
+            )
             clears_threshold = (
                 pair_result.probability >= threshold
                 if pair_result.probability is not None

--- a/app/domain/references/services/deduplication_evaluation_runner.py
+++ b/app/domain/references/services/deduplication_evaluation_runner.py
@@ -4,7 +4,7 @@ import json
 from collections.abc import AsyncIterable, AsyncIterator, Sequence
 from enum import StrEnum, auto
 from json import JSONDecodeError
-from typing import Literal, Protocol
+from typing import Literal, Protocol, cast
 from uuid import UUID, uuid7
 
 import destiny_sdk
@@ -14,8 +14,10 @@ from app.core.exceptions import DeduplicationError
 from app.core.telemetry.logger import get_logger
 from app.domain.references.models.models import (
     CandidateIdentifier,
+    CandidateRoute,
     CandidateSelectionInput,
     DeduplicationAssessment,
+    DeduplicationPairResult,
     RetrievalPolicyName,
 )
 
@@ -70,6 +72,21 @@ class EvaluationRecordResult(BaseModel):
     error: EvaluationRecordError | None = None
 
 
+class EvaluationPairResult(BaseModel):
+    """One analysis-friendly row projected from an assessment candidate."""
+
+    run_id: UUID
+    query_id: str
+    line_number: int
+    incoming_reference_id: UUID
+    candidate_reference_id: UUID
+    retrieval_rank: int
+    retrieval_routes: list[CandidateRoute]
+    pair_result: DeduplicationPairResult
+    threshold: float
+    clears_threshold: bool | None
+
+
 class SuppliedReferenceAssessor(Protocol):
     """Read-only supplied-reference assessment operation used by the runner."""
 
@@ -95,6 +112,30 @@ class DeduplicationEvaluationRunner:
     def __init__(self, *, assessor: SuppliedReferenceAssessor) -> None:
         """Initialize the runner with its read-only assessment dependency."""
         self._assessor = assessor
+
+    @staticmethod
+    def project_pair_results(
+        result: EvaluationRecordResult,
+    ) -> list[EvaluationPairResult]:
+        """Project analysis rows from one completed record assessment."""
+        if result.status is not EvaluationRecordStatus.ASSESSED:
+            return []
+        assessment = cast(DeduplicationAssessment, result.assessment)
+        return [
+            EvaluationPairResult(
+                run_id=result.run_id,
+                query_id=cast(str, result.query_id),
+                line_number=result.line_number,
+                incoming_reference_id=cast(UUID, result.incoming_reference_id),
+                candidate_reference_id=scored.candidate.reference_id,
+                retrieval_rank=scored.candidate.rank,
+                retrieval_routes=scored.candidate.routes,
+                pair_result=scored.pair_result,
+                threshold=assessment.deduper.threshold,
+                clears_threshold=scored.clears_threshold,
+            )
+            for scored in assessment.scored_candidates
+        ]
 
     async def evaluate_lines(
         self,

--- a/app/domain/references/services/deduplication_evaluation_runner.py
+++ b/app/domain/references/services/deduplication_evaluation_runner.py
@@ -157,30 +157,35 @@ class DeduplicationEvaluationRunner:
         configuration: EvaluationRunConfiguration,
     ) -> EvaluationRunArtifacts:
         """Evaluate a JSONL blob and write its run-scoped artifact bundle."""
-        source_bytes = b"".join(
-            [
-                chunk
-                async for chunk in blob_repository.stream_chunks_from_blob_storage(
-                    input_file
+        # Two passes over the immutable input: the manifest digest must cover the
+        # exact bytes, which the line reader cannot yield once it has decoded them.
+        digest = hashlib.sha256()
+        byte_size = 0
+        async for chunk in blob_repository.stream_chunks_from_blob_storage(input_file):
+            digest.update(chunk)
+            byte_size += len(chunk)
+
+        record_results: list[EvaluationRecordResult] = []
+        line_number = 0
+        async with blob_repository.stream_file_from_blob_storage(input_file) as lines:
+            async for line in lines:
+                line_number += 1
+                if not line.strip():
+                    continue
+                record_results.append(
+                    await self._evaluate_line(
+                        run_id=run_id,
+                        line=line,
+                        line_number=line_number,
+                        configuration=configuration,
+                    )
                 )
-            ]
-        )
-        record_results = [
-            await self._evaluate_line(
-                run_id=run_id,
-                line=line,
-                line_number=line_number,
-                configuration=configuration,
-            )
-            for line_number, line in enumerate(source_bytes.decode().splitlines(), 1)
-            if line.strip()
-        ]
         pair_results = [
             pair
             for record_result in record_results
             for pair in self._pair_results(record_result)
         ]
-        input_sha256 = hashlib.sha256(source_bytes).hexdigest()
+        input_sha256 = digest.hexdigest()
         path = f"deduplication_evaluation/{run_id}"
 
         record_bytes = self._jsonl(record_results)
@@ -194,7 +199,8 @@ class DeduplicationEvaluationRunner:
         summary_bytes = self._summary(
             run_id=run_id,
             input_file=input_file,
-            input_bytes=source_bytes,
+            input_byte_size=byte_size,
+            input_sha256=input_sha256,
             records=record_results,
             pairs=pair_results,
         ).encode()
@@ -209,7 +215,7 @@ class DeduplicationEvaluationRunner:
             "input": {
                 "uri": input_file.to_uri(),
                 "dataset_version": configuration.dataset_version,
-                "byte_size": len(source_bytes),
+                "byte_size": byte_size,
                 "sha256": input_sha256,
             },
             "configuration": configuration.model_dump(mode="json"),
@@ -243,7 +249,7 @@ class DeduplicationEvaluationRunner:
         return EvaluationRunArtifacts(
             run_id=run_id,
             input_file=input_file,
-            input_byte_size=len(source_bytes),
+            input_byte_size=byte_size,
             input_sha256=input_sha256,
             record_results_file=record_file,
             pair_results_file=pair_file,
@@ -455,11 +461,12 @@ class DeduplicationEvaluationRunner:
         }
 
     @staticmethod
-    def _summary(
+    def _summary(  # noqa: PLR0913
         *,
         run_id: UUID,
         input_file: BlobStorageFile,
-        input_bytes: bytes,
+        input_byte_size: int,
+        input_sha256: str,
         records: Sequence[EvaluationRecordResult],
         pairs: Sequence[EvaluationPairResult],
     ) -> str:
@@ -476,8 +483,8 @@ class DeduplicationEvaluationRunner:
             "# Deduplication evaluation summary\n\n"
             f"Run ID: `{run_id}`\n\n"
             f"Input: `{input_file.to_uri()}`\n\n"
-            f"Input bytes: {len(input_bytes)}\n\n"
-            f"Input SHA-256: `{hashlib.sha256(input_bytes).hexdigest()}`\n\n"
+            f"Input bytes: {input_byte_size}\n\n"
+            f"Input SHA-256: `{input_sha256}`\n\n"
             f"Records: {len(records)}\n\n"
             f"Assessed records: {statuses[EvaluationRecordStatus.ASSESSED]}\n\n"
             "Invalid input records: "

--- a/app/domain/references/services/deduplication_evaluation_runner.py
+++ b/app/domain/references/services/deduplication_evaluation_runner.py
@@ -1,0 +1,186 @@
+"""Run read-only deduplication assessments over supplied evaluation records."""
+
+from collections.abc import Sequence
+from enum import StrEnum, auto
+from typing import Literal, Protocol
+from uuid import UUID, uuid7
+
+import destiny_sdk
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.domain.references.models.models import (
+    CandidateIdentifier,
+    CandidateSelectionInput,
+    DeduplicationAssessment,
+    RetrievalPolicyName,
+)
+
+
+class EvaluationRecordStatus(StrEnum):
+    """Result status for one non-blank evaluation input line."""
+
+    ASSESSED = auto()
+
+
+class EvaluationInputReference(BaseModel):
+    """Bibliographic fields frozen into one retrieval-evaluation row."""
+
+    title: str | None
+    authors: list[str]
+    year: int | None
+
+
+class EvaluationInputRecord(BaseModel):
+    """Fields needed to assess one retrieval-evaluation dataset row."""
+
+    query_id: str
+    input_reference: EvaluationInputReference
+    input_identifiers: list[str]
+    route_applicability: list[Literal["identifier", "fuzzy"]]
+    excluded_reference_ids: list[UUID] = Field(default_factory=list)
+    dataset_version: str
+
+    model_config = ConfigDict(extra="allow")
+
+
+class EvaluationRecordResult(BaseModel):
+    """Assessment or structured failure for one non-blank input line."""
+
+    run_id: UUID
+    query_id: str
+    line_number: int
+    status: EvaluationRecordStatus
+    incoming_reference_id: UUID
+    assessment: DeduplicationAssessment
+    error: None = None
+
+
+class SuppliedReferenceAssessor(Protocol):
+    """Read-only supplied-reference assessment operation used by the runner."""
+
+    async def evaluate_supplied(
+        self,
+        incoming: destiny_sdk.references.Reference,
+        selection_input: CandidateSelectionInput,
+        *,
+        retrieval_policy: RetrievalPolicyName | None = None,
+        k: int | None = None,
+    ) -> DeduplicationAssessment:
+        """Assess one supplied reference without writing repository state."""
+        ...
+
+
+class DeduplicationEvaluationRunner:
+    """Convert supplied records and pass them to the read-only assessor."""
+
+    def __init__(self, *, assessor: SuppliedReferenceAssessor) -> None:
+        """Initialize the runner with its read-only assessment dependency."""
+        self._assessor = assessor
+
+    async def evaluate_line(
+        self,
+        *,
+        run_id: UUID,
+        line: str,
+        line_number: int,
+        retrieval_policy: RetrievalPolicyName,
+        k: int,
+    ) -> EvaluationRecordResult:
+        """Evaluate one supplied JSONL record."""
+        record = EvaluationInputRecord.model_validate_json(line)
+        incoming, selection_input = self._build_assessment_inputs(record)
+        assessment = await self._assessor.evaluate_supplied(
+            incoming,
+            selection_input,
+            retrieval_policy=retrieval_policy,
+            k=k,
+        )
+        return EvaluationRecordResult(
+            run_id=run_id,
+            query_id=record.query_id,
+            line_number=line_number,
+            status=EvaluationRecordStatus.ASSESSED,
+            incoming_reference_id=incoming.id,
+            assessment=assessment,
+        )
+
+    @classmethod
+    def _build_assessment_inputs(
+        cls, record: EvaluationInputRecord
+    ) -> tuple[destiny_sdk.references.Reference, CandidateSelectionInput]:
+        """Build the frozen scorer input and independently controlled query."""
+        reference_id = uuid7()
+        identifiers = [
+            cls._parse_identifier(identifier) for identifier in record.input_identifiers
+        ]
+        authorship = cls._build_authorship(record.input_reference.authors)
+        incoming = destiny_sdk.references.Reference(
+            id=reference_id,
+            identifiers=identifiers,
+            enhancements=[
+                destiny_sdk.enhancements.Enhancement(
+                    reference_id=reference_id,
+                    source=record.dataset_version,
+                    visibility=destiny_sdk.visibility.Visibility.PUBLIC,
+                    content=(
+                        destiny_sdk.enhancements.BibliographicMetadataEnhancement(
+                            title=record.input_reference.title,
+                            authorship=authorship,
+                            publication_year=record.input_reference.year,
+                        )
+                    ),
+                )
+            ],
+        )
+        query_identifiers = (
+            [
+                CandidateIdentifier.from_specific(identifier)
+                for identifier in identifiers
+            ]
+            if "identifier" in record.route_applicability
+            else []
+        )
+        selection_input = CandidateSelectionInput(
+            title=record.input_reference.title,
+            authors=record.input_reference.authors,
+            publication_year=record.input_reference.year,
+            identifiers=query_identifiers,
+            excluded_reference_id=(
+                record.excluded_reference_ids[0]
+                if record.excluded_reference_ids
+                else None
+            ),
+        )
+        return incoming, selection_input
+
+    @staticmethod
+    def _parse_identifier(
+        value: str,
+    ) -> destiny_sdk.identifiers.ExternalIdentifier:
+        """Parse one dataset identifier through the SDK's import identifier types."""
+        lookup = destiny_sdk.identifiers.IdentifierLookup.parse(value)
+        return destiny_sdk.identifiers.ExternalIdentifierAdapter.validate_python(
+            lookup.model_dump()
+        )
+
+    @staticmethod
+    def _build_authorship(
+        authors: Sequence[str],
+    ) -> list[destiny_sdk.enhancements.Authorship]:
+        """Convert ordered display names to the SDK bibliographic shape."""
+        last_index = len(authors) - 1
+        return [
+            destiny_sdk.enhancements.Authorship(
+                display_name=display_name,
+                position=(
+                    destiny_sdk.enhancements.AuthorPosition.FIRST
+                    if index == 0
+                    else (
+                        destiny_sdk.enhancements.AuthorPosition.LAST
+                        if index == last_index
+                        else destiny_sdk.enhancements.AuthorPosition.MIDDLE
+                    )
+                ),
+            )
+            for index, display_name in enumerate(authors)
+        ]

--- a/app/domain/references/services/deduplication_evaluation_runner.py
+++ b/app/domain/references/services/deduplication_evaluation_runner.py
@@ -14,7 +14,10 @@ from uuid import UUID, uuid7
 import destiny_sdk
 from pydantic import BaseModel, ConfigDict, Field
 
-from app.core.exceptions import DeduplicationError
+from app.core.exceptions import (
+    DeduplicationError,
+    EvaluationConfigurationMismatchError,
+)
 from app.core.telemetry.logger import get_logger
 from app.domain.references.models.models import (
     CandidateIdentifier,
@@ -336,6 +339,7 @@ class DeduplicationEvaluationRunner:
                     message=f"Evaluation failed ({type(exc).__name__}): {exc}",
                 ),
             )
+        self._verify_configuration(assessment, configuration, line_number)
         return EvaluationRecordResult(
             run_id=run_id,
             query_id=record.query_id,
@@ -344,6 +348,44 @@ class DeduplicationEvaluationRunner:
             incoming_reference_id=incoming.id,
             assessment=assessment,
         )
+
+    @staticmethod
+    def _verify_configuration(
+        assessment: DeduplicationAssessment,
+        configuration: EvaluationRunConfiguration,
+        line_number: int,
+    ) -> None:
+        """Fail the run rather than publish a manifest the run contradicts."""
+        selection = assessment.candidate_selection
+        asserted: list[tuple[str, object, object]] = [
+            (
+                "retrieval_policy",
+                configuration.retrieval_policy,
+                selection.retrieval_policy,
+            ),
+            ("k", configuration.k, selection.k_requested),
+            ("deduper", configuration.deduper, assessment.deduper),
+        ]
+        if selection.index_version is not None:
+            # An absent index version means this record was never searched.
+            asserted.append(
+                (
+                    "elasticsearch_index_version",
+                    configuration.elasticsearch_index_version,
+                    selection.index_version,
+                )
+            )
+        mismatches = [
+            f"{name} asserted {claimed!r}, ran {observed!r}"
+            for name, claimed, observed in asserted
+            if claimed != observed
+        ]
+        if mismatches:
+            msg = (
+                f"Evaluation run contradicts its configuration at line {line_number}: "
+                + "; ".join(mismatches)
+            )
+            raise EvaluationConfigurationMismatchError(msg)
 
     @staticmethod
     def _invalid_result(

--- a/app/domain/references/services/deduplication_evaluation_runner.py
+++ b/app/domain/references/services/deduplication_evaluation_runner.py
@@ -52,6 +52,12 @@ class EvaluationInputReference(BaseModel):
     title: str | None
     authors: list[str]
     year: int | None
+    journal: str | None = None
+    issue: str | None = None
+    first_page: str | None = None
+    last_page: str | None = None
+    volume: str | None = None
+    """Unscored, but the scorer's early-stop veto compares it raw and unnormalised."""
 
 
 class EvaluationInputRecord(BaseModel):
@@ -165,11 +171,9 @@ class DeduplicationEvaluationRunner:
         """Evaluate a JSONL blob and write its run-scoped artifact bundle."""
         # Two passes over the immutable input: the manifest digest must cover the
         # exact bytes, which the line reader cannot yield once it has decoded them.
-        digest = hashlib.sha256()
-        byte_size = 0
-        async for chunk in blob_repository.stream_chunks_from_blob_storage(input_file):
-            digest.update(chunk)
-            byte_size += len(chunk)
+        streamed = await blob_repository.digest(input_file)
+        byte_size = streamed.byte_size
+        input_sha256 = streamed.sha256_checksum
 
         path = f"deduplication_evaluation/{run_id}"
         record_results: list[EvaluationRecordResult] = []
@@ -196,8 +200,8 @@ class DeduplicationEvaluationRunner:
                             result.assessment, configuration, line_number
                         )
         except BaseException:
-            # A run costs hours of retrieval, so keep whatever completed, a
-            # cancelling shutdown included. No manifest marks the bundle incomplete.
+            # Keep whatever completed, a cancelling shutdown included: discarding it
+            # means querying every record again. No manifest marks it incomplete.
             await self._upload(
                 blob_repository,
                 path,
@@ -211,7 +215,6 @@ class DeduplicationEvaluationRunner:
             for record_result in record_results
             for pair in self._pair_results(record_result)
         ]
-        input_sha256 = digest.hexdigest()
 
         record_bytes = self._jsonl(record_results)
         record_file = await self._upload(
@@ -373,6 +376,8 @@ class DeduplicationEvaluationRunner:
         line_number: int,
     ) -> None:
         """Fail the run rather than publish a manifest the run contradicts."""
+        # Returned provenance is checked, not the arguments sent: an assessor may
+        # substitute a default, clamp k, or report either value incorrectly.
         selection = assessment.candidate_selection
         asserted: list[tuple[str, object, object]] = [
             (
@@ -467,6 +472,22 @@ class DeduplicationEvaluationRunner:
             )
             for index, name in enumerate(record.input_reference.authors)
         ]
+        biblio = record.input_reference
+        venue = (
+            destiny_sdk.enhancements.PublicationVenue(display_name=biblio.journal)
+            if biblio.journal
+            else None
+        )
+        pagination = (
+            destiny_sdk.enhancements.Pagination(
+                volume=biblio.volume,
+                issue=biblio.issue,
+                first_page=biblio.first_page,
+                last_page=biblio.last_page,
+            )
+            if any((biblio.volume, biblio.issue, biblio.first_page, biblio.last_page))
+            else None
+        )
         incoming = Reference(
             id=reference_id,
             identifiers=[
@@ -484,6 +505,8 @@ class DeduplicationEvaluationRunner:
                         title=record.input_reference.title,
                         authorship=authorship,
                         publication_year=record.input_reference.year,
+                        publication_venue=venue,
+                        pagination=pagination,
                     ),
                 )
             ],

--- a/app/domain/references/services/deduplication_evaluation_runner.py
+++ b/app/domain/references/services/deduplication_evaluation_runner.py
@@ -1,9 +1,9 @@
-"""Run read-only deduplication assessments over supplied evaluation records."""
+"""Run read-only deduplication assessments over a supplied JSONL blob."""
 
-import codecs
 import hashlib
 import json
-from collections.abc import AsyncIterable, AsyncIterator, Sequence
+from collections import Counter
+from collections.abc import Sequence
 from datetime import datetime
 from enum import StrEnum, auto
 from io import BytesIO
@@ -33,7 +33,7 @@ logger = get_logger(__name__)
 
 
 class EvaluationRecordStatus(StrEnum):
-    """Result status for one non-blank evaluation input line."""
+    """Status of one non-blank input line."""
 
     ASSESSED = auto()
     INPUT_INVALID = auto()
@@ -41,7 +41,7 @@ class EvaluationRecordStatus(StrEnum):
 
 
 class EvaluationInputReference(BaseModel):
-    """Bibliographic fields frozen into one retrieval-evaluation row."""
+    """Bibliographic fields frozen into one evaluation row."""
 
     title: str | None
     authors: list[str]
@@ -49,7 +49,7 @@ class EvaluationInputReference(BaseModel):
 
 
 class EvaluationInputRecord(BaseModel):
-    """Fields needed to assess one retrieval-evaluation dataset row."""
+    """Dataset fields needed for one assessment."""
 
     query_id: str
     input_reference: EvaluationInputReference
@@ -62,14 +62,14 @@ class EvaluationInputRecord(BaseModel):
 
 
 class EvaluationRecordError(BaseModel):
-    """Stable machine code and reviewable detail for one failed record."""
+    """Stable code and reviewable detail for one failed record."""
 
     code: Literal["invalid_json", "invalid_record", "evaluation_failed"]
     message: str
 
 
 class EvaluationRecordResult(BaseModel):
-    """Assessment or structured failure for one non-blank input line."""
+    """Assessment or structured failure for one input line."""
 
     run_id: UUID
     query_id: str | None
@@ -81,7 +81,7 @@ class EvaluationRecordResult(BaseModel):
 
 
 class EvaluationPairResult(BaseModel):
-    """One analysis-friendly row projected from an assessment candidate."""
+    """Analysis row projected from one assessed candidate."""
 
     run_id: UUID
     query_id: str
@@ -95,21 +95,8 @@ class EvaluationPairResult(BaseModel):
     clears_threshold: bool | None
 
 
-class EvaluationRunArtifacts(BaseModel):
-    """Run-scoped artifacts written before the completion manifest."""
-
-    run_id: UUID
-    input_file: BlobStorageFile
-    input_byte_size: int
-    input_sha256: str
-    record_results_file: BlobStorageFile
-    pair_results_file: BlobStorageFile
-    summary_file: BlobStorageFile
-    manifest_file: BlobStorageFile
-
-
 class EvaluationRunConfiguration(BaseModel):
-    """Fixed dataset, corpus, retrieval and scorer identity for one run."""
+    """Dataset, corpus, retrieval and scorer identity for one run."""
 
     dataset_version: str
     environment: str
@@ -121,53 +108,17 @@ class EvaluationRunConfiguration(BaseModel):
     deduper: DeduperMetadata
 
 
-class EvaluationManifestInput(BaseModel):
-    """Immutable input identity recorded in the completion manifest."""
+class EvaluationRunArtifacts(BaseModel):
+    """Files and immutable input identity produced by a completed run."""
 
-    uri: str
-    dataset_version: str
-    byte_size: int
-    sha256: str
-
-
-class EvaluationManifestArtifact(BaseModel):
-    """Identity and digest of one artifact written before the manifest."""
-
-    uri: str
-    schema_version: str
-    byte_size: int
-    sha256: str
-
-
-class EvaluationManifestCounts(BaseModel):
-    """Record and pair totals for one completed evaluation run."""
-
-    record_statuses: dict[EvaluationRecordStatus, int]
-    pair_rows: int
-
-
-class EvaluationManifest(BaseModel):
-    """Completion marker for one immutable evaluation artifact bundle."""
-
-    schema_version: Literal["deduplication-evaluation-manifest/v1"] = (
-        "deduplication-evaluation-manifest/v1"
-    )
     run_id: UUID
-    input: EvaluationManifestInput
-    configuration: EvaluationRunConfiguration
-    counts: EvaluationManifestCounts
-    artifacts: dict[str, EvaluationManifestArtifact]
-
-
-class _EvaluationSummaryCounts(BaseModel):
-    """Aggregate record decisions and pair evidence for the summary."""
-
-    record_statuses: dict[EvaluationRecordStatus, int]
-    assessment_outcomes: dict[DeduplicationAssessmentOutcome, int]
-    pair_rows: int
-    threshold_clearing_pairs: int
-    below_threshold_pairs: int
-    unscorable_pairs: int
+    input_file: BlobStorageFile
+    input_byte_size: int
+    input_sha256: str
+    record_results_file: BlobStorageFile
+    pair_results_file: BlobStorageFile
+    summary_file: BlobStorageFile
+    manifest_file: BlobStorageFile
 
 
 class SuppliedReferenceAssessor(Protocol):
@@ -190,35 +141,11 @@ class SuppliedReferenceAssessor(Protocol):
 
 
 class DeduplicationEvaluationRunner:
-    """Convert supplied records and pass them to the read-only assessor."""
+    """Assess supplied records and write a reviewable artifact bundle."""
 
     def __init__(self, *, assessor: SuppliedReferenceAssessor) -> None:
-        """Initialize the runner with its read-only assessment dependency."""
+        """Keep the read-only assessor used by each record."""
         self._assessor = assessor
-
-    @staticmethod
-    def project_pair_results(
-        result: EvaluationRecordResult,
-    ) -> list[EvaluationPairResult]:
-        """Project analysis rows from one completed record assessment."""
-        if result.status is not EvaluationRecordStatus.ASSESSED:
-            return []
-        assessment = cast(DeduplicationAssessment, result.assessment)
-        return [
-            EvaluationPairResult(
-                run_id=result.run_id,
-                query_id=cast(str, result.query_id),
-                line_number=result.line_number,
-                incoming_reference_id=cast(UUID, result.incoming_reference_id),
-                candidate_reference_id=scored.candidate.reference_id,
-                retrieval_rank=scored.candidate.rank,
-                retrieval_routes=scored.candidate.routes,
-                pair_result=scored.pair_result,
-                threshold=assessment.deduper.threshold,
-                clears_threshold=scored.clears_threshold,
-            )
-            for scored in assessment.scored_candidates
-        ]
 
     async def run(
         self,
@@ -228,294 +155,148 @@ class DeduplicationEvaluationRunner:
         blob_repository: BlobRepository,
         configuration: EvaluationRunConfiguration,
     ) -> EvaluationRunArtifacts:
-        """Evaluate an immutable JSONL blob and write run-scoped artifacts."""
-        path = f"deduplication_evaluation/{run_id}"
-        await blob_repository.upload_file_to_blob_storage(
-            content=BytesIO(),
-            path=path,
-            filename="record-results.jsonl",
-            content_type="application/jsonl",
+        """Evaluate a JSONL blob and write its run-scoped artifact bundle."""
+        source_bytes = b"".join(
+            [
+                chunk
+                async for chunk in blob_repository.stream_chunks_from_blob_storage(
+                    input_file
+                )
+            ]
         )
-        hasher = hashlib.sha256()
-        input_byte_size = 0
-        decoder = codecs.getincrementaldecoder("utf-8")()
-
-        async def input_lines() -> AsyncIterator[str]:
-            nonlocal input_byte_size
-            buffer = ""
-            async for chunk in blob_repository.stream_chunks_from_blob_storage(
-                input_file
-            ):
-                hasher.update(chunk)
-                input_byte_size += len(chunk)
-                buffer += decoder.decode(chunk)
-                while "\n" in buffer:
-                    line, buffer = buffer.split("\n", 1)
-                    yield line
-            buffer += decoder.decode(b"", final=True)
-            if buffer:
-                yield buffer
-
         record_results = [
-            result
-            async for result in self.evaluate_lines(
+            await self._evaluate_line(
                 run_id=run_id,
-                lines=input_lines(),
-                retrieval_policy=configuration.retrieval_policy,
-                k=configuration.k,
+                line=line,
+                line_number=line_number,
+                configuration=configuration,
             )
+            for line_number, line in enumerate(source_bytes.decode().splitlines(), 1)
+            if line.strip()
         ]
         pair_results = [
             pair
             for record_result in record_results
-            for pair in self.project_pair_results(record_result)
+            for pair in self._pair_results(record_result)
         ]
-        input_sha256 = hasher.hexdigest()
-        summary_counts = self._summary_counts(record_results, pair_results)
-        record_results_buffer = self._jsonl_buffer(record_results)
-        record_results_bytes = record_results_buffer.getvalue()
-        record_results_file = await blob_repository.upload_file_to_blob_storage(
-            content=record_results_buffer,
-            path=path,
-            filename="record-results.jsonl",
-            content_type="application/jsonl",
+        input_sha256 = hashlib.sha256(source_bytes).hexdigest()
+        path = f"deduplication_evaluation/{run_id}"
+
+        record_bytes = self._jsonl(record_results)
+        record_file = await self._upload(
+            blob_repository, path, "record-results.jsonl", record_bytes
         )
-        pair_results_buffer = self._jsonl_buffer(pair_results)
-        pair_results_bytes = pair_results_buffer.getvalue()
-        pair_results_file = await blob_repository.upload_file_to_blob_storage(
-            content=pair_results_buffer,
-            path=path,
-            filename="pair-results.jsonl",
-            content_type="application/jsonl",
+        pair_bytes = self._jsonl(pair_results)
+        pair_file = await self._upload(
+            blob_repository, path, "pair-results.jsonl", pair_bytes
         )
         summary_bytes = self._summary(
             run_id=run_id,
-            input_details=(input_file, input_byte_size, input_sha256),
-            record_count=len(record_results),
-            counts=summary_counts,
+            input_file=input_file,
+            input_bytes=source_bytes,
+            records=record_results,
+            pairs=pair_results,
         ).encode()
-        summary_file = await blob_repository.upload_file_to_blob_storage(
-            content=BytesIO(summary_bytes),
-            path=path,
-            filename="summary.md",
-            content_type="text/markdown",
+        summary_file = await self._upload(
+            blob_repository, path, "summary.md", summary_bytes
         )
-        manifest = EvaluationManifest(
-            run_id=run_id,
-            input=EvaluationManifestInput(
-                uri=input_file.to_uri(),
-                dataset_version=configuration.dataset_version,
-                byte_size=input_byte_size,
-                sha256=input_sha256,
-            ),
-            configuration=configuration,
-            counts=EvaluationManifestCounts(
-                record_statuses=summary_counts.record_statuses,
-                pair_rows=len(pair_results),
-            ),
-            artifacts={
-                "record-results.jsonl": self._artifact_metadata(
-                    record_results_file,
-                    record_results_bytes,
-                    "evaluation-record-result/v1",
+
+        status_counts = Counter(result.status for result in record_results)
+        manifest = {
+            "schema_version": "deduplication-evaluation-manifest/v1",
+            "run_id": str(run_id),
+            "input": {
+                "uri": input_file.to_uri(),
+                "dataset_version": configuration.dataset_version,
+                "byte_size": len(source_bytes),
+                "sha256": input_sha256,
+            },
+            "configuration": configuration.model_dump(mode="json"),
+            "counts": {
+                "record_statuses": {
+                    status.value: status_counts[status]
+                    for status in EvaluationRecordStatus
+                },
+                "pair_rows": len(pair_results),
+            },
+            "artifacts": {
+                "record-results.jsonl": self._artifact(
+                    record_file, record_bytes, "evaluation-record-result/v1"
                 ),
-                "pair-results.jsonl": self._artifact_metadata(
-                    pair_results_file,
-                    pair_results_bytes,
-                    "evaluation-pair-result/v1",
+                "pair-results.jsonl": self._artifact(
+                    pair_file, pair_bytes, "evaluation-pair-result/v1"
                 ),
-                "summary.md": self._artifact_metadata(
+                "summary.md": self._artifact(
                     summary_file,
                     summary_bytes,
                     "deduplication-evaluation-summary/v1",
                 ),
             },
-        )
-        manifest_file = await blob_repository.upload_file_to_blob_storage(
-            content=BytesIO(manifest.model_dump_json(indent=2).encode()),
-            path=path,
-            filename="manifest.json",
-            content_type="application/json",
+        }
+        manifest_file = await self._upload(
+            blob_repository,
+            path,
+            "manifest.json",
+            json.dumps(manifest, indent=2).encode(),
         )
         return EvaluationRunArtifacts(
             run_id=run_id,
             input_file=input_file,
-            input_byte_size=input_byte_size,
+            input_byte_size=len(source_bytes),
             input_sha256=input_sha256,
-            record_results_file=record_results_file,
-            pair_results_file=pair_results_file,
+            record_results_file=record_file,
+            pair_results_file=pair_file,
             summary_file=summary_file,
             manifest_file=manifest_file,
         )
 
-    @staticmethod
-    def _jsonl_buffer(rows: Sequence[BaseModel]) -> BytesIO:
-        """Serialize model rows as newline-terminated JSONL bytes."""
-        return BytesIO("".join(f"{row.model_dump_json()}\n" for row in rows).encode())
-
-    @staticmethod
-    def _artifact_metadata(
-        file: BlobStorageFile,
-        content: bytes,
-        schema_version: str,
-    ) -> EvaluationManifestArtifact:
-        """Describe the exact bytes uploaded for one pre-manifest artifact."""
-        return EvaluationManifestArtifact(
-            uri=file.to_uri(),
-            schema_version=schema_version,
-            byte_size=len(content),
-            sha256=hashlib.sha256(content).hexdigest(),
-        )
-
-    @staticmethod
-    def _status_counts(
-        record_results: Sequence[EvaluationRecordResult],
-    ) -> dict[EvaluationRecordStatus, int]:
-        """Count every stable record status, including zero-count statuses."""
-        return {
-            status: sum(result.status is status for result in record_results)
-            for status in EvaluationRecordStatus
-        }
-
-    @classmethod
-    def _summary_counts(
-        cls,
-        record_results: Sequence[EvaluationRecordResult],
-        pair_results: Sequence[EvaluationPairResult],
-    ) -> _EvaluationSummaryCounts:
-        """Aggregate all stable summary categories, including zero counts."""
-        return _EvaluationSummaryCounts(
-            record_statuses=cls._status_counts(record_results),
-            assessment_outcomes={
-                outcome: sum(
-                    result.assessment is not None
-                    and result.assessment.outcome is outcome
-                    for result in record_results
-                )
-                for outcome in DeduplicationAssessmentOutcome
-            },
-            pair_rows=len(pair_results),
-            threshold_clearing_pairs=sum(
-                pair.clears_threshold is True for pair in pair_results
-            ),
-            below_threshold_pairs=sum(
-                pair.clears_threshold is False for pair in pair_results
-            ),
-            unscorable_pairs=sum(
-                pair.clears_threshold is None for pair in pair_results
-            ),
-        )
-
-    @staticmethod
-    def _summary(
-        *,
-        run_id: UUID,
-        input_details: tuple[BlobStorageFile, int, str],
-        record_count: int,
-        counts: _EvaluationSummaryCounts,
-    ) -> str:
-        """Render the human-readable summary written before the manifest."""
-        input_file, input_byte_size, input_sha256 = input_details
-        return (
-            "# Deduplication evaluation summary\n\n"
-            f"Run ID: `{run_id}`\n\n"
-            f"Input: `{input_file.to_uri()}`\n\n"
-            f"Input bytes: {input_byte_size}\n\n"
-            f"Input SHA-256: `{input_sha256}`\n\n"
-            f"Records: {record_count}\n\n"
-            "Assessed records: "
-            f"{counts.record_statuses[EvaluationRecordStatus.ASSESSED]}\n\n"
-            "Invalid input records: "
-            f"{counts.record_statuses[EvaluationRecordStatus.INPUT_INVALID]}\n\n"
-            "Evaluation-failed records: "
-            f"{counts.record_statuses[EvaluationRecordStatus.EVALUATION_FAILED]}\n\n"
-            f"Pair rows: {counts.pair_rows}\n\n"
-            "## Assessment outcomes\n\n"
-            "- `propose_canonical`: "
-            f"{counts.assessment_outcomes[DeduplicationAssessmentOutcome.PROPOSE_CANONICAL]}\n"
-            "- `propose_duplicate`: "
-            f"{counts.assessment_outcomes[DeduplicationAssessmentOutcome.PROPOSE_DUPLICATE]}\n"
-            "- `no_proposal`: "
-            f"{counts.assessment_outcomes[DeduplicationAssessmentOutcome.NO_PROPOSAL]}\n\n"
-            "## Pair evidence\n\n"
-            f"- Clears threshold: {counts.threshold_clearing_pairs}\n"
-            f"- Below threshold: {counts.below_threshold_pairs}\n"
-            f"- Unscorable: {counts.unscorable_pairs}\n"
-        )
-
-    async def evaluate_lines(
-        self,
-        *,
-        run_id: UUID,
-        lines: AsyncIterable[str],
-        retrieval_policy: RetrievalPolicyName,
-        k: int,
-    ) -> AsyncIterator[EvaluationRecordResult]:
-        """Evaluate each non-blank line in physical input order."""
-        line_number = 0
-        async for line in lines:
-            line_number += 1
-            if line.strip():
-                yield await self.evaluate_line(
-                    run_id=run_id,
-                    line=line,
-                    line_number=line_number,
-                    retrieval_policy=retrieval_policy,
-                    k=k,
-                )
-
-    async def evaluate_line(
+    async def _evaluate_line(
         self,
         *,
         run_id: UUID,
         line: str,
         line_number: int,
-        retrieval_policy: RetrievalPolicyName,
-        k: int,
+        configuration: EvaluationRunConfiguration,
     ) -> EvaluationRecordResult:
-        """Evaluate one supplied JSONL record."""
         try:
             payload = json.loads(line)
         except JSONDecodeError as exc:
             return self._invalid_result(
-                run_id=run_id,
-                query_id=None,
-                line_number=line_number,
-                code="invalid_json",
-                message=(
-                    f"Invalid JSON: {exc.msg} at line {exc.lineno}, column {exc.colno}."
-                ),
+                run_id,
+                None,
+                line_number,
+                "invalid_json",
+                f"Invalid JSON: {exc.msg} at line {exc.lineno}, column {exc.colno}.",
             )
-
         if not isinstance(payload, dict):
             return self._invalid_result(
-                run_id=run_id,
-                query_id=None,
-                line_number=line_number,
-                code="invalid_record",
-                message="Invalid evaluation record: expected a JSON object.",
+                run_id,
+                None,
+                line_number,
+                "invalid_record",
+                "Invalid evaluation record: expected a JSON object.",
             )
 
         raw_query_id = payload.get("query_id")
         query_id = raw_query_id if isinstance(raw_query_id, str) else None
         try:
             record = EvaluationInputRecord.model_validate(payload)
-            incoming, selection_input = self._build_assessment_inputs(record)
+            incoming, selection_input = self._assessment_inputs(record)
         except ValueError as exc:
             return self._invalid_result(
-                run_id=run_id,
-                query_id=query_id,
-                line_number=line_number,
-                code="invalid_record",
-                message=f"Invalid evaluation record: {exc}",
+                run_id,
+                query_id,
+                line_number,
+                "invalid_record",
+                f"Invalid evaluation record: {exc}",
             )
 
         try:
             assessment = await self._assessor.evaluate_supplied(
                 incoming,
                 selection_input,
-                retrieval_policy=retrieval_policy,
-                k=k,
+                retrieval_policy=configuration.retrieval_policy,
+                k=configuration.k,
             )
         except DeduplicationError as exc:
             logger.exception(
@@ -545,14 +326,12 @@ class DeduplicationEvaluationRunner:
 
     @staticmethod
     def _invalid_result(
-        *,
         run_id: UUID,
         query_id: str | None,
         line_number: int,
         code: Literal["invalid_json", "invalid_record"],
         message: str,
     ) -> EvaluationRecordResult:
-        """Build one input failure envelope without invoking the assessor."""
         return EvaluationRecordResult(
             run_id=run_id,
             query_id=query_id,
@@ -561,16 +340,53 @@ class DeduplicationEvaluationRunner:
             error=EvaluationRecordError(code=code, message=message),
         )
 
-    @classmethod
-    def _build_assessment_inputs(
-        cls, record: EvaluationInputRecord
+    @staticmethod
+    def _pair_results(result: EvaluationRecordResult) -> list[EvaluationPairResult]:
+        if result.assessment is None:
+            return []
+        return [
+            EvaluationPairResult(
+                run_id=result.run_id,
+                query_id=cast(str, result.query_id),
+                line_number=result.line_number,
+                incoming_reference_id=cast(UUID, result.incoming_reference_id),
+                candidate_reference_id=scored.candidate.reference_id,
+                retrieval_rank=scored.candidate.rank,
+                retrieval_routes=scored.candidate.routes,
+                pair_result=scored.pair_result,
+                threshold=result.assessment.deduper.threshold,
+                clears_threshold=scored.clears_threshold,
+            )
+            for scored in result.assessment.scored_candidates
+        ]
+
+    @staticmethod
+    def _assessment_inputs(
+        record: EvaluationInputRecord,
     ) -> tuple[destiny_sdk.references.Reference, CandidateSelectionInput]:
-        """Build the frozen scorer input and independently controlled query."""
         reference_id = uuid7()
         identifiers = [
-            cls._parse_identifier(identifier) for identifier in record.input_identifiers
+            destiny_sdk.identifiers.ExternalIdentifierAdapter.validate_python(
+                destiny_sdk.identifiers.IdentifierLookup.parse(value).model_dump()
+            )
+            for value in record.input_identifiers
         ]
-        authorship = cls._build_authorship(record.input_reference.authors)
+        last_author = len(record.input_reference.authors) - 1
+        authorship = [
+            destiny_sdk.enhancements.Authorship(
+                display_name=name,
+                position=(
+                    destiny_sdk.enhancements.AuthorPosition.FIRST
+                    if index == 0
+                    else (
+                        destiny_sdk.enhancements.AuthorPosition.LAST
+                        if index == last_author
+                        else destiny_sdk.enhancements.AuthorPosition.MIDDLE
+                    )
+                ),
+            )
+            for index, name in enumerate(record.input_reference.authors)
+        ]
         incoming = destiny_sdk.references.Reference(
             id=reference_id,
             identifiers=identifiers,
@@ -579,29 +395,23 @@ class DeduplicationEvaluationRunner:
                     reference_id=reference_id,
                     source=record.dataset_version,
                     visibility=destiny_sdk.visibility.Visibility.PUBLIC,
-                    content=(
-                        destiny_sdk.enhancements.BibliographicMetadataEnhancement(
-                            title=record.input_reference.title,
-                            authorship=authorship,
-                            publication_year=record.input_reference.year,
-                        )
+                    content=destiny_sdk.enhancements.BibliographicMetadataEnhancement(
+                        title=record.input_reference.title,
+                        authorship=authorship,
+                        publication_year=record.input_reference.year,
                     ),
                 )
             ],
-        )
-        query_identifiers = (
-            [
-                CandidateIdentifier.from_specific(identifier)
-                for identifier in identifiers
-            ]
-            if "identifier" in record.route_applicability
-            else []
         )
         selection_input = CandidateSelectionInput(
             title=record.input_reference.title,
             authors=record.input_reference.authors,
             publication_year=record.input_reference.year,
-            identifiers=query_identifiers,
+            identifiers=(
+                [CandidateIdentifier.from_specific(item) for item in identifiers]
+                if "identifier" in record.route_applicability
+                else []
+            ),
             excluded_reference_id=(
                 record.excluded_reference_ids[0]
                 if record.excluded_reference_ids
@@ -611,33 +421,80 @@ class DeduplicationEvaluationRunner:
         return incoming, selection_input
 
     @staticmethod
-    def _parse_identifier(
-        value: str,
-    ) -> destiny_sdk.identifiers.ExternalIdentifier:
-        """Parse one dataset identifier through the SDK's import identifier types."""
-        lookup = destiny_sdk.identifiers.IdentifierLookup.parse(value)
-        return destiny_sdk.identifiers.ExternalIdentifierAdapter.validate_python(
-            lookup.model_dump()
+    def _jsonl(rows: Sequence[BaseModel]) -> bytes:
+        return "".join(f"{row.model_dump_json()}\n" for row in rows).encode()
+
+    @staticmethod
+    async def _upload(
+        repository: BlobRepository,
+        path: str,
+        filename: str,
+        content: bytes,
+    ) -> BlobStorageFile:
+        return await repository.upload_file_to_blob_storage(
+            content=BytesIO(content),
+            path=path,
+            filename=filename,
+            content_type=(
+                "text/markdown"
+                if filename.endswith(".md")
+                else "application/jsonl"
+                if filename.endswith(".jsonl")
+                else "application/json"
+            ),
         )
 
     @staticmethod
-    def _build_authorship(
-        authors: Sequence[str],
-    ) -> list[destiny_sdk.enhancements.Authorship]:
-        """Convert ordered display names to the SDK bibliographic shape."""
-        last_index = len(authors) - 1
-        return [
-            destiny_sdk.enhancements.Authorship(
-                display_name=display_name,
-                position=(
-                    destiny_sdk.enhancements.AuthorPosition.FIRST
-                    if index == 0
-                    else (
-                        destiny_sdk.enhancements.AuthorPosition.LAST
-                        if index == last_index
-                        else destiny_sdk.enhancements.AuthorPosition.MIDDLE
-                    )
-                ),
-            )
-            for index, display_name in enumerate(authors)
-        ]
+    def _artifact(
+        file: BlobStorageFile, content: bytes, schema_version: str
+    ) -> dict[str, str | int]:
+        return {
+            "uri": file.to_uri(),
+            "schema_version": schema_version,
+            "byte_size": len(content),
+            "sha256": hashlib.sha256(content).hexdigest(),
+        }
+
+    @staticmethod
+    def _summary(
+        *,
+        run_id: UUID,
+        input_file: BlobStorageFile,
+        input_bytes: bytes,
+        records: Sequence[EvaluationRecordResult],
+        pairs: Sequence[EvaluationPairResult],
+    ) -> str:
+        statuses = Counter(result.status for result in records)
+        outcomes = Counter(
+            result.assessment.outcome
+            for result in records
+            if result.assessment is not None
+        )
+        clears = sum(pair.clears_threshold is True for pair in pairs)
+        below = sum(pair.clears_threshold is False for pair in pairs)
+        unscorable = sum(pair.clears_threshold is None for pair in pairs)
+        return (
+            "# Deduplication evaluation summary\n\n"
+            f"Run ID: `{run_id}`\n\n"
+            f"Input: `{input_file.to_uri()}`\n\n"
+            f"Input bytes: {len(input_bytes)}\n\n"
+            f"Input SHA-256: `{hashlib.sha256(input_bytes).hexdigest()}`\n\n"
+            f"Records: {len(records)}\n\n"
+            f"Assessed records: {statuses[EvaluationRecordStatus.ASSESSED]}\n\n"
+            "Invalid input records: "
+            f"{statuses[EvaluationRecordStatus.INPUT_INVALID]}\n\n"
+            "Evaluation-failed records: "
+            f"{statuses[EvaluationRecordStatus.EVALUATION_FAILED]}\n\n"
+            f"Pair rows: {len(pairs)}\n\n"
+            "## Assessment outcomes\n\n"
+            "- `propose_canonical`: "
+            f"{outcomes[DeduplicationAssessmentOutcome.PROPOSE_CANONICAL]}\n"
+            "- `propose_duplicate`: "
+            f"{outcomes[DeduplicationAssessmentOutcome.PROPOSE_DUPLICATE]}\n"
+            "- `no_proposal`: "
+            f"{outcomes[DeduplicationAssessmentOutcome.NO_PROPOSAL]}\n\n"
+            "## Pair evidence\n\n"
+            f"- Clears threshold: {clears}\n"
+            f"- Below threshold: {below}\n"
+            f"- Unscorable: {unscorable}\n"
+        )

--- a/app/domain/references/services/deduplication_evaluation_runner.py
+++ b/app/domain/references/services/deduplication_evaluation_runner.py
@@ -1,8 +1,11 @@
 """Run read-only deduplication assessments over supplied evaluation records."""
 
+import codecs
+import hashlib
 import json
 from collections.abc import AsyncIterable, AsyncIterator, Sequence
 from enum import StrEnum, auto
+from io import BytesIO
 from json import JSONDecodeError
 from typing import Literal, Protocol, cast
 from uuid import UUID, uuid7
@@ -20,6 +23,8 @@ from app.domain.references.models.models import (
     DeduplicationPairResult,
     RetrievalPolicyName,
 )
+from app.persistence.blob.models import BlobStorageFile
+from app.persistence.blob.repository import BlobRepository
 
 logger = get_logger(__name__)
 
@@ -87,6 +92,18 @@ class EvaluationPairResult(BaseModel):
     clears_threshold: bool | None
 
 
+class EvaluationRunArtifacts(BaseModel):
+    """Run-scoped artifacts written before the completion manifest."""
+
+    run_id: UUID
+    input_file: BlobStorageFile
+    input_byte_size: int
+    input_sha256: str
+    record_results_file: BlobStorageFile
+    pair_results_file: BlobStorageFile
+    summary_file: BlobStorageFile
+
+
 class SuppliedReferenceAssessor(Protocol):
     """Read-only supplied-reference assessment operation used by the runner."""
 
@@ -136,6 +153,124 @@ class DeduplicationEvaluationRunner:
             )
             for scored in assessment.scored_candidates
         ]
+
+    async def run(
+        self,
+        *,
+        run_id: UUID,
+        input_file: BlobStorageFile,
+        blob_repository: BlobRepository,
+        retrieval_policy: RetrievalPolicyName,
+        k: int,
+    ) -> EvaluationRunArtifacts:
+        """Evaluate an immutable JSONL blob and write run-scoped artifacts."""
+        hasher = hashlib.sha256()
+        input_byte_size = 0
+        decoder = codecs.getincrementaldecoder("utf-8")()
+
+        async def input_lines() -> AsyncIterator[str]:
+            nonlocal input_byte_size
+            buffer = ""
+            async for chunk in blob_repository.stream_chunks_from_blob_storage(
+                input_file
+            ):
+                hasher.update(chunk)
+                input_byte_size += len(chunk)
+                buffer += decoder.decode(chunk)
+                while "\n" in buffer:
+                    line, buffer = buffer.split("\n", 1)
+                    yield line
+            buffer += decoder.decode(b"", final=True)
+            if buffer:
+                yield buffer
+
+        record_results = [
+            result
+            async for result in self.evaluate_lines(
+                run_id=run_id,
+                lines=input_lines(),
+                retrieval_policy=retrieval_policy,
+                k=k,
+            )
+        ]
+        pair_results = [
+            pair
+            for record_result in record_results
+            for pair in self.project_pair_results(record_result)
+        ]
+        path = f"deduplication_evaluation/{run_id}"
+        record_results_file = await blob_repository.upload_file_to_blob_storage(
+            content=self._jsonl_buffer(record_results),
+            path=path,
+            filename="record-results.jsonl",
+            content_type="application/jsonl",
+        )
+        pair_results_file = await blob_repository.upload_file_to_blob_storage(
+            content=self._jsonl_buffer(pair_results),
+            path=path,
+            filename="pair-results.jsonl",
+            content_type="application/jsonl",
+        )
+        summary_file = await blob_repository.upload_file_to_blob_storage(
+            content=BytesIO(
+                self._summary(
+                    run_id=run_id,
+                    input_details=(
+                        input_file,
+                        input_byte_size,
+                        hasher.hexdigest(),
+                    ),
+                    record_results=record_results,
+                    pair_count=len(pair_results),
+                ).encode()
+            ),
+            path=path,
+            filename="summary.md",
+            content_type="text/markdown",
+        )
+        return EvaluationRunArtifacts(
+            run_id=run_id,
+            input_file=input_file,
+            input_byte_size=input_byte_size,
+            input_sha256=hasher.hexdigest(),
+            record_results_file=record_results_file,
+            pair_results_file=pair_results_file,
+            summary_file=summary_file,
+        )
+
+    @staticmethod
+    def _jsonl_buffer(rows: Sequence[BaseModel]) -> BytesIO:
+        """Serialize model rows as newline-terminated JSONL bytes."""
+        return BytesIO("".join(f"{row.model_dump_json()}\n" for row in rows).encode())
+
+    @staticmethod
+    def _summary(
+        *,
+        run_id: UUID,
+        input_details: tuple[BlobStorageFile, int, str],
+        record_results: Sequence[EvaluationRecordResult],
+        pair_count: int,
+    ) -> str:
+        """Render the human-readable summary written before the manifest."""
+        input_file, input_byte_size, input_sha256 = input_details
+        status_counts = {
+            status: sum(result.status is status for result in record_results)
+            for status in EvaluationRecordStatus
+        }
+        return (
+            "# Deduplication evaluation summary\n\n"
+            f"Run ID: `{run_id}`\n\n"
+            f"Input: `{input_file.to_uri()}`\n\n"
+            f"Input bytes: {input_byte_size}\n\n"
+            f"Input SHA-256: `{input_sha256}`\n\n"
+            f"Records: {len(record_results)}\n\n"
+            f"Assessed records: {status_counts[EvaluationRecordStatus.ASSESSED]}\n\n"
+            "Invalid input records: "
+            f"{status_counts[EvaluationRecordStatus.INPUT_INVALID]}\n\n"
+            "Evaluation-failed records: "
+            f"{status_counts[EvaluationRecordStatus.EVALUATION_FAILED]}\n\n"
+            f"Pair rows: {pair_count}\n"
+        )
 
     async def evaluate_lines(
         self,

--- a/app/domain/references/services/deduplication_evaluation_runner.py
+++ b/app/domain/references/services/deduplication_evaluation_runner.py
@@ -1,7 +1,9 @@
 """Run read-only deduplication assessments over supplied evaluation records."""
 
-from collections.abc import Sequence
+import json
+from collections.abc import AsyncIterable, AsyncIterator, Sequence
 from enum import StrEnum, auto
+from json import JSONDecodeError
 from typing import Literal, Protocol
 from uuid import UUID, uuid7
 
@@ -20,6 +22,7 @@ class EvaluationRecordStatus(StrEnum):
     """Result status for one non-blank evaluation input line."""
 
     ASSESSED = auto()
+    INPUT_INVALID = auto()
 
 
 class EvaluationInputReference(BaseModel):
@@ -37,22 +40,29 @@ class EvaluationInputRecord(BaseModel):
     input_reference: EvaluationInputReference
     input_identifiers: list[str]
     route_applicability: list[Literal["identifier", "fuzzy"]]
-    excluded_reference_ids: list[UUID] = Field(default_factory=list)
+    excluded_reference_ids: list[UUID] = Field(default_factory=list, max_length=1)
     dataset_version: str
 
     model_config = ConfigDict(extra="allow")
+
+
+class EvaluationRecordError(BaseModel):
+    """Stable machine code and reviewable detail for one failed record."""
+
+    code: Literal["invalid_json", "invalid_record"]
+    message: str
 
 
 class EvaluationRecordResult(BaseModel):
     """Assessment or structured failure for one non-blank input line."""
 
     run_id: UUID
-    query_id: str
+    query_id: str | None
     line_number: int
     status: EvaluationRecordStatus
-    incoming_reference_id: UUID
-    assessment: DeduplicationAssessment
-    error: None = None
+    incoming_reference_id: UUID | None = None
+    assessment: DeduplicationAssessment | None = None
+    error: EvaluationRecordError | None = None
 
 
 class SuppliedReferenceAssessor(Protocol):
@@ -77,6 +87,27 @@ class DeduplicationEvaluationRunner:
         """Initialize the runner with its read-only assessment dependency."""
         self._assessor = assessor
 
+    async def evaluate_lines(
+        self,
+        *,
+        run_id: UUID,
+        lines: AsyncIterable[str],
+        retrieval_policy: RetrievalPolicyName,
+        k: int,
+    ) -> AsyncIterator[EvaluationRecordResult]:
+        """Evaluate each non-blank line in physical input order."""
+        line_number = 0
+        async for line in lines:
+            line_number += 1
+            if line.strip():
+                yield await self.evaluate_line(
+                    run_id=run_id,
+                    line=line,
+                    line_number=line_number,
+                    retrieval_policy=retrieval_policy,
+                    k=k,
+                )
+
     async def evaluate_line(
         self,
         *,
@@ -87,8 +118,42 @@ class DeduplicationEvaluationRunner:
         k: int,
     ) -> EvaluationRecordResult:
         """Evaluate one supplied JSONL record."""
-        record = EvaluationInputRecord.model_validate_json(line)
-        incoming, selection_input = self._build_assessment_inputs(record)
+        try:
+            payload = json.loads(line)
+        except JSONDecodeError as exc:
+            return self._invalid_result(
+                run_id=run_id,
+                query_id=None,
+                line_number=line_number,
+                code="invalid_json",
+                message=(
+                    f"Invalid JSON: {exc.msg} at line {exc.lineno}, column {exc.colno}."
+                ),
+            )
+
+        if not isinstance(payload, dict):
+            return self._invalid_result(
+                run_id=run_id,
+                query_id=None,
+                line_number=line_number,
+                code="invalid_record",
+                message="Invalid evaluation record: expected a JSON object.",
+            )
+
+        raw_query_id = payload.get("query_id")
+        query_id = raw_query_id if isinstance(raw_query_id, str) else None
+        try:
+            record = EvaluationInputRecord.model_validate(payload)
+            incoming, selection_input = self._build_assessment_inputs(record)
+        except ValueError as exc:
+            return self._invalid_result(
+                run_id=run_id,
+                query_id=query_id,
+                line_number=line_number,
+                code="invalid_record",
+                message=f"Invalid evaluation record: {exc}",
+            )
+
         assessment = await self._assessor.evaluate_supplied(
             incoming,
             selection_input,
@@ -102,6 +167,24 @@ class DeduplicationEvaluationRunner:
             status=EvaluationRecordStatus.ASSESSED,
             incoming_reference_id=incoming.id,
             assessment=assessment,
+        )
+
+    @staticmethod
+    def _invalid_result(
+        *,
+        run_id: UUID,
+        query_id: str | None,
+        line_number: int,
+        code: Literal["invalid_json", "invalid_record"],
+        message: str,
+    ) -> EvaluationRecordResult:
+        """Build one input failure envelope without invoking the assessor."""
+        return EvaluationRecordResult(
+            run_id=run_id,
+            query_id=query_id,
+            line_number=line_number,
+            status=EvaluationRecordStatus.INPUT_INVALID,
+            error=EvaluationRecordError(code=code, message=message),
         )
 
     @classmethod

--- a/app/domain/references/services/deduplication_evaluation_runner.py
+++ b/app/domain/references/services/deduplication_evaluation_runner.py
@@ -323,6 +323,16 @@ class DeduplicationEvaluationRunner:
                 f"Invalid evaluation record: {exc}",
             )
 
+        if record.dataset_version != configuration.dataset_version:
+            # Checked before the assessment, unlike the run's own values: the input
+            # can contradict the manifest without any retrieval being spent on it.
+            msg = (
+                f"Evaluation run contradicts its configuration at line {line_number}: "
+                f"dataset_version asserted {configuration.dataset_version!r}, "
+                f"record declares {record.dataset_version!r}"
+            )
+            raise EvaluationConfigurationMismatchError(msg)
+
         try:
             assessment = await self._assessor.evaluate_supplied(
                 incoming,

--- a/app/domain/references/services/deduplication_evaluation_runner.py
+++ b/app/domain/references/services/deduplication_evaluation_runner.py
@@ -298,7 +298,7 @@ class DeduplicationEvaluationRunner:
                 None,
                 line_number,
                 "invalid_json",
-                f"Invalid JSON: {exc.msg} at line {exc.lineno}, column {exc.colno}.",
+                f"Invalid JSON: {exc.msg} at column {exc.colno}.",
             )
         if not isinstance(payload, dict):
             return self._invalid_result(

--- a/app/domain/references/services/deduplication_evaluation_runner.py
+++ b/app/domain/references/services/deduplication_evaluation_runner.py
@@ -10,6 +10,8 @@ from uuid import UUID, uuid7
 import destiny_sdk
 from pydantic import BaseModel, ConfigDict, Field
 
+from app.core.exceptions import DeduplicationError
+from app.core.telemetry.logger import get_logger
 from app.domain.references.models.models import (
     CandidateIdentifier,
     CandidateSelectionInput,
@@ -17,12 +19,15 @@ from app.domain.references.models.models import (
     RetrievalPolicyName,
 )
 
+logger = get_logger(__name__)
+
 
 class EvaluationRecordStatus(StrEnum):
     """Result status for one non-blank evaluation input line."""
 
     ASSESSED = auto()
     INPUT_INVALID = auto()
+    EVALUATION_FAILED = auto()
 
 
 class EvaluationInputReference(BaseModel):
@@ -49,7 +54,7 @@ class EvaluationInputRecord(BaseModel):
 class EvaluationRecordError(BaseModel):
     """Stable machine code and reviewable detail for one failed record."""
 
-    code: Literal["invalid_json", "invalid_record"]
+    code: Literal["invalid_json", "invalid_record", "evaluation_failed"]
     message: str
 
 
@@ -76,7 +81,11 @@ class SuppliedReferenceAssessor(Protocol):
         retrieval_policy: RetrievalPolicyName | None = None,
         k: int | None = None,
     ) -> DeduplicationAssessment:
-        """Assess one supplied reference without writing repository state."""
+        """
+        Assess one supplied reference without writing repository state.
+
+        :raises DeduplicationError: If this record cannot be assessed.
+        """
         ...
 
 
@@ -154,12 +163,30 @@ class DeduplicationEvaluationRunner:
                 message=f"Invalid evaluation record: {exc}",
             )
 
-        assessment = await self._assessor.evaluate_supplied(
-            incoming,
-            selection_input,
-            retrieval_policy=retrieval_policy,
-            k=k,
-        )
+        try:
+            assessment = await self._assessor.evaluate_supplied(
+                incoming,
+                selection_input,
+                retrieval_policy=retrieval_policy,
+                k=k,
+            )
+        except DeduplicationError as exc:
+            logger.exception(
+                "Failed to assess supplied evaluation record",
+                query_id=record.query_id,
+                line_number=line_number,
+            )
+            return EvaluationRecordResult(
+                run_id=run_id,
+                query_id=record.query_id,
+                line_number=line_number,
+                status=EvaluationRecordStatus.EVALUATION_FAILED,
+                incoming_reference_id=incoming.id,
+                error=EvaluationRecordError(
+                    code="evaluation_failed",
+                    message=f"Evaluation failed ({type(exc).__name__}): {exc}",
+                ),
+            )
         return EvaluationRecordResult(
             run_id=run_id,
             query_id=record.query_id,

--- a/app/domain/references/services/deduplication_evaluation_runner.py
+++ b/app/domain/references/services/deduplication_evaluation_runner.py
@@ -167,11 +167,17 @@ class DeduplicationEvaluationRunner:
         input_file: BlobStorageFile,
         blob_repository: BlobRepository,
         configuration: EvaluationRunConfiguration,
+        max_input_bytes: int | None = None,
     ) -> EvaluationRunArtifacts:
-        """Evaluate a JSONL blob and write its run-scoped artifact bundle."""
+        """
+        Evaluate a JSONL blob and write its run-scoped artifact bundle.
+
+        :raises BlobSizeExceededError: If the input exceeds ``max_input_bytes``.
+        """
         # Two passes over the immutable input: the manifest digest must cover the
         # exact bytes, which the line reader cannot yield once it has decoded them.
-        streamed = await blob_repository.digest(input_file)
+        # The cap is checked on this first pass, before any record is assessed.
+        streamed = await blob_repository.digest(input_file, max_bytes=max_input_bytes)
         byte_size = streamed.byte_size
         input_sha256 = streamed.sha256_checksum
 

--- a/app/domain/references/services/deduplication_evaluation_runner.py
+++ b/app/domain/references/services/deduplication_evaluation_runner.py
@@ -55,6 +55,7 @@ class EvaluationInputRecord(BaseModel):
     input_reference: EvaluationInputReference
     input_identifiers: list[str]
     route_applicability: list[Literal["identifier", "fuzzy"]]
+    """Analysis label for the row; deliberately does not shape the candidate query."""
     excluded_reference_ids: list[UUID] = Field(default_factory=list, max_length=1)
     dataset_version: str
 
@@ -407,11 +408,9 @@ class DeduplicationEvaluationRunner:
             title=record.input_reference.title,
             authors=record.input_reference.authors,
             publication_year=record.input_reference.year,
-            identifiers=(
-                [CandidateIdentifier.from_specific(item) for item in identifiers]
-                if "identifier" in record.route_applicability
-                else []
-            ),
+            identifiers=[
+                CandidateIdentifier.from_specific(item) for item in identifiers
+            ],
             excluded_reference_id=(
                 record.excluded_reference_ids[0]
                 if record.excluded_reference_ids

--- a/app/domain/references/services/deduplication_evaluation_runner.py
+++ b/app/domain/references/services/deduplication_evaluation_runner.py
@@ -4,6 +4,7 @@ import codecs
 import hashlib
 import json
 from collections.abc import AsyncIterable, AsyncIterator, Sequence
+from datetime import datetime
 from enum import StrEnum, auto
 from io import BytesIO
 from json import JSONDecodeError
@@ -19,7 +20,9 @@ from app.domain.references.models.models import (
     CandidateIdentifier,
     CandidateRoute,
     CandidateSelectionInput,
+    DeduperMetadata,
     DeduplicationAssessment,
+    DeduplicationAssessmentOutcome,
     DeduplicationPairResult,
     RetrievalPolicyName,
 )
@@ -102,6 +105,69 @@ class EvaluationRunArtifacts(BaseModel):
     record_results_file: BlobStorageFile
     pair_results_file: BlobStorageFile
     summary_file: BlobStorageFile
+    manifest_file: BlobStorageFile
+
+
+class EvaluationRunConfiguration(BaseModel):
+    """Fixed dataset, corpus, retrieval and scorer identity for one run."""
+
+    dataset_version: str
+    environment: str
+    corpus_observed_at: datetime
+    elasticsearch_index_version: str
+    code_commit: str
+    retrieval_policy: RetrievalPolicyName
+    k: int = Field(ge=1)
+    deduper: DeduperMetadata
+
+
+class EvaluationManifestInput(BaseModel):
+    """Immutable input identity recorded in the completion manifest."""
+
+    uri: str
+    dataset_version: str
+    byte_size: int
+    sha256: str
+
+
+class EvaluationManifestArtifact(BaseModel):
+    """Identity and digest of one artifact written before the manifest."""
+
+    uri: str
+    schema_version: str
+    byte_size: int
+    sha256: str
+
+
+class EvaluationManifestCounts(BaseModel):
+    """Record and pair totals for one completed evaluation run."""
+
+    record_statuses: dict[EvaluationRecordStatus, int]
+    pair_rows: int
+
+
+class EvaluationManifest(BaseModel):
+    """Completion marker for one immutable evaluation artifact bundle."""
+
+    schema_version: Literal["deduplication-evaluation-manifest/v1"] = (
+        "deduplication-evaluation-manifest/v1"
+    )
+    run_id: UUID
+    input: EvaluationManifestInput
+    configuration: EvaluationRunConfiguration
+    counts: EvaluationManifestCounts
+    artifacts: dict[str, EvaluationManifestArtifact]
+
+
+class _EvaluationSummaryCounts(BaseModel):
+    """Aggregate record decisions and pair evidence for the summary."""
+
+    record_statuses: dict[EvaluationRecordStatus, int]
+    assessment_outcomes: dict[DeduplicationAssessmentOutcome, int]
+    pair_rows: int
+    threshold_clearing_pairs: int
+    below_threshold_pairs: int
+    unscorable_pairs: int
 
 
 class SuppliedReferenceAssessor(Protocol):
@@ -160,10 +226,16 @@ class DeduplicationEvaluationRunner:
         run_id: UUID,
         input_file: BlobStorageFile,
         blob_repository: BlobRepository,
-        retrieval_policy: RetrievalPolicyName,
-        k: int,
+        configuration: EvaluationRunConfiguration,
     ) -> EvaluationRunArtifacts:
         """Evaluate an immutable JSONL blob and write run-scoped artifacts."""
+        path = f"deduplication_evaluation/{run_id}"
+        await blob_repository.upload_file_to_blob_storage(
+            content=BytesIO(),
+            path=path,
+            filename="record-results.jsonl",
+            content_type="application/jsonl",
+        )
         hasher = hashlib.sha256()
         input_byte_size = 0
         decoder = codecs.getincrementaldecoder("utf-8")()
@@ -189,8 +261,8 @@ class DeduplicationEvaluationRunner:
             async for result in self.evaluate_lines(
                 run_id=run_id,
                 lines=input_lines(),
-                retrieval_policy=retrieval_policy,
-                k=k,
+                retrieval_policy=configuration.retrieval_policy,
+                k=configuration.k,
             )
         ]
         pair_results = [
@@ -198,44 +270,82 @@ class DeduplicationEvaluationRunner:
             for record_result in record_results
             for pair in self.project_pair_results(record_result)
         ]
-        path = f"deduplication_evaluation/{run_id}"
+        input_sha256 = hasher.hexdigest()
+        summary_counts = self._summary_counts(record_results, pair_results)
+        record_results_buffer = self._jsonl_buffer(record_results)
+        record_results_bytes = record_results_buffer.getvalue()
         record_results_file = await blob_repository.upload_file_to_blob_storage(
-            content=self._jsonl_buffer(record_results),
+            content=record_results_buffer,
             path=path,
             filename="record-results.jsonl",
             content_type="application/jsonl",
         )
+        pair_results_buffer = self._jsonl_buffer(pair_results)
+        pair_results_bytes = pair_results_buffer.getvalue()
         pair_results_file = await blob_repository.upload_file_to_blob_storage(
-            content=self._jsonl_buffer(pair_results),
+            content=pair_results_buffer,
             path=path,
             filename="pair-results.jsonl",
             content_type="application/jsonl",
         )
+        summary_bytes = self._summary(
+            run_id=run_id,
+            input_details=(input_file, input_byte_size, input_sha256),
+            record_count=len(record_results),
+            counts=summary_counts,
+        ).encode()
         summary_file = await blob_repository.upload_file_to_blob_storage(
-            content=BytesIO(
-                self._summary(
-                    run_id=run_id,
-                    input_details=(
-                        input_file,
-                        input_byte_size,
-                        hasher.hexdigest(),
-                    ),
-                    record_results=record_results,
-                    pair_count=len(pair_results),
-                ).encode()
-            ),
+            content=BytesIO(summary_bytes),
             path=path,
             filename="summary.md",
             content_type="text/markdown",
+        )
+        manifest = EvaluationManifest(
+            run_id=run_id,
+            input=EvaluationManifestInput(
+                uri=input_file.to_uri(),
+                dataset_version=configuration.dataset_version,
+                byte_size=input_byte_size,
+                sha256=input_sha256,
+            ),
+            configuration=configuration,
+            counts=EvaluationManifestCounts(
+                record_statuses=summary_counts.record_statuses,
+                pair_rows=len(pair_results),
+            ),
+            artifacts={
+                "record-results.jsonl": self._artifact_metadata(
+                    record_results_file,
+                    record_results_bytes,
+                    "evaluation-record-result/v1",
+                ),
+                "pair-results.jsonl": self._artifact_metadata(
+                    pair_results_file,
+                    pair_results_bytes,
+                    "evaluation-pair-result/v1",
+                ),
+                "summary.md": self._artifact_metadata(
+                    summary_file,
+                    summary_bytes,
+                    "deduplication-evaluation-summary/v1",
+                ),
+            },
+        )
+        manifest_file = await blob_repository.upload_file_to_blob_storage(
+            content=BytesIO(manifest.model_dump_json(indent=2).encode()),
+            path=path,
+            filename="manifest.json",
+            content_type="application/json",
         )
         return EvaluationRunArtifacts(
             run_id=run_id,
             input_file=input_file,
             input_byte_size=input_byte_size,
-            input_sha256=hasher.hexdigest(),
+            input_sha256=input_sha256,
             record_results_file=record_results_file,
             pair_results_file=pair_results_file,
             summary_file=summary_file,
+            manifest_file=manifest_file,
         )
 
     @staticmethod
@@ -244,32 +354,93 @@ class DeduplicationEvaluationRunner:
         return BytesIO("".join(f"{row.model_dump_json()}\n" for row in rows).encode())
 
     @staticmethod
+    def _artifact_metadata(
+        file: BlobStorageFile,
+        content: bytes,
+        schema_version: str,
+    ) -> EvaluationManifestArtifact:
+        """Describe the exact bytes uploaded for one pre-manifest artifact."""
+        return EvaluationManifestArtifact(
+            uri=file.to_uri(),
+            schema_version=schema_version,
+            byte_size=len(content),
+            sha256=hashlib.sha256(content).hexdigest(),
+        )
+
+    @staticmethod
+    def _status_counts(
+        record_results: Sequence[EvaluationRecordResult],
+    ) -> dict[EvaluationRecordStatus, int]:
+        """Count every stable record status, including zero-count statuses."""
+        return {
+            status: sum(result.status is status for result in record_results)
+            for status in EvaluationRecordStatus
+        }
+
+    @classmethod
+    def _summary_counts(
+        cls,
+        record_results: Sequence[EvaluationRecordResult],
+        pair_results: Sequence[EvaluationPairResult],
+    ) -> _EvaluationSummaryCounts:
+        """Aggregate all stable summary categories, including zero counts."""
+        return _EvaluationSummaryCounts(
+            record_statuses=cls._status_counts(record_results),
+            assessment_outcomes={
+                outcome: sum(
+                    result.assessment is not None
+                    and result.assessment.outcome is outcome
+                    for result in record_results
+                )
+                for outcome in DeduplicationAssessmentOutcome
+            },
+            pair_rows=len(pair_results),
+            threshold_clearing_pairs=sum(
+                pair.clears_threshold is True for pair in pair_results
+            ),
+            below_threshold_pairs=sum(
+                pair.clears_threshold is False for pair in pair_results
+            ),
+            unscorable_pairs=sum(
+                pair.clears_threshold is None for pair in pair_results
+            ),
+        )
+
+    @staticmethod
     def _summary(
         *,
         run_id: UUID,
         input_details: tuple[BlobStorageFile, int, str],
-        record_results: Sequence[EvaluationRecordResult],
-        pair_count: int,
+        record_count: int,
+        counts: _EvaluationSummaryCounts,
     ) -> str:
         """Render the human-readable summary written before the manifest."""
         input_file, input_byte_size, input_sha256 = input_details
-        status_counts = {
-            status: sum(result.status is status for result in record_results)
-            for status in EvaluationRecordStatus
-        }
         return (
             "# Deduplication evaluation summary\n\n"
             f"Run ID: `{run_id}`\n\n"
             f"Input: `{input_file.to_uri()}`\n\n"
             f"Input bytes: {input_byte_size}\n\n"
             f"Input SHA-256: `{input_sha256}`\n\n"
-            f"Records: {len(record_results)}\n\n"
-            f"Assessed records: {status_counts[EvaluationRecordStatus.ASSESSED]}\n\n"
+            f"Records: {record_count}\n\n"
+            "Assessed records: "
+            f"{counts.record_statuses[EvaluationRecordStatus.ASSESSED]}\n\n"
             "Invalid input records: "
-            f"{status_counts[EvaluationRecordStatus.INPUT_INVALID]}\n\n"
+            f"{counts.record_statuses[EvaluationRecordStatus.INPUT_INVALID]}\n\n"
             "Evaluation-failed records: "
-            f"{status_counts[EvaluationRecordStatus.EVALUATION_FAILED]}\n\n"
-            f"Pair rows: {pair_count}\n"
+            f"{counts.record_statuses[EvaluationRecordStatus.EVALUATION_FAILED]}\n\n"
+            f"Pair rows: {counts.pair_rows}\n\n"
+            "## Assessment outcomes\n\n"
+            "- `propose_canonical`: "
+            f"{counts.assessment_outcomes[DeduplicationAssessmentOutcome.PROPOSE_CANONICAL]}\n"
+            "- `propose_duplicate`: "
+            f"{counts.assessment_outcomes[DeduplicationAssessmentOutcome.PROPOSE_DUPLICATE]}\n"
+            "- `no_proposal`: "
+            f"{counts.assessment_outcomes[DeduplicationAssessmentOutcome.NO_PROPOSAL]}\n\n"
+            "## Pair evidence\n\n"
+            f"- Clears threshold: {counts.threshold_clearing_pairs}\n"
+            f"- Below threshold: {counts.below_threshold_pairs}\n"
+            f"- Unscorable: {counts.unscorable_pairs}\n"
         )
 
     async def evaluate_lines(

--- a/app/domain/references/services/deduplication_evaluation_runner.py
+++ b/app/domain/references/services/deduplication_evaluation_runner.py
@@ -182,17 +182,22 @@ class DeduplicationEvaluationRunner:
                     line_number += 1
                     if not line.strip():
                         continue
-                    record_results.append(
-                        await self._evaluate_line(
-                            run_id=run_id,
-                            line=line,
-                            line_number=line_number,
-                            configuration=configuration,
-                        )
+                    result = await self._evaluate_line(
+                        run_id=run_id,
+                        line=line,
+                        line_number=line_number,
+                        configuration=configuration,
                     )
-        except Exception:
-            # A run costs hours of retrieval, so keep whatever completed. Writing no
-            # manifest is what marks the bundle incomplete.
+                    record_results.append(result)
+                    # Checked after the record is kept, so an aborting bundle still
+                    # carries the assessment that disagrees with the configuration.
+                    if result.assessment is not None:
+                        self._verify_configuration(
+                            result.assessment, configuration, line_number
+                        )
+        except BaseException:
+            # A run costs hours of retrieval, so keep whatever completed, a
+            # cancelling shutdown included. No manifest marks the bundle incomplete.
             await self._upload(
                 blob_repository,
                 path,
@@ -342,7 +347,6 @@ class DeduplicationEvaluationRunner:
                     message=f"Evaluation failed ({type(exc).__name__}): {exc}",
                 ),
             )
-        self._verify_configuration(assessment, configuration, line_number)
         return EvaluationRecordResult(
             run_id=run_id,
             query_id=record.query_id,

--- a/app/domain/references/services/deduplication_evaluation_runner.py
+++ b/app/domain/references/services/deduplication_evaluation_runner.py
@@ -165,28 +165,42 @@ class DeduplicationEvaluationRunner:
             digest.update(chunk)
             byte_size += len(chunk)
 
+        path = f"deduplication_evaluation/{run_id}"
         record_results: list[EvaluationRecordResult] = []
         line_number = 0
-        async with blob_repository.stream_file_from_blob_storage(input_file) as lines:
-            async for line in lines:
-                line_number += 1
-                if not line.strip():
-                    continue
-                record_results.append(
-                    await self._evaluate_line(
-                        run_id=run_id,
-                        line=line,
-                        line_number=line_number,
-                        configuration=configuration,
+        try:
+            async with blob_repository.stream_file_from_blob_storage(
+                input_file
+            ) as lines:
+                async for line in lines:
+                    line_number += 1
+                    if not line.strip():
+                        continue
+                    record_results.append(
+                        await self._evaluate_line(
+                            run_id=run_id,
+                            line=line,
+                            line_number=line_number,
+                            configuration=configuration,
+                        )
                     )
-                )
+        except Exception:
+            # A run costs hours of retrieval, so keep whatever completed. Writing no
+            # manifest is what marks the bundle incomplete.
+            await self._upload(
+                blob_repository,
+                path,
+                "record-results.jsonl",
+                self._jsonl(record_results),
+            )
+            raise
+
         pair_results = [
             pair
             for record_result in record_results
             for pair in self._pair_results(record_result)
         ]
         input_sha256 = digest.hexdigest()
-        path = f"deduplication_evaluation/{run_id}"
 
         record_bytes = self._jsonl(record_results)
         record_file = await self._upload(

--- a/app/domain/references/services/deduplication_evaluation_runner.py
+++ b/app/domain/references/services/deduplication_evaluation_runner.py
@@ -27,6 +27,9 @@ from app.domain.references.models.models import (
     DeduplicationAssessment,
     DeduplicationAssessmentOutcome,
     DeduplicationPairResult,
+    Enhancement,
+    LinkedExternalIdentifier,
+    Reference,
     RetrievalPolicyName,
 )
 from app.persistence.blob.models import BlobStorageFile
@@ -130,7 +133,7 @@ class SuppliedReferenceAssessor(Protocol):
 
     async def evaluate_supplied(
         self,
-        incoming: destiny_sdk.references.Reference,
+        incoming: Reference,
         selection_input: CandidateSelectionInput,
         *,
         retrieval_policy: RetrievalPolicyName | None = None,
@@ -426,7 +429,7 @@ class DeduplicationEvaluationRunner:
     @staticmethod
     def _assessment_inputs(
         record: EvaluationInputRecord,
-    ) -> tuple[destiny_sdk.references.Reference, CandidateSelectionInput]:
+    ) -> tuple[Reference, CandidateSelectionInput]:
         reference_id = uuid7()
         identifiers = [
             destiny_sdk.identifiers.ExternalIdentifierAdapter.validate_python(
@@ -450,11 +453,16 @@ class DeduplicationEvaluationRunner:
             )
             for index, name in enumerate(record.input_reference.authors)
         ]
-        incoming = destiny_sdk.references.Reference(
+        incoming = Reference(
             id=reference_id,
-            identifiers=identifiers,
+            identifiers=[
+                LinkedExternalIdentifier(
+                    identifier=identifier, reference_id=reference_id
+                )
+                for identifier in identifiers
+            ],
             enhancements=[
-                destiny_sdk.enhancements.Enhancement(
+                Enhancement(
                     reference_id=reference_id,
                     source=record.dataset_version,
                     visibility=destiny_sdk.visibility.Visibility.PUBLIC,

--- a/app/persistence/blob/models.py
+++ b/app/persistence/blob/models.py
@@ -133,6 +133,17 @@ class BlobStorageFile(BaseModel):
     model_config = ConfigDict(frozen=True)
 
 
+class BlobDigest(BaseModel):
+    """Model to represent the size and checksum of a streamed blob storage file."""
+
+    byte_size: int = Field(
+        description="The size of the streamed file in bytes.",
+    )
+    sha256_checksum: str = Field(
+        description="The SHA256 checksum of the streamed file.",
+    )
+
+
 class BlobCopyResult(BaseModel):
     """Model to represent the result of copying a blob storage file."""
 

--- a/app/persistence/blob/repository.py
+++ b/app/persistence/blob/repository.py
@@ -226,6 +226,15 @@ class BlobRepository:
         client = await self._preload_config(file)
         yield client.stream_file(file)
 
+    async def stream_chunks_from_blob_storage(
+        self,
+        file: BlobStorageFile,
+    ) -> AsyncIterator[bytes]:
+        """Stream a file as raw bytes from Blob Storage."""
+        client = await self._preload_config(file)
+        async for chunk in client.stream_chunks(file):
+            yield chunk
+
     async def get_signed_url(
         self,
         file: BlobStorageFile,

--- a/app/persistence/blob/repository.py
+++ b/app/persistence/blob/repository.py
@@ -30,6 +30,7 @@ from app.persistence.blob.clients.remote import RemoteBlobStorageClient
 from app.persistence.blob.models import (
     BlobContainer,
     BlobCopyResult,
+    BlobDigest,
     BlobSignedUrlType,
     BlobStorageFile,
     BlobStorageLocation,
@@ -114,6 +115,37 @@ _registry = _BlobClientRegistry()
 async def close_blob_clients() -> None:
     """Release every backend client held by the process-wide registry."""
     await _registry.aclose()
+
+
+class _StreamDigest:
+    """Hash and count chunks in passing, so one read serves both."""
+
+    def __init__(self, source: BlobStorageFile, max_bytes: int | None) -> None:
+        self._source = source
+        self._max_bytes = max_bytes
+        self._hasher = hashlib.sha256()
+        self._byte_size = 0
+
+    async def wrap(self, chunks: AsyncIterator[bytes]) -> AsyncIterator[bytes]:
+        """Yield each chunk onward, aborting once ``max_bytes`` is passed."""
+        async for chunk in chunks:
+            self._hasher.update(chunk)
+            self._byte_size += len(chunk)
+            if self._max_bytes is not None and self._byte_size > self._max_bytes:
+                msg = (
+                    f"Source {self._source.to_uri()} exceeds "
+                    f"max_bytes={self._max_bytes} "
+                    f"(streamed at least {self._byte_size} bytes before abort)."
+                )
+                raise BlobSizeExceededError(msg)
+            yield chunk
+
+    def result(self) -> BlobDigest:
+        """Return the size and checksum of everything streamed so far."""
+        return BlobDigest(
+            byte_size=self._byte_size,
+            sha256_checksum=self._hasher.hexdigest(),
+        )
 
 
 class BlobRepository:
@@ -226,14 +258,29 @@ class BlobRepository:
         client = await self._preload_config(file)
         yield client.stream_file(file)
 
-    async def stream_chunks_from_blob_storage(
+    async def digest(
         self,
         file: BlobStorageFile,
-    ) -> AsyncIterator[bytes]:
-        """Stream a file as raw bytes from Blob Storage."""
+        max_bytes: int | None = None,
+    ) -> BlobDigest:
+        """
+        Stream a file to compute its size and sha256, writing nothing.
+
+        :param file: The file to read.
+        :type file: BlobStorageFile
+        :param max_bytes: Optional cap on the total bytes streamed, enforced as
+            in :meth:`copy`. ``None`` disables the check.
+        :type max_bytes: int | None
+        :return: The size and checksum of the file's bytes.
+        :rtype: BlobDigest
+        :raises BlobSizeExceededError: if ``max_bytes`` is set and the file
+            yields more bytes than allowed.
+        """
         client = await self._preload_config(file)
-        async for chunk in client.stream_chunks(file):
-            yield chunk
+        digest = _StreamDigest(file, max_bytes)
+        async for _ in digest.wrap(client.stream_chunks(file)):
+            pass
+        return digest.result()
 
     async def get_signed_url(
         self,
@@ -301,29 +348,18 @@ class BlobRepository:
         src_client = await self._preload_config(source)
         dest_client = await self._preload_config(destination)
 
-        hasher = hashlib.sha256()
-        size = 0
-
-        async def hashed_chunks() -> AsyncIterator[bytes]:
-            nonlocal size
-            async for chunk in src_client.stream_chunks(source):
-                hasher.update(chunk)
-                size += len(chunk)
-                if max_bytes is not None and size > max_bytes:
-                    msg = (
-                        f"Source {source.to_uri()} exceeds max_bytes={max_bytes} "
-                        f"(streamed at least {size} bytes before abort)."
-                    )
-                    raise BlobSizeExceededError(msg)
-                yield chunk
+        digest = _StreamDigest(source, max_bytes)
 
         await dest_client.upload_file(
-            hashed_chunks(), destination, content_type=content_type
+            digest.wrap(src_client.stream_chunks(source)),
+            destination,
+            content_type=content_type,
         )
+        streamed = digest.result()
 
         return BlobCopyResult(
             source=source,
             destination=destination,
-            byte_size=size,
-            sha256_checksum=hasher.hexdigest(),
+            byte_size=streamed.byte_size,
+            sha256_checksum=streamed.sha256_checksum,
         )

--- a/app/run_evaluation.py
+++ b/app/run_evaluation.py
@@ -1,0 +1,297 @@
+"""
+Drive a read-only deduplication evaluation over a supplied JSONL blob.
+
+Connects to the environment's existing Postgres, Elasticsearch and blob storage,
+assesses every record of the input against the live corpus, and writes the run's
+artifact bundle back to blob storage. Postgres refuses a write from the run's
+transactions; on Elasticsearch the guarantee is only that the assembled services
+take read paths, so it is weaker.
+
+```
+uv run python -m app.run_evaluation \
+    --input minio://operations/retrieval-query-set/v1/queries.jsonl \
+    --dataset-version retrieval-query-set/v1 \
+    --corpus-observed-at 2026-08-17T00:00:00+00:00 \
+    --code-commit "$(git rev-parse HEAD)" \
+    --pair-scorer my_package.my_module:build_scorer
+```
+
+Every run mints its own identifier, so a bundle is never overwritten. The run
+holds no session between records, so it can be interrupted: the runner uploads
+the record results it already has before the interrupt propagates.
+"""
+
+import argparse
+import asyncio
+import datetime
+import importlib
+from uuid import uuid7
+
+from sqlalchemy import text
+
+from app.core.config import get_settings
+from app.core.telemetry.logger import get_logger, logger_configurer
+from app.core.telemetry.otel import configure_otel
+from app.domain.references.models.models import (
+    CandidateSelectionInput,
+    DeduplicationAssessment,
+    Reference,
+    RetrievalPolicyName,
+)
+from app.domain.references.services.anti_corruption_service import (
+    ReferenceAntiCorruptionService,
+)
+from app.domain.references.services.deduplication_assessment_service import (
+    DeduplicationAssessmentService,
+    PairScorer,
+)
+from app.domain.references.services.deduplication_evaluation_runner import (
+    DeduplicationEvaluationRunner,
+    EvaluationRunArtifacts,
+    EvaluationRunConfiguration,
+)
+from app.domain.references.services.deduplication_service import DeduplicationService
+from app.persistence.blob.models import BlobStorageFile
+from app.persistence.blob.repository import BlobRepository, close_blob_clients
+from app.persistence.es.client import es_manager
+from app.persistence.es.uow import AsyncESUnitOfWork
+from app.persistence.sql.session import db_manager
+from app.persistence.sql.uow import AsyncSqlUnitOfWork
+
+settings = get_settings()
+logger = get_logger(__name__)
+
+logger_configurer.configure_console_logger(
+    log_level=settings.log_level, rich_rendering=settings.running_locally
+)
+
+if settings.otel_config and settings.otel_enabled:
+    configure_otel(
+        settings.otel_config,
+        settings.app_name,
+        settings.toml.app_version,
+        settings.env,
+        settings.trace_repr,
+    )
+
+# Distinguishes the run in pg_stat_activity from the API and worker traffic it
+# shares a database with.
+APPLICATION_NAME = "dedup-evaluation"
+
+
+class EvaluationAssessor:
+    """Assess one supplied record per read-only session against the live corpus."""
+
+    def __init__(
+        self, *, blob_repository: BlobRepository, pair_scorer: PairScorer
+    ) -> None:
+        """Keep the dependencies shared by every record."""
+        self._blob_repository = blob_repository
+        self._pair_scorer = pair_scorer
+
+    async def evaluate_supplied(
+        self,
+        incoming: Reference,
+        selection_input: CandidateSelectionInput,
+        *,
+        retrieval_policy: RetrievalPolicyName | None = None,
+        k: int | None = None,
+    ) -> DeduplicationAssessment:
+        """Assess one record, holding a session no longer than that record."""
+        async with db_manager.session() as session, es_manager.client() as client:
+            sql_uow = AsyncSqlUnitOfWork(session=session)
+            es_uow = AsyncESUnitOfWork(client=client)
+            async with sql_uow, es_uow:
+                # Postgres refuses a write from this transaction, so read-only is
+                # enforced rather than left to the services this assembles.
+                await session.execute(text("SET TRANSACTION READ ONLY"))
+                deduplication_service = DeduplicationService(
+                    ReferenceAntiCorruptionService(
+                        sign_url=self._blob_repository.get_signed_url
+                    ),
+                    sql_uow,
+                    es_uow,
+                )
+                assessment_service = DeduplicationAssessmentService(
+                    candidate_selector=deduplication_service.get_deduplication_candidates,
+                    reference_reader=sql_uow.references,
+                    pair_scorer=self._pair_scorer,
+                )
+                return await assessment_service.evaluate_supplied(
+                    incoming,
+                    selection_input,
+                    retrieval_policy=retrieval_policy,
+                    k=k,
+                )
+
+
+def resolve_pair_scorer(factory_path: str) -> PairScorer:
+    """
+    Build the scorer named as ``module:factory``.
+
+    :param factory_path: Import path of a zero-argument scorer factory.
+    :type factory_path: str
+    :return: The constructed pair scorer.
+    :rtype: PairScorer
+    :raises RuntimeError: If the path does not separate a module from a factory.
+    """
+    module_path, separator, factory_name = factory_path.rpartition(":")
+    if not separator or not module_path or not factory_name:
+        # Without the separator the remainder imports as nonsense rather than
+        # reporting the argument that was wrong.
+        msg = f"Pair scorer {factory_path!r} must be given as 'module:factory'."
+        raise RuntimeError(msg)
+
+    factory = getattr(importlib.import_module(module_path), factory_name)
+    return factory()
+
+
+async def current_index_version() -> str:
+    """
+    Read the index the alias resolves to now.
+
+    Stamped from the cluster rather than asserted, so the manifest names the index
+    the run actually searched.
+
+    :return: The physical reference index name.
+    :rtype: str
+    :raises RuntimeError: If the alias resolves to no index.
+    """
+    async with es_manager.client() as client:
+        es_uow = AsyncESUnitOfWork(client=client)
+        async with es_uow:
+            index_version = await es_uow.references.get_current_index_name()
+    if index_version is None:
+        msg = "The reference index alias resolves to no index, so nothing to stamp."
+        raise RuntimeError(msg)
+    return index_version
+
+
+async def run_evaluation(args: argparse.Namespace) -> EvaluationRunArtifacts:
+    """Assess every record of the input blob and write the run's bundle."""
+    # Minted here rather than accepted from the operator: the runner restarts at
+    # line one, so reusing an id overwrites a finished bundle instead of resuming.
+    run_id = uuid7()
+    pair_scorer = resolve_pair_scorer(args.pair_scorer)
+    blob_repository = BlobRepository()
+
+    try:
+        # Inside the cleanup scope, so a failure part-way through initialisation
+        # still releases whatever was opened before it.
+        logger.info("Connecting to %s infrastructure", settings.env.value)
+        db_manager.init(settings.db_config, APPLICATION_NAME)
+        await es_manager.init(settings.es_config)
+
+        configuration = EvaluationRunConfiguration(
+            dataset_version=args.dataset_version,
+            environment=settings.env.value,
+            corpus_observed_at=args.corpus_observed_at,
+            elasticsearch_index_version=await current_index_version(),
+            code_commit=args.code_commit,
+            retrieval_policy=args.retrieval_policy,
+            k=args.k,
+            deduper=pair_scorer.metadata,
+        )
+        logger.info(
+            "Starting evaluation run %s over %s",
+            run_id,
+            args.input,
+            run_configuration=configuration.model_dump(mode="json"),
+        )
+        runner = DeduplicationEvaluationRunner(
+            assessor=EvaluationAssessor(
+                blob_repository=blob_repository, pair_scorer=pair_scorer
+            )
+        )
+        artifacts = await runner.run(
+            run_id=run_id,
+            input_file=BlobStorageFile.from_uri(args.input),
+            blob_repository=blob_repository,
+            configuration=configuration,
+            max_input_bytes=settings.evaluation_input_max_byte_size,
+        )
+    finally:
+        logger.info("Releasing infrastructure clients")
+        await db_manager.close()
+        await es_manager.close()
+        await close_blob_clients()
+
+    logger.info(
+        "Evaluation run %s complete: %s",
+        artifacts.run_id,
+        artifacts.manifest_file.to_uri(),
+    )
+    return artifacts
+
+
+def aware_datetime(value: str) -> datetime.datetime:
+    """
+    Parse an ISO-8601 timestamp, rejecting one with no offset.
+
+    A naive corpus observation cannot be compared across the runs and environments
+    the manifest exists to compare.
+    """
+    parsed = datetime.datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        msg = f"Timestamp {value!r} needs a UTC offset."
+        raise argparse.ArgumentTypeError(msg)
+    return parsed
+
+
+def argument_parser() -> argparse.ArgumentParser:
+    """Create the argument parser for an evaluation run."""
+    parser = argparse.ArgumentParser(
+        description="Run a read-only deduplication evaluation over a JSONL blob."
+    )
+    parser.add_argument(
+        "-i",
+        "--input",
+        type=str,
+        required=True,
+        help="Blob URI of the input JSONL, e.g. minio://operations/set/queries.jsonl.",
+    )
+    parser.add_argument(
+        "-d",
+        "--dataset-version",
+        type=str,
+        required=True,
+        help="Dataset version every input record must declare.",
+    )
+    parser.add_argument(
+        "-c",
+        "--corpus-observed-at",
+        type=aware_datetime,
+        required=True,
+        help="ISO-8601 timestamp, with offset, of the corpus state being measured.",
+    )
+    parser.add_argument(
+        "--code-commit",
+        type=str,
+        required=True,
+        help='Commit the run executed, e.g. "$(git rev-parse HEAD)".',
+    )
+    parser.add_argument(
+        "--pair-scorer",
+        type=str,
+        required=True,
+        help="Import path of a zero-argument scorer factory, as 'module:factory'.",
+    )
+    parser.add_argument(
+        "-p",
+        "--retrieval-policy",
+        type=RetrievalPolicyName,
+        choices=list(RetrievalPolicyName),
+        default=settings.dedup_scoring.default_retrieval_policy,
+        help="Retrieval policy to evaluate. Defaults to the environment's policy.",
+    )
+    parser.add_argument(
+        "-k",
+        type=int,
+        default=settings.dedup_scoring.candidate_k,
+        help="Candidates to retrieve per record. Defaults to the environment's k.",
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    asyncio.run(run_evaluation(argument_parser().parse_args()))

--- a/tests/integration/test_read_only_evaluation_session.py
+++ b/tests/integration/test_read_only_evaluation_session.py
@@ -1,0 +1,33 @@
+"""Confirm the evaluation driver's read-only guard reaches the real transaction."""
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError, InternalError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tests.persistence_models import SimpleSQLModel
+
+
+async def test_read_only_transaction_refuses_a_write(session: AsyncSession) -> None:
+    """
+    A write fails once the transaction is read-only.
+
+    SQLAlchemy opens the transaction on this first statement, so the guard has to
+    land inside the transaction the ORM then reuses, not a discarded one.
+    """
+    await session.execute(text("SET TRANSACTION READ ONLY"))
+
+    session.add(SimpleSQLModel(title="written"))
+    with pytest.raises((DBAPIError, InternalError), match="read-only transaction"):
+        await session.flush()
+
+
+async def test_reads_still_work_in_a_read_only_transaction(
+    session: AsyncSession,
+) -> None:
+    """The guard must not cost the driver the queries it exists to run."""
+    await session.execute(text("SET TRANSACTION READ ONLY"))
+
+    result = await session.execute(text("SELECT count(*) FROM reference"))
+
+    assert result.scalar() == 0

--- a/tests/unit/domain/references/deduplication/test_assessment.py
+++ b/tests/unit/domain/references/deduplication/test_assessment.py
@@ -32,6 +32,7 @@ from app.domain.references.models.models import (
     RetrievalPolicyName,
 )
 from app.domain.references.models.projections import DeduplicationPaperProjection
+from app.domain.references.repository import ReferenceSQLRepository
 from app.domain.references.services.anti_corruption_service import (
     ReferenceAntiCorruptionService,
 )
@@ -857,3 +858,14 @@ async def test_evaluate_supplied_runs_real_candidate_union_without_side_effects(
         method.assert_not_awaited()
     sql_uow.commit.assert_not_awaited()
     es_uow.commit.assert_not_awaited()
+
+
+# This test annotated with -> None so mypy checks the body. Unannotated bodies
+# are skipped, so without it the assignment is never checked and proves nothing.
+def test_reference_repository_satisfies_the_reader_protocol() -> None:
+    """The one real implementation must be assignable to the protocol it implements."""
+    repository = ReferenceSQLRepository(MagicMock())
+
+    reader: ReferenceReader = repository
+
+    assert reader.get_hydrated == repository.get_hydrated

--- a/tests/unit/domain/references/deduplication/test_assessment.py
+++ b/tests/unit/domain/references/deduplication/test_assessment.py
@@ -901,4 +901,6 @@ def test_reference_repository_satisfies_the_reader_protocol() -> None:
 
     reader: ReferenceReader = repository
 
-    assert reader.get_hydrated == repository.get_hydrated
+    # Nothing meaningful to assert at runtime: the annotated assignment above is
+    # the check, and mypy is what performs it.
+    assert reader is repository

--- a/tests/unit/domain/references/deduplication/test_assessment.py
+++ b/tests/unit/domain/references/deduplication/test_assessment.py
@@ -528,6 +528,39 @@ async def test_evaluate_supplied_fails_when_incoming_cannot_project():
 
 
 @pytest.mark.asyncio
+async def test_evaluate_supplied_reports_a_scorer_failure_as_a_deduplication_error():
+    """The Deduper is third-party: one pair it cannot score is one failed record."""
+    incoming = _supplied_reference()
+    candidate = _reference()
+
+    class _RaisingScorer:
+        metadata = DeduperMetadata(
+            package_version="fake-1",
+            configuration_hash="test-config",
+            threshold=0.85,
+        )
+
+        async def score_pair(self, incoming, candidate):
+            msg = "scorer exploded"
+            raise RuntimeError(msg)
+
+    reader = MagicMock(spec=ReferenceReader)
+    reader.get_hydrated = AsyncMock(return_value=[candidate])
+    service = DeduplicationAssessmentService(
+        candidate_selector=AsyncMock(
+            return_value=_selection(
+                Candidate(reference_id=candidate.id, rank=1, routes=[])
+            )
+        ),
+        reference_reader=reader,
+        pair_scorer=_RaisingScorer(),
+    )
+
+    with pytest.raises(DeduplicationError, match="scorer exploded"):
+        await service.evaluate_supplied(incoming, _supplied_input(incoming))
+
+
+@pytest.mark.asyncio
 async def test_evaluate_empty_searchable_union_proposes_canonical():
     incoming = _reference()
     service, _, reader, pair_scorer = _build_service(

--- a/tests/unit/domain/references/deduplication/test_evaluation_runner.py
+++ b/tests/unit/domain/references/deduplication/test_evaluation_runner.py
@@ -3,19 +3,22 @@
 import asyncio
 import hashlib
 import json
+from datetime import UTC, datetime
 from io import BytesIO
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock
-from uuid import uuid7
+from uuid import UUID, uuid7
 
 import pytest
 
-from app.core.exceptions import DeduplicationError
+from app.core.exceptions import BlobStorageError, DeduplicationError
 from app.domain.references.models.models import (
     Candidate,
     CandidateElasticsearchRoute,
     CandidateIdentifier,
     CandidateIdentifierRoute,
     CandidateSelectionDiagnostics,
+    CandidateSelectionInput,
     CandidateSelectionResult,
     DeduperMetadata,
     DeduplicationAssessment,
@@ -30,17 +33,23 @@ from app.domain.references.models.models import (
 )
 from app.domain.references.services.deduplication_evaluation_runner import (
     DeduplicationEvaluationRunner,
+    EvaluationPairResult,
+    EvaluationRecordResult,
     EvaluationRecordStatus,
+    EvaluationRunConfiguration,
 )
 from app.persistence.blob.models import BlobStorageFile, BlobStorageLocation
 from app.persistence.blob.repository import BlobRepository
 
 
-def _assessment(incoming_reference_id):
+def _assessment(
+    incoming_reference_id,
+    retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
+):
     return DeduplicationAssessment(
         incoming_reference_id=incoming_reference_id,
         candidate_selection=CandidateSelectionResult(
-            retrieval_policy=(RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1),
+            retrieval_policy=retrieval_policy,
             index_version="reference_v3",
             k_requested=10,
             input_searchability=InputSearchability(
@@ -56,6 +65,78 @@ def _assessment(incoming_reference_id):
         ),
         outcome=DeduplicationAssessmentOutcome.PROPOSE_CANONICAL,
     )
+
+
+def _assessment_with_pair_evidence(
+    incoming_reference_id,
+    retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
+):
+    assessment = _assessment(incoming_reference_id, retrieval_policy)
+    candidates = [
+        ScoredDeduplicationCandidate(
+            candidate=Candidate(
+                reference_id=uuid7(),
+                rank=rank,
+                routes=[
+                    CandidateElasticsearchRoute(
+                        policy=retrieval_policy.value,
+                        rank=rank,
+                        score=score,
+                    )
+                ],
+            ),
+            pair_result=(
+                DeduplicationPairResult(probability=probability)
+                if probability is not None
+                else DeduplicationPairResult(unscorable_reason="missing title")
+            ),
+            clears_threshold=clears_threshold,
+        )
+        for rank, score, probability, clears_threshold in (
+            (1, 9.1, 0.91, True),
+            (2, 5.1, 0.51, False),
+            (3, 2.1, None, None),
+        )
+    ]
+    return assessment.model_copy(
+        update={
+            "candidate_selection": assessment.candidate_selection.model_copy(
+                update={"candidates": [item.candidate for item in candidates]}
+            ),
+            "scored_candidates": candidates,
+            "outcome": DeduplicationAssessmentOutcome.NO_PROPOSAL,
+            "threshold_clearing_candidate_ids": [candidates[0].candidate.reference_id],
+            "unscorable_candidate_ids": [candidates[2].candidate.reference_id],
+        }
+    )
+
+
+def _run_configuration() -> EvaluationRunConfiguration:
+    return EvaluationRunConfiguration(
+        dataset_version="retrieval-query-set/v1",
+        environment="test",
+        corpus_observed_at=datetime(2026, 8, 10, 3, 30, tzinfo=UTC),
+        elasticsearch_index_version="reference_v3",
+        code_commit="test-commit",
+        retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
+        k=10,
+        deduper=DeduperMetadata(
+            package_version="fake-1",
+            configuration_hash="fake-config",
+            threshold=0.85,
+        ),
+    )
+
+
+def _expected_artifact(
+    file: BlobStorageFile, content: bytes, schema_version: str
+) -> dict[str, object]:
+    return {
+        "uri": file.to_uri(),
+        "schema_version": schema_version,
+        "byte_size": len(content),
+        "sha256": hashlib.sha256(content).hexdigest(),
+    }
 
 
 def _valid_line(query_id: str, **updates: object) -> str:
@@ -82,7 +163,10 @@ async def test_evaluate_line_assesses_yearless_supplied_record_with_correlation(
     held_reference_id = uuid7()
     assessor = AsyncMock()
     assessor.evaluate_supplied.side_effect = lambda incoming, _selection, **_kwargs: (
-        _assessment(incoming.id)
+        _assessment(
+            incoming.id,
+            RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+        )
     )
     runner = DeduplicationEvaluationRunner(assessor=assessor)
     line = f"""{{
@@ -107,39 +191,60 @@ async def test_evaluate_line_assesses_yearless_supplied_record_with_correlation(
         k=10,
     )
 
-    assert result.run_id == run_id
-    assert result.query_id == "oa-km:W1:W2"
-    assert result.line_number == 42
-    assert result.status == EvaluationRecordStatus.ASSESSED
     assert result.incoming_reference_id is not None
-    assert result.incoming_reference_id.version == 7
-    assert result.assessment is not None
-    assert result.assessment == _assessment(result.incoming_reference_id)
-    assert result.error is None
+    assert result == EvaluationRecordResult(
+        run_id=run_id,
+        query_id="oa-km:W1:W2",
+        line_number=42,
+        status=EvaluationRecordStatus.ASSESSED,
+        incoming_reference_id=result.incoming_reference_id,
+        assessment=_assessment(
+            result.incoming_reference_id,
+            RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+        ),
+    )
     incoming, selection = assessor.evaluate_supplied.await_args.args
-    assert incoming.id == result.incoming_reference_id
-    assert incoming.visibility == "public"
-    assert incoming.identifiers[0].identifier_type == ExternalIdentifierType.OPEN_ALEX
-    assert incoming.identifiers[0].identifier == "W1"
-    assert incoming.enhancements[0].source == "retrieval-query-set/v1"
     biblio = incoming.enhancements[0].content
-    assert biblio.title == "A yearless study"
-    assert biblio.publication_year is None
-    assert [author.display_name for author in biblio.authorship] == [
-        "First Author",
-        "Middle Author",
-        "Last Author",
-    ]
-    assert [author.position for author in biblio.authorship] == [
-        "first",
-        "middle",
-        "last",
-    ]
-    assert selection.title == "A yearless study"
-    assert selection.authors == ["First Author", "Middle Author", "Last Author"]
-    assert selection.publication_year is None
-    assert selection.excluded_reference_id == held_reference_id
-    assert selection.identifiers[0].identifier_type == ExternalIdentifierType.OPEN_ALEX
+    assert {
+        "id": incoming.id,
+        "id_version": incoming.id.version,
+        "visibility": incoming.visibility,
+        "identifier": (
+            incoming.identifiers[0].identifier_type,
+            incoming.identifiers[0].identifier,
+        ),
+        "enhancement_source": incoming.enhancements[0].source,
+        "title": biblio.title,
+        "publication_year": biblio.publication_year,
+        "authors": [
+            (author.display_name, author.position) for author in biblio.authorship
+        ],
+    } == {
+        "id": result.incoming_reference_id,
+        "id_version": 7,
+        "visibility": "public",
+        "identifier": (ExternalIdentifierType.OPEN_ALEX, "W1"),
+        "enhancement_source": "retrieval-query-set/v1",
+        "title": "A yearless study",
+        "publication_year": None,
+        "authors": [
+            ("First Author", "first"),
+            ("Middle Author", "middle"),
+            ("Last Author", "last"),
+        ],
+    }
+    assert selection == CandidateSelectionInput(
+        title="A yearless study",
+        authors=["First Author", "Middle Author", "Last Author"],
+        publication_year=None,
+        identifiers=[
+            CandidateIdentifier(
+                identifier="W1",
+                identifier_type=ExternalIdentifierType.OPEN_ALEX,
+            )
+        ],
+        excluded_reference_id=held_reference_id,
+    )
     assert assessor.evaluate_supplied.await_args.kwargs == {
         "retrieval_policy": RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
         "k": 10,
@@ -170,7 +275,7 @@ async def test_evaluate_line_withholds_identifiers_from_fuzzy_only_query():
             "dataset_version": "retrieval-query-set/v1"
         }""",
         line_number=1,
-        retrieval_policy=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+        retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
         k=10,
     )
 
@@ -201,7 +306,7 @@ async def test_evaluate_lines_records_invalid_json_and_continues():
         async for result in runner.evaluate_lines(
             run_id=run_id,
             lines=lines,
-            retrieval_policy=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+            retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
             k=10,
         )
     ]
@@ -236,7 +341,7 @@ async def test_evaluate_line_rejects_multiple_self_exclusions():
             excluded_reference_ids=[str(uuid7()), str(uuid7())],
         ),
         line_number=7,
-        retrieval_policy=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+        retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
         k=10,
     )
 
@@ -258,7 +363,7 @@ async def test_evaluate_line_records_identifier_conversion_failure():
         run_id=uuid7(),
         line=_valid_line("bad-identifier", input_identifiers=["unknown:value"]),
         line_number=8,
-        retrieval_policy=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+        retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
         k=10,
     )
 
@@ -287,7 +392,7 @@ async def test_evaluate_line_records_uncorrelatable_schema_failure(line):
         run_id=uuid7(),
         line=line,
         line_number=9,
-        retrieval_policy=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+        retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
         k=10,
     )
 
@@ -326,7 +431,7 @@ async def test_evaluate_lines_records_assessor_failure_and_continues():
         async for result in runner.evaluate_lines(
             run_id=uuid7(),
             lines=lines,
-            retrieval_policy=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+            retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
             k=10,
         )
     ]
@@ -360,7 +465,7 @@ async def test_evaluate_line_propagates_unexpected_assessor_failure():
             run_id=uuid7(),
             line=_valid_line("unexpected-failure"),
             line_number=1,
-            retrieval_policy=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+            retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
             k=10,
         )
 
@@ -377,7 +482,7 @@ async def test_evaluate_line_does_not_turn_cancellation_into_a_record_failure():
             run_id=uuid7(),
             line=_valid_line("cancelled"),
             line_number=1,
-            retrieval_policy=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+            retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
             k=10,
         )
 
@@ -394,7 +499,7 @@ async def test_project_pair_results_preserves_correlation_routes_and_evidence():
                 rank=1,
                 routes=[
                     CandidateElasticsearchRoute(
-                        policy="soft_year_decay_year_optional_v1",
+                        policy="candidate_selection_v1",
                         rank=2,
                         score=8.5,
                     )
@@ -455,33 +560,28 @@ async def test_project_pair_results_preserves_correlation_routes_and_evidence():
         run_id=uuid7(),
         line=_valid_line("pair-projection"),
         line_number=42,
-        retrieval_policy=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+        retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
         k=10,
     )
 
     pair_results = runner.project_pair_results(record_result)
 
-    assert [row.run_id for row in pair_results] == [record_result.run_id] * 2
-    assert [row.query_id for row in pair_results] == ["pair-projection"] * 2
-    assert [row.line_number for row in pair_results] == [42, 42]
-    assert [row.incoming_reference_id for row in pair_results] == [
-        record_result.incoming_reference_id
-    ] * 2
-    assert [row.candidate_reference_id for row in pair_results] == [
-        es_candidate_id,
-        identifier_candidate_id,
+    incoming_reference_id = cast(UUID, record_result.incoming_reference_id)
+    assert pair_results == [
+        EvaluationPairResult(
+            run_id=record_result.run_id,
+            query_id="pair-projection",
+            line_number=42,
+            incoming_reference_id=incoming_reference_id,
+            candidate_reference_id=item.candidate.reference_id,
+            retrieval_rank=item.candidate.rank,
+            retrieval_routes=item.candidate.routes,
+            pair_result=item.pair_result,
+            threshold=0.85,
+            clears_threshold=item.clears_threshold,
+        )
+        for item in candidates
     ]
-    assert [row.retrieval_rank for row in pair_results] == [1, 2]
-    assert [row.retrieval_routes for row in pair_results] == [
-        candidates[0].candidate.routes,
-        candidates[1].candidate.routes,
-    ]
-    assert [row.pair_result for row in pair_results] == [
-        candidates[0].pair_result,
-        candidates[1].pair_result,
-    ]
-    assert [row.threshold for row in pair_results] == [0.85, 0.85]
-    assert [row.clears_threshold for row in pair_results] == [True, None]
     assessor.evaluate_supplied.assert_awaited_once()
 
 
@@ -494,7 +594,7 @@ async def test_project_pair_results_ignores_non_assessed_record():
         run_id=uuid7(),
         line="not json",
         line_number=7,
-        retrieval_policy=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+        retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
         k=10,
     )
 
@@ -503,8 +603,8 @@ async def test_project_pair_results_ignores_non_assessed_record():
 
 
 @pytest.mark.asyncio
-async def test_run_preserves_input_and_writes_run_scoped_artifacts(monkeypatch):
-    """A blob run hashes exact input bytes and writes only result artifacts."""
+async def test_run_preserves_input_and_writes_complete_bundle(monkeypatch):
+    """A blob run hashes exact input bytes and writes its completion marker last."""
     run_id = uuid7()
     input_file = BlobStorageFile.from_uri(
         "azure://dedup-evals/datasets/retrieval-query-set/v1/records.jsonl"
@@ -519,10 +619,12 @@ async def test_run_preserves_input_and_writes_run_scoped_artifacts(monkeypatch):
         blob_repository, "_preload_config", AsyncMock(return_value=client)
     )
     uploaded: dict[str, bytes] = {}
+    upload_order: list[str] = []
 
     async def upload(content, path, filename, **_kwargs):
         assert isinstance(content, BytesIO)
         uploaded[filename] = content.getvalue()
+        upload_order.append(filename)
         return BlobStorageFile(
             location=BlobStorageLocation.MINIO,
             container="test",
@@ -533,45 +635,152 @@ async def test_run_preserves_input_and_writes_run_scoped_artifacts(monkeypatch):
     blob_repository.upload_file_to_blob_storage = AsyncMock(side_effect=upload)
     assessor = AsyncMock()
     assessor.evaluate_supplied.side_effect = lambda incoming, *_args, **_kwargs: (
-        _assessment(incoming.id)
+        _assessment_with_pair_evidence(incoming.id, _kwargs["retrieval_policy"])
     )
     runner = DeduplicationEvaluationRunner(assessor=assessor)
+    configuration = _run_configuration()
 
     artifacts = await runner.run(
         run_id=run_id,
         input_file=input_file,
         blob_repository=blob_repository,
-        retrieval_policy=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
-        k=10,
+        configuration=configuration,
     )
 
-    assert artifacts.run_id == run_id
-    assert artifacts.input_file == input_file
-    assert artifacts.input_byte_size == len(source_bytes)
-    assert artifacts.input_sha256 == hashlib.sha256(source_bytes).hexdigest()
-    assert set(uploaded) == {
+    input_sha256 = hashlib.sha256(source_bytes).hexdigest()
+    assert (
+        artifacts.run_id,
+        artifacts.input_file,
+        artifacts.input_byte_size,
+        artifacts.input_sha256,
+    ) == (
+        run_id,
+        input_file,
+        len(source_bytes),
+        input_sha256,
+    )
+    assert upload_order == [
+        "record-results.jsonl",
         "record-results.jsonl",
         "pair-results.jsonl",
         "summary.md",
-    }
-    assert all(
-        file.path == f"deduplication_evaluation/{run_id}"
+        "manifest.json",
+    ]
+    assert {
+        file.filename: file.path
         for file in (
             artifacts.record_results_file,
             artifacts.pair_results_file,
             artifacts.summary_file,
+            artifacts.manifest_file,
         )
-    )
+    } == {filename: f"deduplication_evaluation/{run_id}" for filename in uploaded}
     record_rows = [
         json.loads(line) for line in uploaded["record-results.jsonl"].splitlines()
     ]
     assert [row["status"] for row in record_rows] == ["assessed", "input_invalid"]
-    assert uploaded["pair-results.jsonl"] == b""
-    summary = uploaded["summary.md"].decode()
-    assert f"Run ID: `{run_id}`" in summary
-    assert f"Input: `{input_file.to_uri()}`" in summary
-    assert "Assessed records: 1" in summary
-    assert "Invalid input records: 1" in summary
-    assert "Pair rows: 0" in summary
+    assert (
+        record_rows[0]["assessment"]["candidate_selection"]["retrieval_policy"]
+        == configuration.retrieval_policy
+    )
+    pair_rows = [
+        json.loads(line) for line in uploaded["pair-results.jsonl"].splitlines()
+    ]
+    assert [row["clears_threshold"] for row in pair_rows] == [True, False, None]
+    expected_summary = (
+        "# Deduplication evaluation summary\n\n"
+        f"Run ID: `{run_id}`\n\n"
+        f"Input: `{input_file.to_uri()}`\n\n"
+        f"Input bytes: {len(source_bytes)}\n\n"
+        f"Input SHA-256: `{input_sha256}`\n\n"
+        "Records: 2\n\n"
+        "Assessed records: 1\n\n"
+        "Invalid input records: 1\n\n"
+        "Evaluation-failed records: 0\n\n"
+        "Pair rows: 3\n\n"
+        "## Assessment outcomes\n\n"
+        "- `propose_canonical`: 0\n"
+        "- `propose_duplicate`: 0\n"
+        "- `no_proposal`: 1\n\n"
+        "## Pair evidence\n\n"
+        "- Clears threshold: 1\n"
+        "- Below threshold: 1\n"
+        "- Unscorable: 1\n"
+    )
+    assert uploaded["summary.md"].decode() == expected_summary
+    assert json.loads(uploaded["manifest.json"]) == {
+        "schema_version": "deduplication-evaluation-manifest/v1",
+        "run_id": str(run_id),
+        "input": {
+            "uri": input_file.to_uri(),
+            "dataset_version": "retrieval-query-set/v1",
+            "byte_size": len(source_bytes),
+            "sha256": input_sha256,
+        },
+        "configuration": configuration.model_dump(mode="json"),
+        "counts": {
+            "record_statuses": {
+                "assessed": 1,
+                "input_invalid": 1,
+                "evaluation_failed": 0,
+            },
+            "pair_rows": 3,
+        },
+        "artifacts": {
+            "record-results.jsonl": _expected_artifact(
+                artifacts.record_results_file,
+                uploaded["record-results.jsonl"],
+                "evaluation-record-result/v1",
+            ),
+            "pair-results.jsonl": _expected_artifact(
+                artifacts.pair_results_file,
+                uploaded["pair-results.jsonl"],
+                "evaluation-pair-result/v1",
+            ),
+            "summary.md": _expected_artifact(
+                artifacts.summary_file,
+                uploaded["summary.md"],
+                "deduplication-evaluation-summary/v1",
+            ),
+        },
+    }
     client.stream_chunks.assert_called_once_with(input_file)
     assessor.evaluate_supplied.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_checks_artifact_writability_before_evaluation():
+    """A stable output failure is reported before spending work on evaluation."""
+    run_id = uuid7()
+    input_file = BlobStorageFile.from_uri(
+        "azure://dedup-evals/datasets/retrieval-query-set/v1/records.jsonl"
+    )
+    chunks = AsyncMock()
+    chunks.__aiter__.return_value = [_valid_line("unused").encode()]
+    blob_repository = MagicMock(spec=BlobRepository)
+    blob_repository.stream_chunks_from_blob_storage.return_value = chunks
+    error = BlobStorageError("result prefix is not writable")
+    blob_repository.upload_file_to_blob_storage = AsyncMock(side_effect=error)
+    assessor = AsyncMock()
+    assessor.evaluate_supplied.side_effect = lambda incoming, *_args, **_kwargs: (
+        _assessment(incoming.id)
+    )
+    runner = DeduplicationEvaluationRunner(assessor=assessor)
+
+    with pytest.raises(BlobStorageError, match="result prefix is not writable"):
+        await runner.run(
+            run_id=run_id,
+            input_file=input_file,
+            blob_repository=blob_repository,
+            configuration=_run_configuration(),
+        )
+
+    blob_repository.stream_chunks_from_blob_storage.assert_not_called()
+    assessor.evaluate_supplied.assert_not_awaited()
+    preflight = blob_repository.upload_file_to_blob_storage.await_args.kwargs
+    assert preflight["content"].getvalue() == b""
+    assert {key: value for key, value in preflight.items() if key != "content"} == {
+        "path": f"deduplication_evaluation/{run_id}",
+        "filename": "record-results.jsonl",
+        "content_type": "application/jsonl",
+    }

--- a/tests/unit/domain/references/deduplication/test_evaluation_runner.py
+++ b/tests/unit/domain/references/deduplication/test_evaluation_runner.py
@@ -41,7 +41,11 @@ from app.domain.references.services.deduplication_evaluation_runner import (
     EvaluationRunConfiguration,
 )
 from app.persistence.blob.client import GenericBlobStorageClient
-from app.persistence.blob.models import BlobStorageFile, BlobStorageLocation
+from app.persistence.blob.models import (
+    BlobDigest,
+    BlobStorageFile,
+    BlobStorageLocation,
+)
 from app.persistence.blob.repository import BlobRepository
 
 
@@ -72,6 +76,7 @@ def _line(
     input_identifiers: list[str] | None = None,
     excluded_reference_ids: list[str] | None = None,
     dataset_version: str = "retrieval-query-set/v1",
+    input_reference_extra: dict | None = None,
 ) -> str:
     return json.dumps(
         {
@@ -80,7 +85,8 @@ def _line(
                 "title": f"Study {query_id}",
                 "authors": ["First Author", "Middle Author", "Last Author"],
                 "year": year,
-            },
+            }
+            | (input_reference_extra or {}),
             "input_identifiers": input_identifiers or ["open_alex:W1"],
             "route_applicability": route_applicability or ["fuzzy"],
             "excluded_reference_ids": excluded_reference_ids or [],
@@ -191,9 +197,11 @@ def _blob_repository(source: bytes) -> tuple[BlobRepository, dict[str, bytes]]:
     midpoint = len(source) // 2
     chunks = [source[:midpoint], source[midpoint:]]
 
-    async def stream_chunks(_file):
-        for chunk in chunks:
-            yield chunk
+    async def digest(_file, **_kwargs):
+        return BlobDigest(
+            byte_size=len(source),
+            sha256_checksum=hashlib.sha256(source).hexdigest(),
+        )
 
     @asynccontextmanager
     async def stream_lines(file):
@@ -212,7 +220,7 @@ def _blob_repository(source: bytes) -> tuple[BlobRepository, dict[str, bytes]]:
         )
 
     repository = MagicMock(spec=BlobRepository)
-    repository.stream_chunks_from_blob_storage = stream_chunks
+    repository.digest = digest
     repository.stream_file_from_blob_storage = stream_lines
     repository.upload_file_to_blob_storage = AsyncMock(side_effect=upload)
     return repository, uploaded
@@ -384,6 +392,37 @@ async def test_run_builds_yearless_and_union_assessment_inputs():
         call.kwargs == {"retrieval_policy": policy, "k": 10}
         for call in assessor.evaluate_supplied.await_args_list
     )
+
+
+@pytest.mark.asyncio
+async def test_run_carries_every_bibliographic_field_the_scorer_reads():
+    """Production hands the scorer these, so a measurement of it has to as well."""
+    source = _line(
+        "enriched",
+        input_reference_extra={
+            "journal": "Journal of Testing",
+            "issue": "3",
+            "first_page": "12",
+            "last_page": "19",
+            "volume": "14",
+        },
+    ).encode()
+    repository, _uploaded = _blob_repository(source)
+    assessor = _assessor()
+
+    await DeduplicationEvaluationRunner(assessor=assessor).run(
+        run_id=uuid7(),
+        input_file=BlobStorageFile.from_uri("azure://dedup-evals/input.jsonl"),
+        blob_repository=repository,
+        configuration=_configuration(),
+    )
+
+    incoming, _selection = assessor.evaluate_supplied.await_args_list[0].args
+    paper = DeduplicationPaperProjection.get_from_reference(incoming)
+    assert paper.journal == "Journal of Testing"
+    assert paper.pages == "12-19"
+    assert paper.issue == "3"
+    assert paper.volume == "14"
 
 
 @pytest.mark.asyncio
@@ -700,7 +739,7 @@ async def test_run_supplies_a_record_the_assessment_service_can_score():
 
 @pytest.mark.asyncio
 async def test_run_keeps_completed_records_when_cancelled():
-    """A shutdown costs the same hours of retrieval as any other abort."""
+    """A shutdown throws away as much completed work as any other abort."""
     source = "\n".join([_line("first"), _line("cancelled")]).encode()
     repository, uploaded = _blob_repository(source)
     call_count = 0

--- a/tests/unit/domain/references/deduplication/test_evaluation_runner.py
+++ b/tests/unit/domain/references/deduplication/test_evaluation_runner.py
@@ -1,0 +1,145 @@
+"""Tests for the deduplication evaluation runner."""
+
+from unittest.mock import AsyncMock
+from uuid import uuid7
+
+import pytest
+
+from app.domain.references.models.models import (
+    CandidateSelectionDiagnostics,
+    CandidateSelectionResult,
+    DeduperMetadata,
+    DeduplicationAssessment,
+    DeduplicationAssessmentOutcome,
+    ExternalIdentifierType,
+    InputSearchability,
+    RetrievalPolicyName,
+)
+from app.domain.references.services.deduplication_evaluation_runner import (
+    DeduplicationEvaluationRunner,
+    EvaluationRecordStatus,
+)
+
+
+def _assessment(incoming_reference_id):
+    return DeduplicationAssessment(
+        incoming_reference_id=incoming_reference_id,
+        candidate_selection=CandidateSelectionResult(
+            retrieval_policy=(RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1),
+            index_version="reference_v3",
+            k_requested=10,
+            input_searchability=InputSearchability(
+                searchable=True,
+                reason="The input has a title and authors.",
+            ),
+            diagnostics=CandidateSelectionDiagnostics(),
+        ),
+        deduper=DeduperMetadata(
+            package_version="fake-1",
+            configuration_hash="fake-config",
+            threshold=0.85,
+        ),
+        outcome=DeduplicationAssessmentOutcome.PROPOSE_CANONICAL,
+    )
+
+
+@pytest.mark.asyncio
+async def test_evaluate_line_assesses_yearless_supplied_record_with_correlation():
+    """A frozen row is assessed without first resolving it to a held record."""
+    run_id = uuid7()
+    held_reference_id = uuid7()
+    assessor = AsyncMock()
+    assessor.evaluate_supplied.side_effect = lambda incoming, _selection, **_kwargs: (
+        _assessment(incoming.id)
+    )
+    runner = DeduplicationEvaluationRunner(assessor=assessor)
+    line = f"""{{
+        "query_id": "oa-km:W1:W2",
+        "input_reference": {{
+            "title": "A yearless study",
+            "authors": ["First Author", "Middle Author", "Last Author"],
+            "year": null
+        }},
+        "input_identifiers": ["open_alex:W1"],
+        "route_applicability": ["identifier", "fuzzy"],
+        "excluded_reference_ids": ["{held_reference_id}"],
+        "dataset_version": "retrieval-query-set/v1",
+        "source_group": "openalex"
+    }}"""
+
+    result = await runner.evaluate_line(
+        run_id=run_id,
+        line=line,
+        line_number=42,
+        retrieval_policy=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+        k=10,
+    )
+
+    assert result.run_id == run_id
+    assert result.query_id == "oa-km:W1:W2"
+    assert result.line_number == 42
+    assert result.status == EvaluationRecordStatus.ASSESSED
+    assert result.incoming_reference_id.version == 7
+    assert result.assessment == _assessment(result.incoming_reference_id)
+    assert result.error is None
+    incoming, selection = assessor.evaluate_supplied.await_args.args
+    assert incoming.id == result.incoming_reference_id
+    assert incoming.visibility == "public"
+    assert incoming.identifiers[0].identifier_type == ExternalIdentifierType.OPEN_ALEX
+    assert incoming.identifiers[0].identifier == "W1"
+    assert incoming.enhancements[0].source == "retrieval-query-set/v1"
+    biblio = incoming.enhancements[0].content
+    assert biblio.title == "A yearless study"
+    assert biblio.publication_year is None
+    assert [author.display_name for author in biblio.authorship] == [
+        "First Author",
+        "Middle Author",
+        "Last Author",
+    ]
+    assert [author.position for author in biblio.authorship] == [
+        "first",
+        "middle",
+        "last",
+    ]
+    assert selection.title == "A yearless study"
+    assert selection.authors == ["First Author", "Middle Author", "Last Author"]
+    assert selection.publication_year is None
+    assert selection.excluded_reference_id == held_reference_id
+    assert selection.identifiers[0].identifier_type == ExternalIdentifierType.OPEN_ALEX
+    assert assessor.evaluate_supplied.await_args.kwargs == {
+        "retrieval_policy": RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+        "k": 10,
+    }
+
+
+@pytest.mark.asyncio
+async def test_evaluate_line_withholds_identifiers_from_fuzzy_only_query():
+    """Dataset identifiers remain scorer input without leaking into retrieval."""
+    assessor = AsyncMock()
+    assessor.evaluate_supplied.side_effect = lambda incoming, _selection, **_kwargs: (
+        _assessment(incoming.id)
+    )
+    runner = DeduplicationEvaluationRunner(assessor=assessor)
+
+    await runner.evaluate_line(
+        run_id=uuid7(),
+        line="""{
+            "query_id": "oa-km:W3:W4",
+            "input_reference": {
+                "title": "A fuzzy-only study",
+                "authors": ["First Author"],
+                "year": 2024
+            },
+            "input_identifiers": ["open_alex:W3"],
+            "route_applicability": ["fuzzy"],
+            "excluded_reference_ids": [],
+            "dataset_version": "retrieval-query-set/v1"
+        }""",
+        line_number=1,
+        retrieval_policy=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+        k=10,
+    )
+
+    incoming, selection = assessor.evaluate_supplied.await_args.args
+    assert incoming.identifiers[0].identifier == "W3"
+    assert selection.identifiers == []

--- a/tests/unit/domain/references/deduplication/test_evaluation_runner.py
+++ b/tests/unit/domain/references/deduplication/test_evaluation_runner.py
@@ -218,6 +218,11 @@ def _blob_repository(source: bytes) -> tuple[BlobRepository, dict[str, bytes]]:
     return repository, uploaded
 
 
+def _rows(artifact: bytes) -> list[dict]:
+    """Read JSONL the way the runner writes it: newline only, never splitlines()."""
+    return [json.loads(row) for row in artifact.decode().split("\n") if row]
+
+
 @pytest.mark.asyncio
 async def test_run_writes_complete_reviewable_bundle():
     """The public run contract preserves input identity and writes manifest last."""
@@ -257,8 +262,8 @@ async def test_run_writes_complete_reviewable_bundle():
     assert artifacts.input_byte_size == len(source)
     assert artifacts.input_sha256 == hashlib.sha256(source).hexdigest()
 
-    records = [json.loads(row) for row in uploaded["record-results.jsonl"].splitlines()]
-    pairs = [json.loads(row) for row in uploaded["pair-results.jsonl"].splitlines()]
+    records = _rows(uploaded["record-results.jsonl"])
+    pairs = _rows(uploaded["pair-results.jsonl"])
     assert [
         (row["query_id"], row["line_number"], row["status"]) for row in records
     ] == [
@@ -266,6 +271,9 @@ async def test_run_writes_complete_reviewable_bundle():
         (None, 2, "input_invalid"),
     ]
     assert records[1]["error"]["code"] == "invalid_json"
+    # The parser is handed one line at a time, so its own line number is always 1
+    # and would contradict the envelope's.
+    assert "line" not in records[1]["error"]["message"]
     assert [row["clears_threshold"] for row in pairs] == [True, False, None]
     assert all(row["query_id"] == "assessed" for row in pairs)
     assert pairs[0]["retrieval_routes"][0]["policy"] == "candidate_selection_v1"
@@ -407,7 +415,7 @@ async def test_run_splits_records_only_on_newline():
         configuration=_configuration(),
     )
 
-    records = [json.loads(row) for row in uploaded["record-results.jsonl"].splitlines()]
+    records = _rows(uploaded["record-results.jsonl"])
     assert [
         (row["query_id"], row["line_number"], row["status"]) for row in records
     ] == [
@@ -461,7 +469,7 @@ async def test_run_records_expected_failures_and_continues():
         configuration=_configuration(),
     )
 
-    records = [json.loads(row) for row in uploaded["record-results.jsonl"].splitlines()]
+    records = _rows(uploaded["record-results.jsonl"])
     assert [row["line_number"] for row in records] == [1, 3, 4, 5, 6, 7, 8]
     assert [row["status"] for row in records] == [
         "assessed",
@@ -511,7 +519,7 @@ async def test_run_preserves_completed_records_when_it_aborts():
         )
 
     assert set(uploaded) == {"record-results.jsonl"}
-    records = [json.loads(row) for row in uploaded["record-results.jsonl"].splitlines()]
+    records = _rows(uploaded["record-results.jsonl"])
     assert [(row["query_id"], row["status"]) for row in records] == [
         ("first", "assessed")
     ]
@@ -586,7 +594,7 @@ async def test_run_aborts_when_a_record_contradicts_the_published_configuration(
         field for field in _CONFIGURATION_FIELDS if f"{field} asserted" in message
     ] == reported
     assert set(uploaded) == {"record-results.jsonl"}
-    records = [json.loads(row) for row in uploaded["record-results.jsonl"].splitlines()]
+    records = _rows(uploaded["record-results.jsonl"])
     # The record that triggered the mismatch is kept, so the bundle shows what
     # actually ran against what the configuration declared.
     assert [(row["query_id"], row["status"]) for row in records] == [
@@ -618,7 +626,7 @@ async def test_run_aborts_when_a_record_declares_another_dataset():
     assert set(uploaded) == {"record-results.jsonl"}
     # Rejected before it is assessed, so unlike a drifted run there is nothing
     # completed to keep for that line.
-    records = [json.loads(row) for row in uploaded["record-results.jsonl"].splitlines()]
+    records = _rows(uploaded["record-results.jsonl"])
     assert [(row["query_id"], row["status"]) for row in records] == [
         ("first", "assessed")
     ]
@@ -656,6 +664,10 @@ async def test_run_supplies_a_record_the_assessment_service_can_score():
     configuration = _configuration()
     pair_scorer = MagicMock(spec=PairScorer)
     pair_scorer.metadata = configuration.deduper
+    # Set explicitly: the protocol declares get_hydrated `-> Awaitable[...]` rather
+    # than `async def`, so MagicMock(spec=...) mocks it as sync and awaiting fails.
+    reference_reader = MagicMock(spec=ReferenceReader)
+    reference_reader.get_hydrated = AsyncMock(return_value=[])
     service = DeduplicationAssessmentService(
         candidate_selector=AsyncMock(
             return_value=CandidateSelectionResult(
@@ -669,7 +681,7 @@ async def test_run_supplies_a_record_the_assessment_service_can_score():
                 diagnostics=CandidateSelectionDiagnostics(),
             )
         ),
-        reference_reader=MagicMock(spec=ReferenceReader),
+        reference_reader=reference_reader,
         pair_scorer=pair_scorer,
     )
 
@@ -680,7 +692,7 @@ async def test_run_supplies_a_record_the_assessment_service_can_score():
         configuration=configuration,
     )
 
-    records = [json.loads(row) for row in uploaded["record-results.jsonl"].splitlines()]
+    records = _rows(uploaded["record-results.jsonl"])
     assert [(row["query_id"], row["status"]) for row in records] == [
         ("scoreable", "assessed")
     ]
@@ -712,7 +724,7 @@ async def test_run_keeps_completed_records_when_cancelled():
         )
 
     assert set(uploaded) == {"record-results.jsonl"}
-    records = [json.loads(row) for row in uploaded["record-results.jsonl"].splitlines()]
+    records = _rows(uploaded["record-results.jsonl"])
     assert [(row["query_id"], row["status"]) for row in records] == [
         ("first", "assessed")
     ]
@@ -751,7 +763,7 @@ async def test_run_keeps_completed_records_when_its_task_is_cancelled():
         await task
 
     assert set(uploaded) == {"record-results.jsonl"}
-    records = [json.loads(row) for row in uploaded["record-results.jsonl"].splitlines()]
+    records = _rows(uploaded["record-results.jsonl"])
     assert [(row["query_id"], row["status"]) for row in records] == [
         ("first", "assessed")
     ]

--- a/tests/unit/domain/references/deduplication/test_evaluation_runner.py
+++ b/tests/unit/domain/references/deduplication/test_evaluation_runner.py
@@ -13,6 +13,7 @@ from uuid import uuid7
 import pytest
 
 from app.core.exceptions import (
+    BlobSizeExceededError,
     DeduplicationError,
     EvaluationConfigurationMismatchError,
 )
@@ -197,7 +198,12 @@ def _blob_repository(source: bytes) -> tuple[BlobRepository, dict[str, bytes]]:
     midpoint = len(source) // 2
     chunks = [source[:midpoint], source[midpoint:]]
 
-    async def digest(_file, **_kwargs):
+    async def digest(_file, max_bytes=None, **_kwargs):
+        # Mirrors the real repository, which aborts the stream rather than
+        # returning a digest, so a cap test cannot pass against a stub alone.
+        if max_bytes is not None and len(source) > max_bytes:
+            msg = f"Blob exceeds max_bytes={max_bytes}"
+            raise BlobSizeExceededError(msg)
         return BlobDigest(
             byte_size=len(source),
             sha256_checksum=hashlib.sha256(source).hexdigest(),
@@ -232,6 +238,25 @@ def _rows(artifact: bytes) -> list[dict]:
 
 
 @pytest.mark.asyncio
+async def test_run_refuses_an_input_over_the_cap_before_assessing_anything():
+    """The cap has to bite on the digest pass, not after a corpus query per record."""
+    source = (_line("assessed") + "\n").encode()
+    repository, uploaded = _blob_repository(source)
+    assessor = _assessor(with_pairs=True)
+
+    with pytest.raises(BlobSizeExceededError):
+        await DeduplicationEvaluationRunner(assessor=assessor).run(
+            run_id=uuid7(),
+            input_file=BlobStorageFile.from_uri("azure://evals/datasets/in.jsonl"),
+            blob_repository=repository,
+            configuration=_configuration(),
+            max_input_bytes=len(source) - 1,
+        )
+
+    assert assessor.evaluate_supplied.await_count == 0
+    assert uploaded == {}
+
+
 async def test_run_writes_complete_reviewable_bundle():
     """The public run contract preserves input identity and writes manifest last."""
     run_id = uuid7()

--- a/tests/unit/domain/references/deduplication/test_evaluation_runner.py
+++ b/tests/unit/domain/references/deduplication/test_evaluation_runner.py
@@ -30,6 +30,12 @@ from app.domain.references.models.models import (
     RetrievalPolicyName,
     ScoredDeduplicationCandidate,
 )
+from app.domain.references.models.projections import DeduplicationPaperProjection
+from app.domain.references.services.deduplication_assessment_service import (
+    DeduplicationAssessmentService,
+    PairScorer,
+    ReferenceReader,
+)
 from app.domain.references.services.deduplication_evaluation_runner import (
     DeduplicationEvaluationRunner,
     EvaluationRunConfiguration,
@@ -334,12 +340,16 @@ async def test_run_builds_yearless_and_union_assessment_inputs():
     second_incoming, second_selection = assessor.evaluate_supplied.await_args_list[
         1
     ].args
-    bibliography = first_incoming.enhancements[0].content
+    # Through the projection the scorer runs on, not the record's own attributes: a
+    # record can hold every field and still be unscorable.
+    first_paper = DeduplicationPaperProjection.get_from_reference(first_incoming)
     assert first_incoming.id.version == 7
-    assert first_incoming.identifiers[0].identifier == "W1"
-    assert bibliography.publication_year is None
+    assert first_paper.openalex_id is not None
+    assert first_paper.openalex_id.identifier == "W1"
+    assert first_paper.title == "Study yearless"
+    assert first_paper.year is None
     assert [
-        (author.display_name, author.position) for author in bibliography.authorship
+        (author.display_name, author.position) for author in first_paper.authors or []
     ] == [
         ("First Author", "first"),
         ("Middle Author", "middle"),
@@ -350,7 +360,9 @@ async def test_run_builds_yearless_and_union_assessment_inputs():
         first_selection.identifiers[0].identifier_type
         is ExternalIdentifierType.OPEN_ALEX
     )
-    assert second_incoming.identifiers[0].identifier == "W1"
+    second_paper = DeduplicationPaperProjection.get_from_reference(second_incoming)
+    assert second_paper.openalex_id is not None
+    assert second_paper.openalex_id.identifier == "W1"
     # route_applicability is analysis metadata, not query-shaping input.
     # The runner sends full input so production policy records real provenance.
     assert (
@@ -601,6 +613,43 @@ async def test_run_accepts_a_record_the_corpus_was_never_searched_for():
 
     manifest = json.loads(uploaded["manifest.json"])
     assert manifest["counts"]["record_statuses"]["assessed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_run_supplies_a_record_the_assessment_service_can_score():
+    """A stand-in assessor takes any record, so drive the service the runner gets."""
+    repository, uploaded = _blob_repository(_line("scoreable").encode())
+    configuration = _configuration()
+    pair_scorer = MagicMock(spec=PairScorer)
+    pair_scorer.metadata = configuration.deduper
+    service = DeduplicationAssessmentService(
+        candidate_selector=AsyncMock(
+            return_value=CandidateSelectionResult(
+                retrieval_policy=configuration.retrieval_policy,
+                index_version=configuration.elasticsearch_index_version,
+                k_requested=configuration.k,
+                input_searchability=InputSearchability(
+                    searchable=True, reason="The input has a title and authors."
+                ),
+                candidates=[],
+                diagnostics=CandidateSelectionDiagnostics(),
+            )
+        ),
+        reference_reader=MagicMock(spec=ReferenceReader),
+        pair_scorer=pair_scorer,
+    )
+
+    await DeduplicationEvaluationRunner(assessor=service).run(
+        run_id=uuid7(),
+        input_file=BlobStorageFile.from_uri("azure://dedup-evals/input.jsonl"),
+        blob_repository=repository,
+        configuration=configuration,
+    )
+
+    records = [json.loads(row) for row in uploaded["record-results.jsonl"].splitlines()]
+    assert [(row["query_id"], row["status"]) for row in records] == [
+        ("scoreable", "assessed")
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/domain/references/deduplication/test_evaluation_runner.py
+++ b/tests/unit/domain/references/deduplication/test_evaluation_runner.py
@@ -71,6 +71,7 @@ def _line(
     route_applicability: list[str] | None = None,
     input_identifiers: list[str] | None = None,
     excluded_reference_ids: list[str] | None = None,
+    dataset_version: str = "retrieval-query-set/v1",
 ) -> str:
     return json.dumps(
         {
@@ -83,7 +84,7 @@ def _line(
             "input_identifiers": input_identifiers or ["open_alex:W1"],
             "route_applicability": route_applicability or ["fuzzy"],
             "excluded_reference_ids": excluded_reference_ids or [],
-            "dataset_version": "retrieval-query-set/v1",
+            "dataset_version": dataset_version,
         }
     )
 
@@ -592,6 +593,36 @@ async def test_run_aborts_when_a_record_contradicts_the_published_configuration(
         ("first", "assessed"),
         ("drifted", "assessed"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_run_aborts_when_a_record_declares_another_dataset():
+    """A manifest naming one dataset must not describe records from another."""
+    source = "\n".join(
+        [_line("first"), _line("other", dataset_version="retrieval-query-set/v2")]
+    ).encode()
+    repository, uploaded = _blob_repository(source)
+    assessor = _assessor()
+
+    with pytest.raises(EvaluationConfigurationMismatchError) as mismatch:
+        await DeduplicationEvaluationRunner(assessor=assessor).run(
+            run_id=uuid7(),
+            input_file=BlobStorageFile.from_uri("azure://dedup-evals/input.jsonl"),
+            blob_repository=repository,
+            configuration=_configuration(),
+        )
+
+    message = str(mismatch.value)
+    assert "retrieval-query-set/v1" in message
+    assert "retrieval-query-set/v2" in message
+    assert set(uploaded) == {"record-results.jsonl"}
+    # Rejected before it is assessed, so unlike a drifted run there is nothing
+    # completed to keep for that line.
+    records = [json.loads(row) for row in uploaded["record-results.jsonl"].splitlines()]
+    assert [(row["query_id"], row["status"]) for row in records] == [
+        ("first", "assessed")
+    ]
+    assert assessor.evaluate_supplied.await_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/domain/references/deduplication/test_evaluation_runner.py
+++ b/tests/unit/domain/references/deduplication/test_evaluation_runner.py
@@ -456,20 +456,46 @@ async def test_run_records_expected_failures_and_continues():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "error",
-    [
-        pytest.param(ValueError("unexpected scorer defect"), id="unexpected"),
-        pytest.param(asyncio.CancelledError(), id="cancelled"),
-    ],
-)
-async def test_run_propagates_non_record_failures(error):
-    """Programming errors and cancellation abort the run."""
+async def test_run_preserves_completed_records_when_it_aborts():
+    """An abort keeps finished work; the absent manifest marks the bundle incomplete."""
+    source = "\n".join([_line("first"), _line("boom"), _line("never")]).encode()
+    repository, uploaded = _blob_repository(source)
+    call_count = 0
+
+    async def assess(incoming, *_args, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            message = "unexpected scorer defect"
+            raise ValueError(message)
+        return _assessment(incoming.id)
+
+    assessor = AsyncMock()
+    assessor.evaluate_supplied = AsyncMock(side_effect=assess)
+
+    with pytest.raises(ValueError, match="unexpected scorer defect"):
+        await DeduplicationEvaluationRunner(assessor=assessor).run(
+            run_id=uuid7(),
+            input_file=BlobStorageFile.from_uri("azure://dedup-evals/input.jsonl"),
+            blob_repository=repository,
+            configuration=_configuration(),
+        )
+
+    assert set(uploaded) == {"record-results.jsonl"}
+    records = [json.loads(row) for row in uploaded["record-results.jsonl"].splitlines()]
+    assert [(row["query_id"], row["status"]) for row in records] == [
+        ("first", "assessed")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_writes_nothing_when_cancelled():
+    """Cancellation unwinds without further blob I/O."""
     repository, uploaded = _blob_repository(_line("failed").encode())
     assessor = AsyncMock()
-    assessor.evaluate_supplied.side_effect = error
+    assessor.evaluate_supplied.side_effect = asyncio.CancelledError()
 
-    with pytest.raises(type(error)):
+    with pytest.raises(asyncio.CancelledError):
         await DeduplicationEvaluationRunner(assessor=assessor).run(
             run_id=uuid7(),
             input_file=BlobStorageFile.from_uri("azure://dedup-evals/input.jsonl"),

--- a/tests/unit/domain/references/deduplication/test_evaluation_runner.py
+++ b/tests/unit/domain/references/deduplication/test_evaluation_runner.py
@@ -1,5 +1,6 @@
 """Tests for the deduplication evaluation runner."""
 
+import json
 from unittest.mock import AsyncMock
 from uuid import uuid7
 
@@ -43,6 +44,23 @@ def _assessment(incoming_reference_id):
     )
 
 
+def _valid_line(query_id: str, **updates: object) -> str:
+    record: dict[str, object] = {
+        "query_id": query_id,
+        "input_reference": {
+            "title": "A study",
+            "authors": ["First Author"],
+            "year": 2024,
+        },
+        "input_identifiers": ["open_alex:W1"],
+        "route_applicability": ["fuzzy"],
+        "excluded_reference_ids": [],
+        "dataset_version": "retrieval-query-set/v1",
+    }
+    record.update(updates)
+    return json.dumps(record)
+
+
 @pytest.mark.asyncio
 async def test_evaluate_line_assesses_yearless_supplied_record_with_correlation():
     """A frozen row is assessed without first resolving it to a held record."""
@@ -79,7 +97,9 @@ async def test_evaluate_line_assesses_yearless_supplied_record_with_correlation(
     assert result.query_id == "oa-km:W1:W2"
     assert result.line_number == 42
     assert result.status == EvaluationRecordStatus.ASSESSED
+    assert result.incoming_reference_id is not None
     assert result.incoming_reference_id.version == 7
+    assert result.assessment is not None
     assert result.assessment == _assessment(result.incoming_reference_id)
     assert result.error is None
     incoming, selection = assessor.evaluate_supplied.await_args.args
@@ -143,3 +163,122 @@ async def test_evaluate_line_withholds_identifiers_from_fuzzy_only_query():
     incoming, selection = assessor.evaluate_supplied.await_args.args
     assert incoming.identifiers[0].identifier == "W3"
     assert selection.identifiers == []
+
+
+@pytest.mark.asyncio
+async def test_evaluate_lines_records_invalid_json_and_continues():
+    """Every non-blank physical line gets an envelope without aborting later rows."""
+    run_id = uuid7()
+    assessor = AsyncMock()
+    assessor.evaluate_supplied.side_effect = lambda incoming, _selection, **_kwargs: (
+        _assessment(incoming.id)
+    )
+    runner = DeduplicationEvaluationRunner(assessor=assessor)
+    lines = AsyncMock()
+    lines.__aiter__.return_value = [
+        _valid_line("first"),
+        "   ",
+        '{"query_id": "broken"',
+        _valid_line("last"),
+    ]
+
+    results = [
+        result
+        async for result in runner.evaluate_lines(
+            run_id=run_id,
+            lines=lines,
+            retrieval_policy=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+            k=10,
+        )
+    ]
+
+    assert [result.line_number for result in results] == [1, 3, 4]
+    assert [result.status for result in results] == [
+        "assessed",
+        "input_invalid",
+        "assessed",
+    ]
+    invalid = results[1]
+    assert invalid.run_id == run_id
+    assert invalid.query_id is None
+    assert invalid.incoming_reference_id is None
+    assert invalid.assessment is None
+    assert invalid.error is not None
+    assert invalid.error.code == "invalid_json"
+    assert "Invalid JSON" in invalid.error.message
+    assert assessor.evaluate_supplied.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_evaluate_line_rejects_multiple_self_exclusions():
+    """The singular assessment query must not silently choose one exclusion."""
+    assessor = AsyncMock()
+    runner = DeduplicationEvaluationRunner(assessor=assessor)
+
+    result = await runner.evaluate_line(
+        run_id=uuid7(),
+        line=_valid_line(
+            "too-many-exclusions",
+            excluded_reference_ids=[str(uuid7()), str(uuid7())],
+        ),
+        line_number=7,
+        retrieval_policy=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+        k=10,
+    )
+
+    assert result.query_id == "too-many-exclusions"
+    assert result.status == "input_invalid"
+    assert result.error is not None
+    assert result.error.code == "invalid_record"
+    assert "excluded_reference_ids" in result.error.message
+    assessor.evaluate_supplied.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_evaluate_line_records_identifier_conversion_failure():
+    """An invalid SDK identifier is a record error, not a run failure."""
+    assessor = AsyncMock()
+    runner = DeduplicationEvaluationRunner(assessor=assessor)
+
+    result = await runner.evaluate_line(
+        run_id=uuid7(),
+        line=_valid_line("bad-identifier", input_identifiers=["unknown:value"]),
+        line_number=8,
+        retrieval_policy=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+        k=10,
+    )
+
+    assert result.query_id == "bad-identifier"
+    assert result.status == "input_invalid"
+    assert result.error is not None
+    assert result.error.code == "invalid_record"
+    assert "Unknown identifier type" in result.error.message
+    assessor.evaluate_supplied.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "line",
+    [
+        pytest.param("[]", id="non-object"),
+        pytest.param('{"query_id": 42}', id="non-string-query-id"),
+    ],
+)
+async def test_evaluate_line_records_uncorrelatable_schema_failure(line):
+    """Invalid object shapes still produce an envelope without a false query key."""
+    assessor = AsyncMock()
+    runner = DeduplicationEvaluationRunner(assessor=assessor)
+
+    result = await runner.evaluate_line(
+        run_id=uuid7(),
+        line=line,
+        line_number=9,
+        retrieval_policy=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+        k=10,
+    )
+
+    assert result.query_id is None
+    assert result.status == "input_invalid"
+    assert result.error is not None
+    assert result.error.code == "invalid_record"
+    assessor.evaluate_supplied.assert_not_awaited()

--- a/tests/unit/domain/references/deduplication/test_evaluation_runner.py
+++ b/tests/unit/domain/references/deduplication/test_evaluation_runner.py
@@ -1,8 +1,10 @@
 """Tests for the deduplication evaluation runner."""
 
 import asyncio
+import hashlib
 import json
-from unittest.mock import AsyncMock
+from io import BytesIO
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid7
 
 import pytest
@@ -30,6 +32,8 @@ from app.domain.references.services.deduplication_evaluation_runner import (
     DeduplicationEvaluationRunner,
     EvaluationRecordStatus,
 )
+from app.persistence.blob.models import BlobStorageFile, BlobStorageLocation
+from app.persistence.blob.repository import BlobRepository
 
 
 def _assessment(incoming_reference_id):
@@ -496,3 +500,78 @@ async def test_project_pair_results_ignores_non_assessed_record():
 
     assert runner.project_pair_results(record_result) == []
     assessor.evaluate_supplied.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_preserves_input_and_writes_run_scoped_artifacts(monkeypatch):
+    """A blob run hashes exact input bytes and writes only result artifacts."""
+    run_id = uuid7()
+    input_file = BlobStorageFile.from_uri(
+        "azure://dedup-evals/datasets/retrieval-query-set/v1/records.jsonl"
+    )
+    source_bytes = (_valid_line("assessed") + "\nnot json").encode()
+    chunks = AsyncMock()
+    chunks.__aiter__.return_value = [source_bytes[:17], source_bytes[17:]]
+    client = MagicMock()
+    client.stream_chunks.return_value = chunks
+    blob_repository = BlobRepository()
+    monkeypatch.setattr(
+        blob_repository, "_preload_config", AsyncMock(return_value=client)
+    )
+    uploaded: dict[str, bytes] = {}
+
+    async def upload(content, path, filename, **_kwargs):
+        assert isinstance(content, BytesIO)
+        uploaded[filename] = content.getvalue()
+        return BlobStorageFile(
+            location=BlobStorageLocation.MINIO,
+            container="test",
+            path=path,
+            filename=filename,
+        )
+
+    blob_repository.upload_file_to_blob_storage = AsyncMock(side_effect=upload)
+    assessor = AsyncMock()
+    assessor.evaluate_supplied.side_effect = lambda incoming, *_args, **_kwargs: (
+        _assessment(incoming.id)
+    )
+    runner = DeduplicationEvaluationRunner(assessor=assessor)
+
+    artifacts = await runner.run(
+        run_id=run_id,
+        input_file=input_file,
+        blob_repository=blob_repository,
+        retrieval_policy=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+        k=10,
+    )
+
+    assert artifacts.run_id == run_id
+    assert artifacts.input_file == input_file
+    assert artifacts.input_byte_size == len(source_bytes)
+    assert artifacts.input_sha256 == hashlib.sha256(source_bytes).hexdigest()
+    assert set(uploaded) == {
+        "record-results.jsonl",
+        "pair-results.jsonl",
+        "summary.md",
+    }
+    assert all(
+        file.path == f"deduplication_evaluation/{run_id}"
+        for file in (
+            artifacts.record_results_file,
+            artifacts.pair_results_file,
+            artifacts.summary_file,
+        )
+    )
+    record_rows = [
+        json.loads(line) for line in uploaded["record-results.jsonl"].splitlines()
+    ]
+    assert [row["status"] for row in record_rows] == ["assessed", "input_invalid"]
+    assert uploaded["pair-results.jsonl"] == b""
+    summary = uploaded["summary.md"].decode()
+    assert f"Run ID: `{run_id}`" in summary
+    assert f"Input: `{input_file.to_uri()}`" in summary
+    assert "Assessed records: 1" in summary
+    assert "Invalid input records: 1" in summary
+    assert "Pair rows: 0" in summary
+    client.stream_chunks.assert_called_once_with(input_file)
+    assessor.evaluate_supplied.assert_awaited_once()

--- a/tests/unit/domain/references/deduplication/test_evaluation_runner.py
+++ b/tests/unit/domain/references/deduplication/test_evaluation_runner.py
@@ -258,8 +258,8 @@ async def test_run_writes_complete_reviewable_bundle():
 
 
 @pytest.mark.asyncio
-async def test_run_builds_yearless_and_fuzzy_only_assessment_inputs():
-    """Frozen inputs preserve scoring data while controlling retrieval routes."""
+async def test_run_builds_yearless_and_union_assessment_inputs():
+    """Frozen inputs preserve scoring data and query the production route union."""
     held_reference_id = uuid7()
     source = (
         _line(
@@ -269,7 +269,7 @@ async def test_run_builds_yearless_and_fuzzy_only_assessment_inputs():
             excluded_reference_ids=[str(held_reference_id)],
         )
         + "\n"
-        + _line("fuzzy-only")
+        + _line("labelled-fuzzy")
     ).encode()
     repository, _uploaded = _blob_repository(source)
     assessor = AsyncMock()
@@ -306,7 +306,14 @@ async def test_run_builds_yearless_and_fuzzy_only_assessment_inputs():
         is ExternalIdentifierType.OPEN_ALEX
     )
     assert second_incoming.identifiers[0].identifier == "W1"
-    assert second_selection.identifiers == []
+    # route_applicability is analysis metadata, not query-shaping input.
+    # The runner sends full input so production policy records real provenance.
+    assert (
+        second_selection.identifiers[0].identifier_type
+        is ExternalIdentifierType.OPEN_ALEX
+    )
+    assert second_selection.title == "Study labelled-fuzzy"
+    assert second_selection.publication_year == 2024
     assert all(
         call.kwargs == {"retrieval_policy": policy, "k": 10}
         for call in assessor.evaluate_supplied.await_args_list

--- a/tests/unit/domain/references/deduplication/test_evaluation_runner.py
+++ b/tests/unit/domain/references/deduplication/test_evaluation_runner.py
@@ -9,14 +9,22 @@ import pytest
 
 from app.core.exceptions import DeduplicationError
 from app.domain.references.models.models import (
+    Candidate,
+    CandidateElasticsearchRoute,
+    CandidateIdentifier,
+    CandidateIdentifierRoute,
     CandidateSelectionDiagnostics,
     CandidateSelectionResult,
     DeduperMetadata,
     DeduplicationAssessment,
     DeduplicationAssessmentOutcome,
+    DeduplicationFieldComparison,
+    DeduplicationFieldStatus,
+    DeduplicationPairResult,
     ExternalIdentifierType,
     InputSearchability,
     RetrievalPolicyName,
+    ScoredDeduplicationCandidate,
 )
 from app.domain.references.services.deduplication_evaluation_runner import (
     DeduplicationEvaluationRunner,
@@ -368,3 +376,123 @@ async def test_evaluate_line_does_not_turn_cancellation_into_a_record_failure():
             retrieval_policy=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
             k=10,
         )
+
+
+@pytest.mark.asyncio
+async def test_project_pair_results_preserves_correlation_routes_and_evidence():
+    """Pair rows are a pure projection of the completed assessment."""
+    es_candidate_id = uuid7()
+    identifier_candidate_id = uuid7()
+    candidates = [
+        ScoredDeduplicationCandidate(
+            candidate=Candidate(
+                reference_id=es_candidate_id,
+                rank=1,
+                routes=[
+                    CandidateElasticsearchRoute(
+                        policy="soft_year_decay_year_optional_v1",
+                        rank=2,
+                        score=8.5,
+                    )
+                ],
+            ),
+            pair_result=DeduplicationPairResult(
+                probability=0.91,
+                field_comparisons={
+                    "title": DeduplicationFieldComparison(
+                        incoming_value="A study",
+                        candidate_value="A Study",
+                        status=DeduplicationFieldStatus.MATCH,
+                        score=0.98,
+                    )
+                },
+                suggested_label="duplicate",
+            ),
+            clears_threshold=True,
+        ),
+        ScoredDeduplicationCandidate(
+            candidate=Candidate(
+                reference_id=identifier_candidate_id,
+                rank=2,
+                routes=[
+                    CandidateIdentifierRoute(
+                        matched_identifiers=[
+                            CandidateIdentifier(
+                                identifier="W1",
+                                identifier_type=ExternalIdentifierType.OPEN_ALEX,
+                            )
+                        ]
+                    )
+                ],
+            ),
+            pair_result=DeduplicationPairResult(
+                unscorable_reason="insufficient comparable fields"
+            ),
+            clears_threshold=None,
+        ),
+    ]
+    assessor = AsyncMock()
+
+    def assess(incoming, _selection, **_kwargs):
+        assessment = _assessment(incoming.id)
+        return assessment.model_copy(
+            update={
+                "candidate_selection": assessment.candidate_selection.model_copy(
+                    update={"candidates": [item.candidate for item in candidates]}
+                ),
+                "scored_candidates": candidates,
+                "unscorable_candidate_ids": [identifier_candidate_id],
+            }
+        )
+
+    assessor.evaluate_supplied.side_effect = assess
+    runner = DeduplicationEvaluationRunner(assessor=assessor)
+    record_result = await runner.evaluate_line(
+        run_id=uuid7(),
+        line=_valid_line("pair-projection"),
+        line_number=42,
+        retrieval_policy=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+        k=10,
+    )
+
+    pair_results = runner.project_pair_results(record_result)
+
+    assert [row.run_id for row in pair_results] == [record_result.run_id] * 2
+    assert [row.query_id for row in pair_results] == ["pair-projection"] * 2
+    assert [row.line_number for row in pair_results] == [42, 42]
+    assert [row.incoming_reference_id for row in pair_results] == [
+        record_result.incoming_reference_id
+    ] * 2
+    assert [row.candidate_reference_id for row in pair_results] == [
+        es_candidate_id,
+        identifier_candidate_id,
+    ]
+    assert [row.retrieval_rank for row in pair_results] == [1, 2]
+    assert [row.retrieval_routes for row in pair_results] == [
+        candidates[0].candidate.routes,
+        candidates[1].candidate.routes,
+    ]
+    assert [row.pair_result for row in pair_results] == [
+        candidates[0].pair_result,
+        candidates[1].pair_result,
+    ]
+    assert [row.threshold for row in pair_results] == [0.85, 0.85]
+    assert [row.clears_threshold for row in pair_results] == [True, None]
+    assessor.evaluate_supplied.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_project_pair_results_ignores_non_assessed_record():
+    """Input failures do not contribute rows to the pair artifact."""
+    assessor = AsyncMock()
+    runner = DeduplicationEvaluationRunner(assessor=assessor)
+    record_result = await runner.evaluate_line(
+        run_id=uuid7(),
+        line="not json",
+        line_number=7,
+        retrieval_policy=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+        k=10,
+    )
+
+    assert runner.project_pair_results(record_result) == []
+    assessor.evaluate_supplied.assert_not_awaited()

--- a/tests/unit/domain/references/deduplication/test_evaluation_runner.py
+++ b/tests/unit/domain/references/deduplication/test_evaluation_runner.py
@@ -1,11 +1,13 @@
 """Tests for the deduplication evaluation runner."""
 
+import asyncio
 import json
 from unittest.mock import AsyncMock
 from uuid import uuid7
 
 import pytest
 
+from app.core.exceptions import DeduplicationError
 from app.domain.references.models.models import (
     CandidateSelectionDiagnostics,
     CandidateSelectionResult,
@@ -282,3 +284,87 @@ async def test_evaluate_line_records_uncorrelatable_schema_failure(line):
     assert result.error is not None
     assert result.error.code == "invalid_record"
     assessor.evaluate_supplied.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_evaluate_lines_records_assessor_failure_and_continues():
+    """A retrieval, hydration or scoring failure must remain local to its record."""
+    call_count = 0
+
+    async def assess(incoming, _selection, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            msg = "candidate hydration failed"
+            raise DeduplicationError(msg)
+        return _assessment(incoming.id)
+
+    assessor = AsyncMock()
+    assessor.evaluate_supplied.side_effect = assess
+    runner = DeduplicationEvaluationRunner(assessor=assessor)
+    lines = AsyncMock()
+    lines.__aiter__.return_value = [
+        _valid_line("first"),
+        _valid_line("failed"),
+        _valid_line("last"),
+    ]
+
+    results = [
+        result
+        async for result in runner.evaluate_lines(
+            run_id=uuid7(),
+            lines=lines,
+            retrieval_policy=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+            k=10,
+        )
+    ]
+
+    assert [result.status for result in results] == [
+        "assessed",
+        "evaluation_failed",
+        "assessed",
+    ]
+    failed = results[1]
+    assert failed.query_id == "failed"
+    assert failed.incoming_reference_id is not None
+    assert failed.assessment is None
+    assert failed.error is not None
+    assert failed.error.code == "evaluation_failed"
+    assert failed.error.message == (
+        "Evaluation failed (DeduplicationError): candidate hydration failed"
+    )
+    assert assessor.evaluate_supplied.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_evaluate_line_propagates_unexpected_assessor_failure():
+    """Systemic failures and programming errors must fail the run."""
+    assessor = AsyncMock()
+    assessor.evaluate_supplied.side_effect = ValueError("unexpected scorer defect")
+    runner = DeduplicationEvaluationRunner(assessor=assessor)
+
+    with pytest.raises(ValueError, match="unexpected scorer defect"):
+        await runner.evaluate_line(
+            run_id=uuid7(),
+            line=_valid_line("unexpected-failure"),
+            line_number=1,
+            retrieval_policy=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+            k=10,
+        )
+
+
+@pytest.mark.asyncio
+async def test_evaluate_line_does_not_turn_cancellation_into_a_record_failure():
+    """Run cancellation must still stop evaluation immediately."""
+    assessor = AsyncMock()
+    assessor.evaluate_supplied.side_effect = asyncio.CancelledError
+    runner = DeduplicationEvaluationRunner(assessor=assessor)
+
+    with pytest.raises(asyncio.CancelledError):
+        await runner.evaluate_line(
+            run_id=uuid7(),
+            line=_valid_line("cancelled"),
+            line_number=1,
+            retrieval_policy=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+            k=10,
+        )

--- a/tests/unit/domain/references/deduplication/test_evaluation_runner.py
+++ b/tests/unit/domain/references/deduplication/test_evaluation_runner.py
@@ -7,24 +7,19 @@ from datetime import UTC, datetime
 from io import BytesIO
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock
-from uuid import UUID, uuid7
+from uuid import uuid7
 
 import pytest
 
-from app.core.exceptions import BlobStorageError, DeduplicationError
+from app.core.exceptions import DeduplicationError
 from app.domain.references.models.models import (
     Candidate,
     CandidateElasticsearchRoute,
-    CandidateIdentifier,
-    CandidateIdentifierRoute,
     CandidateSelectionDiagnostics,
-    CandidateSelectionInput,
     CandidateSelectionResult,
     DeduperMetadata,
     DeduplicationAssessment,
     DeduplicationAssessmentOutcome,
-    DeduplicationFieldComparison,
-    DeduplicationFieldStatus,
     DeduplicationPairResult,
     ExternalIdentifierType,
     InputSearchability,
@@ -33,29 +28,98 @@ from app.domain.references.models.models import (
 )
 from app.domain.references.services.deduplication_evaluation_runner import (
     DeduplicationEvaluationRunner,
-    EvaluationPairResult,
-    EvaluationRecordResult,
-    EvaluationRecordStatus,
     EvaluationRunConfiguration,
 )
 from app.persistence.blob.models import BlobStorageFile, BlobStorageLocation
 from app.persistence.blob.repository import BlobRepository
 
 
-def _assessment(
-    incoming_reference_id,
-    retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
-):
+def _configuration(
+    policy: RetrievalPolicyName = RetrievalPolicyName.CANDIDATE_SELECTION_V1,
+) -> EvaluationRunConfiguration:
+    return EvaluationRunConfiguration(
+        dataset_version="retrieval-query-set/v1",
+        environment="test",
+        corpus_observed_at=datetime(2026, 8, 10, 3, 30, tzinfo=UTC),
+        elasticsearch_index_version="reference_v3",
+        code_commit="test-commit",
+        retrieval_policy=policy,
+        k=10,
+        deduper=DeduperMetadata(
+            package_version="fake-1",
+            configuration_hash="fake-config",
+            threshold=0.85,
+        ),
+    )
+
+
+def _line(
+    query_id: str,
+    *,
+    year: int | None = 2024,
+    route_applicability: list[str] | None = None,
+    input_identifiers: list[str] | None = None,
+    excluded_reference_ids: list[str] | None = None,
+) -> str:
+    return json.dumps(
+        {
+            "query_id": query_id,
+            "input_reference": {
+                "title": f"Study {query_id}",
+                "authors": ["First Author", "Middle Author", "Last Author"],
+                "year": year,
+            },
+            "input_identifiers": input_identifiers or ["open_alex:W1"],
+            "route_applicability": route_applicability or ["fuzzy"],
+            "excluded_reference_ids": excluded_reference_ids or [],
+            "dataset_version": "retrieval-query-set/v1",
+        }
+    )
+
+
+def _assessment(incoming_id, *, with_pairs: bool = False):
+    candidates = []
+    scored_candidates = []
+    if with_pairs:
+        for rank, probability, clears_threshold in (
+            (1, 0.91, True),
+            (2, 0.51, False),
+            (3, None, None),
+        ):
+            candidate = Candidate(
+                reference_id=uuid7(),
+                rank=rank,
+                routes=[
+                    CandidateElasticsearchRoute(
+                        policy="candidate_selection_v1",
+                        rank=rank,
+                        score=float(10 - rank),
+                    )
+                ],
+            )
+            candidates.append(candidate)
+            scored_candidates.append(
+                ScoredDeduplicationCandidate(
+                    candidate=candidate,
+                    pair_result=(
+                        DeduplicationPairResult(probability=probability)
+                        if probability is not None
+                        else DeduplicationPairResult(unscorable_reason="missing title")
+                    ),
+                    clears_threshold=clears_threshold,
+                )
+            )
     return DeduplicationAssessment(
-        incoming_reference_id=incoming_reference_id,
+        incoming_reference_id=incoming_id,
         candidate_selection=CandidateSelectionResult(
-            retrieval_policy=retrieval_policy,
+            retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
             index_version="reference_v3",
             k_requested=10,
             input_searchability=InputSearchability(
                 searchable=True,
                 reason="The input has a title and authors.",
             ),
+            candidates=candidates,
             diagnostics=CandidateSelectionDiagnostics(),
         ),
         deduper=DeduperMetadata(
@@ -63,568 +127,26 @@ def _assessment(
             configuration_hash="fake-config",
             threshold=0.85,
         ),
-        outcome=DeduplicationAssessmentOutcome.PROPOSE_CANONICAL,
-    )
-
-
-def _assessment_with_pair_evidence(
-    incoming_reference_id,
-    retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
-):
-    assessment = _assessment(incoming_reference_id, retrieval_policy)
-    candidates = [
-        ScoredDeduplicationCandidate(
-            candidate=Candidate(
-                reference_id=uuid7(),
-                rank=rank,
-                routes=[
-                    CandidateElasticsearchRoute(
-                        policy=retrieval_policy.value,
-                        rank=rank,
-                        score=score,
-                    )
-                ],
-            ),
-            pair_result=(
-                DeduplicationPairResult(probability=probability)
-                if probability is not None
-                else DeduplicationPairResult(unscorable_reason="missing title")
-            ),
-            clears_threshold=clears_threshold,
-        )
-        for rank, score, probability, clears_threshold in (
-            (1, 9.1, 0.91, True),
-            (2, 5.1, 0.51, False),
-            (3, 2.1, None, None),
-        )
-    ]
-    return assessment.model_copy(
-        update={
-            "candidate_selection": assessment.candidate_selection.model_copy(
-                update={"candidates": [item.candidate for item in candidates]}
-            ),
-            "scored_candidates": candidates,
-            "outcome": DeduplicationAssessmentOutcome.NO_PROPOSAL,
-            "threshold_clearing_candidate_ids": [candidates[0].candidate.reference_id],
-            "unscorable_candidate_ids": [candidates[2].candidate.reference_id],
-        }
-    )
-
-
-def _run_configuration() -> EvaluationRunConfiguration:
-    return EvaluationRunConfiguration(
-        dataset_version="retrieval-query-set/v1",
-        environment="test",
-        corpus_observed_at=datetime(2026, 8, 10, 3, 30, tzinfo=UTC),
-        elasticsearch_index_version="reference_v3",
-        code_commit="test-commit",
-        retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
-        k=10,
-        deduper=DeduperMetadata(
-            package_version="fake-1",
-            configuration_hash="fake-config",
-            threshold=0.85,
+        scored_candidates=scored_candidates,
+        outcome=(
+            DeduplicationAssessmentOutcome.NO_PROPOSAL
+            if with_pairs
+            else DeduplicationAssessmentOutcome.PROPOSE_CANONICAL
         ),
     )
 
 
-def _expected_artifact(
-    file: BlobStorageFile, content: bytes, schema_version: str
-) -> dict[str, object]:
-    return {
-        "uri": file.to_uri(),
-        "schema_version": schema_version,
-        "byte_size": len(content),
-        "sha256": hashlib.sha256(content).hexdigest(),
-    }
+def _blob_repository(source: bytes) -> tuple[BlobRepository, dict[str, bytes]]:
+    async def chunks():
+        midpoint = len(source) // 2
+        for chunk in (source[:midpoint], source[midpoint:]):
+            yield chunk
 
-
-def _valid_line(query_id: str, **updates: object) -> str:
-    record: dict[str, object] = {
-        "query_id": query_id,
-        "input_reference": {
-            "title": "A study",
-            "authors": ["First Author"],
-            "year": 2024,
-        },
-        "input_identifiers": ["open_alex:W1"],
-        "route_applicability": ["fuzzy"],
-        "excluded_reference_ids": [],
-        "dataset_version": "retrieval-query-set/v1",
-    }
-    record.update(updates)
-    return json.dumps(record)
-
-
-@pytest.mark.asyncio
-async def test_evaluate_line_assesses_yearless_supplied_record_with_correlation():
-    """A frozen row is assessed without first resolving it to a held record."""
-    run_id = uuid7()
-    held_reference_id = uuid7()
-    assessor = AsyncMock()
-    assessor.evaluate_supplied.side_effect = lambda incoming, _selection, **_kwargs: (
-        _assessment(
-            incoming.id,
-            RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
-        )
-    )
-    runner = DeduplicationEvaluationRunner(assessor=assessor)
-    line = f"""{{
-        "query_id": "oa-km:W1:W2",
-        "input_reference": {{
-            "title": "A yearless study",
-            "authors": ["First Author", "Middle Author", "Last Author"],
-            "year": null
-        }},
-        "input_identifiers": ["open_alex:W1"],
-        "route_applicability": ["identifier", "fuzzy"],
-        "excluded_reference_ids": ["{held_reference_id}"],
-        "dataset_version": "retrieval-query-set/v1",
-        "source_group": "openalex"
-    }}"""
-
-    result = await runner.evaluate_line(
-        run_id=run_id,
-        line=line,
-        line_number=42,
-        retrieval_policy=RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
-        k=10,
-    )
-
-    assert result.incoming_reference_id is not None
-    assert result == EvaluationRecordResult(
-        run_id=run_id,
-        query_id="oa-km:W1:W2",
-        line_number=42,
-        status=EvaluationRecordStatus.ASSESSED,
-        incoming_reference_id=result.incoming_reference_id,
-        assessment=_assessment(
-            result.incoming_reference_id,
-            RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
-        ),
-    )
-    incoming, selection = assessor.evaluate_supplied.await_args.args
-    biblio = incoming.enhancements[0].content
-    assert {
-        "id": incoming.id,
-        "id_version": incoming.id.version,
-        "visibility": incoming.visibility,
-        "identifier": (
-            incoming.identifiers[0].identifier_type,
-            incoming.identifiers[0].identifier,
-        ),
-        "enhancement_source": incoming.enhancements[0].source,
-        "title": biblio.title,
-        "publication_year": biblio.publication_year,
-        "authors": [
-            (author.display_name, author.position) for author in biblio.authorship
-        ],
-    } == {
-        "id": result.incoming_reference_id,
-        "id_version": 7,
-        "visibility": "public",
-        "identifier": (ExternalIdentifierType.OPEN_ALEX, "W1"),
-        "enhancement_source": "retrieval-query-set/v1",
-        "title": "A yearless study",
-        "publication_year": None,
-        "authors": [
-            ("First Author", "first"),
-            ("Middle Author", "middle"),
-            ("Last Author", "last"),
-        ],
-    }
-    assert selection == CandidateSelectionInput(
-        title="A yearless study",
-        authors=["First Author", "Middle Author", "Last Author"],
-        publication_year=None,
-        identifiers=[
-            CandidateIdentifier(
-                identifier="W1",
-                identifier_type=ExternalIdentifierType.OPEN_ALEX,
-            )
-        ],
-        excluded_reference_id=held_reference_id,
-    )
-    assert assessor.evaluate_supplied.await_args.kwargs == {
-        "retrieval_policy": RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
-        "k": 10,
-    }
-
-
-@pytest.mark.asyncio
-async def test_evaluate_line_withholds_identifiers_from_fuzzy_only_query():
-    """Dataset identifiers remain scorer input without leaking into retrieval."""
-    assessor = AsyncMock()
-    assessor.evaluate_supplied.side_effect = lambda incoming, _selection, **_kwargs: (
-        _assessment(incoming.id)
-    )
-    runner = DeduplicationEvaluationRunner(assessor=assessor)
-
-    await runner.evaluate_line(
-        run_id=uuid7(),
-        line="""{
-            "query_id": "oa-km:W3:W4",
-            "input_reference": {
-                "title": "A fuzzy-only study",
-                "authors": ["First Author"],
-                "year": 2024
-            },
-            "input_identifiers": ["open_alex:W3"],
-            "route_applicability": ["fuzzy"],
-            "excluded_reference_ids": [],
-            "dataset_version": "retrieval-query-set/v1"
-        }""",
-        line_number=1,
-        retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
-        k=10,
-    )
-
-    incoming, selection = assessor.evaluate_supplied.await_args.args
-    assert incoming.identifiers[0].identifier == "W3"
-    assert selection.identifiers == []
-
-
-@pytest.mark.asyncio
-async def test_evaluate_lines_records_invalid_json_and_continues():
-    """Every non-blank physical line gets an envelope without aborting later rows."""
-    run_id = uuid7()
-    assessor = AsyncMock()
-    assessor.evaluate_supplied.side_effect = lambda incoming, _selection, **_kwargs: (
-        _assessment(incoming.id)
-    )
-    runner = DeduplicationEvaluationRunner(assessor=assessor)
-    lines = AsyncMock()
-    lines.__aiter__.return_value = [
-        _valid_line("first"),
-        "   ",
-        '{"query_id": "broken"',
-        _valid_line("last"),
-    ]
-
-    results = [
-        result
-        async for result in runner.evaluate_lines(
-            run_id=run_id,
-            lines=lines,
-            retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
-            k=10,
-        )
-    ]
-
-    assert [result.line_number for result in results] == [1, 3, 4]
-    assert [result.status for result in results] == [
-        "assessed",
-        "input_invalid",
-        "assessed",
-    ]
-    invalid = results[1]
-    assert invalid.run_id == run_id
-    assert invalid.query_id is None
-    assert invalid.incoming_reference_id is None
-    assert invalid.assessment is None
-    assert invalid.error is not None
-    assert invalid.error.code == "invalid_json"
-    assert "Invalid JSON" in invalid.error.message
-    assert assessor.evaluate_supplied.await_count == 2
-
-
-@pytest.mark.asyncio
-async def test_evaluate_line_rejects_multiple_self_exclusions():
-    """The singular assessment query must not silently choose one exclusion."""
-    assessor = AsyncMock()
-    runner = DeduplicationEvaluationRunner(assessor=assessor)
-
-    result = await runner.evaluate_line(
-        run_id=uuid7(),
-        line=_valid_line(
-            "too-many-exclusions",
-            excluded_reference_ids=[str(uuid7()), str(uuid7())],
-        ),
-        line_number=7,
-        retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
-        k=10,
-    )
-
-    assert result.query_id == "too-many-exclusions"
-    assert result.status == "input_invalid"
-    assert result.error is not None
-    assert result.error.code == "invalid_record"
-    assert "excluded_reference_ids" in result.error.message
-    assessor.evaluate_supplied.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_evaluate_line_records_identifier_conversion_failure():
-    """An invalid SDK identifier is a record error, not a run failure."""
-    assessor = AsyncMock()
-    runner = DeduplicationEvaluationRunner(assessor=assessor)
-
-    result = await runner.evaluate_line(
-        run_id=uuid7(),
-        line=_valid_line("bad-identifier", input_identifiers=["unknown:value"]),
-        line_number=8,
-        retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
-        k=10,
-    )
-
-    assert result.query_id == "bad-identifier"
-    assert result.status == "input_invalid"
-    assert result.error is not None
-    assert result.error.code == "invalid_record"
-    assert "Unknown identifier type" in result.error.message
-    assessor.evaluate_supplied.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "line",
-    [
-        pytest.param("[]", id="non-object"),
-        pytest.param('{"query_id": 42}', id="non-string-query-id"),
-    ],
-)
-async def test_evaluate_line_records_uncorrelatable_schema_failure(line):
-    """Invalid object shapes still produce an envelope without a false query key."""
-    assessor = AsyncMock()
-    runner = DeduplicationEvaluationRunner(assessor=assessor)
-
-    result = await runner.evaluate_line(
-        run_id=uuid7(),
-        line=line,
-        line_number=9,
-        retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
-        k=10,
-    )
-
-    assert result.query_id is None
-    assert result.status == "input_invalid"
-    assert result.error is not None
-    assert result.error.code == "invalid_record"
-    assessor.evaluate_supplied.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_evaluate_lines_records_assessor_failure_and_continues():
-    """A retrieval, hydration or scoring failure must remain local to its record."""
-    call_count = 0
-
-    async def assess(incoming, _selection, **_kwargs):
-        nonlocal call_count
-        call_count += 1
-        if call_count == 2:
-            msg = "candidate hydration failed"
-            raise DeduplicationError(msg)
-        return _assessment(incoming.id)
-
-    assessor = AsyncMock()
-    assessor.evaluate_supplied.side_effect = assess
-    runner = DeduplicationEvaluationRunner(assessor=assessor)
-    lines = AsyncMock()
-    lines.__aiter__.return_value = [
-        _valid_line("first"),
-        _valid_line("failed"),
-        _valid_line("last"),
-    ]
-
-    results = [
-        result
-        async for result in runner.evaluate_lines(
-            run_id=uuid7(),
-            lines=lines,
-            retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
-            k=10,
-        )
-    ]
-
-    assert [result.status for result in results] == [
-        "assessed",
-        "evaluation_failed",
-        "assessed",
-    ]
-    failed = results[1]
-    assert failed.query_id == "failed"
-    assert failed.incoming_reference_id is not None
-    assert failed.assessment is None
-    assert failed.error is not None
-    assert failed.error.code == "evaluation_failed"
-    assert failed.error.message == (
-        "Evaluation failed (DeduplicationError): candidate hydration failed"
-    )
-    assert assessor.evaluate_supplied.await_count == 3
-
-
-@pytest.mark.asyncio
-async def test_evaluate_line_propagates_unexpected_assessor_failure():
-    """Systemic failures and programming errors must fail the run."""
-    assessor = AsyncMock()
-    assessor.evaluate_supplied.side_effect = ValueError("unexpected scorer defect")
-    runner = DeduplicationEvaluationRunner(assessor=assessor)
-
-    with pytest.raises(ValueError, match="unexpected scorer defect"):
-        await runner.evaluate_line(
-            run_id=uuid7(),
-            line=_valid_line("unexpected-failure"),
-            line_number=1,
-            retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
-            k=10,
-        )
-
-
-@pytest.mark.asyncio
-async def test_evaluate_line_does_not_turn_cancellation_into_a_record_failure():
-    """Run cancellation must still stop evaluation immediately."""
-    assessor = AsyncMock()
-    assessor.evaluate_supplied.side_effect = asyncio.CancelledError
-    runner = DeduplicationEvaluationRunner(assessor=assessor)
-
-    with pytest.raises(asyncio.CancelledError):
-        await runner.evaluate_line(
-            run_id=uuid7(),
-            line=_valid_line("cancelled"),
-            line_number=1,
-            retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
-            k=10,
-        )
-
-
-@pytest.mark.asyncio
-async def test_project_pair_results_preserves_correlation_routes_and_evidence():
-    """Pair rows are a pure projection of the completed assessment."""
-    es_candidate_id = uuid7()
-    identifier_candidate_id = uuid7()
-    candidates = [
-        ScoredDeduplicationCandidate(
-            candidate=Candidate(
-                reference_id=es_candidate_id,
-                rank=1,
-                routes=[
-                    CandidateElasticsearchRoute(
-                        policy="candidate_selection_v1",
-                        rank=2,
-                        score=8.5,
-                    )
-                ],
-            ),
-            pair_result=DeduplicationPairResult(
-                probability=0.91,
-                field_comparisons={
-                    "title": DeduplicationFieldComparison(
-                        incoming_value="A study",
-                        candidate_value="A Study",
-                        status=DeduplicationFieldStatus.MATCH,
-                        score=0.98,
-                    )
-                },
-                suggested_label="duplicate",
-            ),
-            clears_threshold=True,
-        ),
-        ScoredDeduplicationCandidate(
-            candidate=Candidate(
-                reference_id=identifier_candidate_id,
-                rank=2,
-                routes=[
-                    CandidateIdentifierRoute(
-                        matched_identifiers=[
-                            CandidateIdentifier(
-                                identifier="W1",
-                                identifier_type=ExternalIdentifierType.OPEN_ALEX,
-                            )
-                        ]
-                    )
-                ],
-            ),
-            pair_result=DeduplicationPairResult(
-                unscorable_reason="insufficient comparable fields"
-            ),
-            clears_threshold=None,
-        ),
-    ]
-    assessor = AsyncMock()
-
-    def assess(incoming, _selection, **_kwargs):
-        assessment = _assessment(incoming.id)
-        return assessment.model_copy(
-            update={
-                "candidate_selection": assessment.candidate_selection.model_copy(
-                    update={"candidates": [item.candidate for item in candidates]}
-                ),
-                "scored_candidates": candidates,
-                "unscorable_candidate_ids": [identifier_candidate_id],
-            }
-        )
-
-    assessor.evaluate_supplied.side_effect = assess
-    runner = DeduplicationEvaluationRunner(assessor=assessor)
-    record_result = await runner.evaluate_line(
-        run_id=uuid7(),
-        line=_valid_line("pair-projection"),
-        line_number=42,
-        retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
-        k=10,
-    )
-
-    pair_results = runner.project_pair_results(record_result)
-
-    incoming_reference_id = cast(UUID, record_result.incoming_reference_id)
-    assert pair_results == [
-        EvaluationPairResult(
-            run_id=record_result.run_id,
-            query_id="pair-projection",
-            line_number=42,
-            incoming_reference_id=incoming_reference_id,
-            candidate_reference_id=item.candidate.reference_id,
-            retrieval_rank=item.candidate.rank,
-            retrieval_routes=item.candidate.routes,
-            pair_result=item.pair_result,
-            threshold=0.85,
-            clears_threshold=item.clears_threshold,
-        )
-        for item in candidates
-    ]
-    assessor.evaluate_supplied.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_project_pair_results_ignores_non_assessed_record():
-    """Input failures do not contribute rows to the pair artifact."""
-    assessor = AsyncMock()
-    runner = DeduplicationEvaluationRunner(assessor=assessor)
-    record_result = await runner.evaluate_line(
-        run_id=uuid7(),
-        line="not json",
-        line_number=7,
-        retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
-        k=10,
-    )
-
-    assert runner.project_pair_results(record_result) == []
-    assessor.evaluate_supplied.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_run_preserves_input_and_writes_complete_bundle(monkeypatch):
-    """A blob run hashes exact input bytes and writes its completion marker last."""
-    run_id = uuid7()
-    input_file = BlobStorageFile.from_uri(
-        "azure://dedup-evals/datasets/retrieval-query-set/v1/records.jsonl"
-    )
-    source_bytes = (_valid_line("assessed") + "\nnot json").encode()
-    chunks = AsyncMock()
-    chunks.__aiter__.return_value = [source_bytes[:17], source_bytes[17:]]
-    client = MagicMock()
-    client.stream_chunks.return_value = chunks
-    blob_repository = BlobRepository()
-    monkeypatch.setattr(
-        blob_repository, "_preload_config", AsyncMock(return_value=client)
-    )
     uploaded: dict[str, bytes] = {}
-    upload_order: list[str] = []
 
     async def upload(content, path, filename, **_kwargs):
         assert isinstance(content, BytesIO)
         uploaded[filename] = content.getvalue()
-        upload_order.append(filename)
         return BlobStorageFile(
             location=BlobStorageLocation.MINIO,
             container="test",
@@ -632,35 +154,36 @@ async def test_run_preserves_input_and_writes_complete_bundle(monkeypatch):
             filename=filename,
         )
 
-    blob_repository.upload_file_to_blob_storage = AsyncMock(side_effect=upload)
+    repository = MagicMock(spec=BlobRepository)
+    repository.stream_chunks_from_blob_storage.return_value = chunks()
+    repository.upload_file_to_blob_storage = AsyncMock(side_effect=upload)
+    return repository, uploaded
+
+
+@pytest.mark.asyncio
+async def test_run_writes_complete_reviewable_bundle():
+    """The public run contract preserves input identity and writes manifest last."""
+    run_id = uuid7()
+    input_file = BlobStorageFile.from_uri(
+        "azure://dedup-evals/datasets/retrieval-query-set/v1/records.jsonl"
+    )
+    source = (_line("assessed") + "\nnot json\n").encode()
+    repository, uploaded = _blob_repository(source)
     assessor = AsyncMock()
     assessor.evaluate_supplied.side_effect = lambda incoming, *_args, **_kwargs: (
-        _assessment_with_pair_evidence(incoming.id, _kwargs["retrieval_policy"])
+        _assessment(incoming.id, with_pairs=True)
     )
-    runner = DeduplicationEvaluationRunner(assessor=assessor)
-    configuration = _run_configuration()
 
-    artifacts = await runner.run(
+    artifacts = await DeduplicationEvaluationRunner(assessor=assessor).run(
         run_id=run_id,
         input_file=input_file,
-        blob_repository=blob_repository,
-        configuration=configuration,
+        blob_repository=repository,
+        configuration=_configuration(),
     )
 
-    input_sha256 = hashlib.sha256(source_bytes).hexdigest()
-    assert (
-        artifacts.run_id,
-        artifacts.input_file,
-        artifacts.input_byte_size,
-        artifacts.input_sha256,
-    ) == (
-        run_id,
-        input_file,
-        len(source_bytes),
-        input_sha256,
-    )
-    assert upload_order == [
-        "record-results.jsonl",
+    expected_path = f"deduplication_evaluation/{run_id}"
+    upload = cast(AsyncMock, repository.upload_file_to_blob_storage)
+    assert [call.kwargs["filename"] for call in upload.await_args_list] == [
         "record-results.jsonl",
         "pair-results.jsonl",
         "summary.md",
@@ -674,113 +197,202 @@ async def test_run_preserves_input_and_writes_complete_bundle(monkeypatch):
             artifacts.summary_file,
             artifacts.manifest_file,
         )
-    } == {filename: f"deduplication_evaluation/{run_id}" for filename in uploaded}
-    record_rows = [
-        json.loads(line) for line in uploaded["record-results.jsonl"].splitlines()
+    } == {filename: expected_path for filename in uploaded}
+    assert artifacts.input_file == input_file
+    assert artifacts.input_byte_size == len(source)
+    assert artifacts.input_sha256 == hashlib.sha256(source).hexdigest()
+
+    records = [json.loads(row) for row in uploaded["record-results.jsonl"].splitlines()]
+    pairs = [json.loads(row) for row in uploaded["pair-results.jsonl"].splitlines()]
+    assert [
+        (row["query_id"], row["line_number"], row["status"]) for row in records
+    ] == [
+        ("assessed", 1, "assessed"),
+        (None, 2, "input_invalid"),
     ]
-    assert [row["status"] for row in record_rows] == ["assessed", "input_invalid"]
-    assert (
-        record_rows[0]["assessment"]["candidate_selection"]["retrieval_policy"]
-        == configuration.retrieval_policy
-    )
-    pair_rows = [
-        json.loads(line) for line in uploaded["pair-results.jsonl"].splitlines()
-    ]
-    assert [row["clears_threshold"] for row in pair_rows] == [True, False, None]
-    expected_summary = (
-        "# Deduplication evaluation summary\n\n"
-        f"Run ID: `{run_id}`\n\n"
-        f"Input: `{input_file.to_uri()}`\n\n"
-        f"Input bytes: {len(source_bytes)}\n\n"
-        f"Input SHA-256: `{input_sha256}`\n\n"
-        "Records: 2\n\n"
-        "Assessed records: 1\n\n"
-        "Invalid input records: 1\n\n"
-        "Evaluation-failed records: 0\n\n"
-        "Pair rows: 3\n\n"
-        "## Assessment outcomes\n\n"
-        "- `propose_canonical`: 0\n"
-        "- `propose_duplicate`: 0\n"
-        "- `no_proposal`: 1\n\n"
-        "## Pair evidence\n\n"
-        "- Clears threshold: 1\n"
-        "- Below threshold: 1\n"
-        "- Unscorable: 1\n"
-    )
-    assert uploaded["summary.md"].decode() == expected_summary
-    assert json.loads(uploaded["manifest.json"]) == {
-        "schema_version": "deduplication-evaluation-manifest/v1",
-        "run_id": str(run_id),
-        "input": {
-            "uri": input_file.to_uri(),
-            "dataset_version": "retrieval-query-set/v1",
-            "byte_size": len(source_bytes),
-            "sha256": input_sha256,
-        },
-        "configuration": configuration.model_dump(mode="json"),
-        "counts": {
-            "record_statuses": {
-                "assessed": 1,
-                "input_invalid": 1,
-                "evaluation_failed": 0,
-            },
-            "pair_rows": 3,
-        },
-        "artifacts": {
-            "record-results.jsonl": _expected_artifact(
-                artifacts.record_results_file,
-                uploaded["record-results.jsonl"],
-                "evaluation-record-result/v1",
-            ),
-            "pair-results.jsonl": _expected_artifact(
-                artifacts.pair_results_file,
-                uploaded["pair-results.jsonl"],
-                "evaluation-pair-result/v1",
-            ),
-            "summary.md": _expected_artifact(
-                artifacts.summary_file,
-                uploaded["summary.md"],
-                "deduplication-evaluation-summary/v1",
-            ),
-        },
+    assert records[1]["error"]["code"] == "invalid_json"
+    assert [row["clears_threshold"] for row in pairs] == [True, False, None]
+    assert all(row["query_id"] == "assessed" for row in pairs)
+    assert pairs[0]["retrieval_routes"][0]["policy"] == "candidate_selection_v1"
+    assert pairs[0]["pair_result"]["probability"] == 0.91
+
+    summary = uploaded["summary.md"].decode()
+    for expected in (
+        "Assessed records: 1",
+        "Invalid input records: 1",
+        "Evaluation-failed records: 0",
+        "- `no_proposal`: 1",
+        "- Clears threshold: 1",
+        "- Below threshold: 1",
+        "- Unscorable: 1",
+    ):
+        assert expected in summary
+
+    manifest = json.loads(uploaded["manifest.json"])
+    assert manifest["input"] == {
+        "uri": input_file.to_uri(),
+        "dataset_version": "retrieval-query-set/v1",
+        "byte_size": len(source),
+        "sha256": hashlib.sha256(source).hexdigest(),
     }
-    client.stream_chunks.assert_called_once_with(input_file)
-    assessor.evaluate_supplied.assert_awaited_once()
+    assert manifest["configuration"] == _configuration().model_dump(mode="json")
+    assert manifest["counts"] == {
+        "record_statuses": {
+            "assessed": 1,
+            "input_invalid": 1,
+            "evaluation_failed": 0,
+        },
+        "pair_rows": 3,
+    }
+    for filename, schema in (
+        ("record-results.jsonl", "evaluation-record-result/v1"),
+        ("pair-results.jsonl", "evaluation-pair-result/v1"),
+        ("summary.md", "deduplication-evaluation-summary/v1"),
+    ):
+        assert manifest["artifacts"][filename] == {
+            "uri": f"minio://test/{expected_path}/{filename}",
+            "schema_version": schema,
+            "byte_size": len(uploaded[filename]),
+            "sha256": hashlib.sha256(uploaded[filename]).hexdigest(),
+        }
 
 
 @pytest.mark.asyncio
-async def test_run_checks_artifact_writability_before_evaluation():
-    """A stable output failure is reported before spending work on evaluation."""
-    run_id = uuid7()
-    input_file = BlobStorageFile.from_uri(
-        "azure://dedup-evals/datasets/retrieval-query-set/v1/records.jsonl"
-    )
-    chunks = AsyncMock()
-    chunks.__aiter__.return_value = [_valid_line("unused").encode()]
-    blob_repository = MagicMock(spec=BlobRepository)
-    blob_repository.stream_chunks_from_blob_storage.return_value = chunks
-    error = BlobStorageError("result prefix is not writable")
-    blob_repository.upload_file_to_blob_storage = AsyncMock(side_effect=error)
+async def test_run_builds_yearless_and_fuzzy_only_assessment_inputs():
+    """Frozen inputs preserve scoring data while controlling retrieval routes."""
+    held_reference_id = uuid7()
+    source = (
+        _line(
+            "yearless",
+            year=None,
+            route_applicability=["identifier", "fuzzy"],
+            excluded_reference_ids=[str(held_reference_id)],
+        )
+        + "\n"
+        + _line("fuzzy-only")
+    ).encode()
+    repository, _uploaded = _blob_repository(source)
     assessor = AsyncMock()
     assessor.evaluate_supplied.side_effect = lambda incoming, *_args, **_kwargs: (
         _assessment(incoming.id)
     )
-    runner = DeduplicationEvaluationRunner(assessor=assessor)
+    policy = RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1
 
-    with pytest.raises(BlobStorageError, match="result prefix is not writable"):
-        await runner.run(
-            run_id=run_id,
-            input_file=input_file,
-            blob_repository=blob_repository,
-            configuration=_run_configuration(),
+    await DeduplicationEvaluationRunner(assessor=assessor).run(
+        run_id=uuid7(),
+        input_file=BlobStorageFile.from_uri("azure://dedup-evals/input.jsonl"),
+        blob_repository=repository,
+        configuration=_configuration(policy),
+    )
+
+    first_incoming, first_selection = assessor.evaluate_supplied.await_args_list[0].args
+    second_incoming, second_selection = assessor.evaluate_supplied.await_args_list[
+        1
+    ].args
+    bibliography = first_incoming.enhancements[0].content
+    assert first_incoming.id.version == 7
+    assert first_incoming.identifiers[0].identifier == "W1"
+    assert bibliography.publication_year is None
+    assert [
+        (author.display_name, author.position) for author in bibliography.authorship
+    ] == [
+        ("First Author", "first"),
+        ("Middle Author", "middle"),
+        ("Last Author", "last"),
+    ]
+    assert first_selection.excluded_reference_id == held_reference_id
+    assert (
+        first_selection.identifiers[0].identifier_type
+        is ExternalIdentifierType.OPEN_ALEX
+    )
+    assert second_incoming.identifiers[0].identifier == "W1"
+    assert second_selection.identifiers == []
+    assert all(
+        call.kwargs == {"retrieval_policy": policy, "k": 10}
+        for call in assessor.evaluate_supplied.await_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_records_expected_failures_and_continues():
+    """Every non-blank line gets an envelope and expected failures stay local."""
+    exclusions = [str(uuid7()), str(uuid7())]
+    source = "\n".join(
+        [
+            _line("first"),
+            "   ",
+            '{"query_id": "broken"',
+            "[]",
+            _line("too-many", excluded_reference_ids=exclusions),
+            _line("bad-id", input_identifiers=["unknown:value"]),
+            _line("assessment-failed"),
+            _line("last"),
+        ]
+    ).encode()
+    repository, uploaded = _blob_repository(source)
+    call_count = 0
+
+    async def assess(incoming, *_args, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            message = "candidate hydration failed"
+            raise DeduplicationError(message)
+        return _assessment(incoming.id)
+
+    assessor = AsyncMock(side_effect=assess)
+    assessor.evaluate_supplied = AsyncMock(side_effect=assess)
+
+    await DeduplicationEvaluationRunner(assessor=assessor).run(
+        run_id=uuid7(),
+        input_file=BlobStorageFile.from_uri("azure://dedup-evals/input.jsonl"),
+        blob_repository=repository,
+        configuration=_configuration(),
+    )
+
+    records = [json.loads(row) for row in uploaded["record-results.jsonl"].splitlines()]
+    assert [row["line_number"] for row in records] == [1, 3, 4, 5, 6, 7, 8]
+    assert [row["status"] for row in records] == [
+        "assessed",
+        "input_invalid",
+        "input_invalid",
+        "input_invalid",
+        "input_invalid",
+        "evaluation_failed",
+        "assessed",
+    ]
+    assert [row["error"]["code"] for row in records[1:6]] == [
+        "invalid_json",
+        "invalid_record",
+        "invalid_record",
+        "invalid_record",
+        "evaluation_failed",
+    ]
+    assert records[5]["query_id"] == "assessment-failed"
+    assert "candidate hydration failed" in records[5]["error"]["message"]
+    assert assessor.evaluate_supplied.await_count == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [
+        pytest.param(ValueError("unexpected scorer defect"), id="unexpected"),
+        pytest.param(asyncio.CancelledError(), id="cancelled"),
+    ],
+)
+async def test_run_propagates_non_record_failures(error):
+    """Programming errors and cancellation abort the run."""
+    repository, uploaded = _blob_repository(_line("failed").encode())
+    assessor = AsyncMock()
+    assessor.evaluate_supplied.side_effect = error
+
+    with pytest.raises(type(error)):
+        await DeduplicationEvaluationRunner(assessor=assessor).run(
+            run_id=uuid7(),
+            input_file=BlobStorageFile.from_uri("azure://dedup-evals/input.jsonl"),
+            blob_repository=repository,
+            configuration=_configuration(),
         )
 
-    blob_repository.stream_chunks_from_blob_storage.assert_not_called()
-    assessor.evaluate_supplied.assert_not_awaited()
-    preflight = blob_repository.upload_file_to_blob_storage.await_args.kwargs
-    assert preflight["content"].getvalue() == b""
-    assert {key: value for key, value in preflight.items() if key != "content"} == {
-        "path": f"deduplication_evaluation/{run_id}",
-        "filename": "record-results.jsonl",
-        "content_type": "application/jsonl",
-    }
+    assert uploaded == {}

--- a/tests/unit/domain/references/deduplication/test_evaluation_runner.py
+++ b/tests/unit/domain/references/deduplication/test_evaluation_runner.py
@@ -12,7 +12,10 @@ from uuid import uuid7
 
 import pytest
 
-from app.core.exceptions import DeduplicationError
+from app.core.exceptions import (
+    DeduplicationError,
+    EvaluationConfigurationMismatchError,
+)
 from app.domain.references.models.models import (
     Candidate,
     CandidateElasticsearchRoute,
@@ -79,7 +82,15 @@ def _line(
     )
 
 
-def _assessment(incoming_id, *, with_pairs: bool = False):
+def _assessment(
+    incoming_id,
+    *,
+    with_pairs: bool = False,
+    policy: RetrievalPolicyName = RetrievalPolicyName.CANDIDATE_SELECTION_V1,
+    k: int = 10,
+    index_version: str | None = "reference_v3",
+    deduper: DeduperMetadata | None = None,
+):
     candidates = []
     scored_candidates = []
     if with_pairs:
@@ -114,17 +125,18 @@ def _assessment(incoming_id, *, with_pairs: bool = False):
     return DeduplicationAssessment(
         incoming_reference_id=incoming_id,
         candidate_selection=CandidateSelectionResult(
-            retrieval_policy=RetrievalPolicyName.CANDIDATE_SELECTION_V1,
-            index_version="reference_v3",
-            k_requested=10,
+            retrieval_policy=policy,
+            index_version=index_version,
+            k_requested=k,
             input_searchability=InputSearchability(
-                searchable=True,
+                searchable=index_version is not None,
                 reason="The input has a title and authors.",
             ),
             candidates=candidates,
             diagnostics=CandidateSelectionDiagnostics(),
         ),
-        deduper=DeduperMetadata(
+        deduper=deduper
+        or DeduperMetadata(
             package_version="fake-1",
             configuration_hash="fake-config",
             threshold=0.85,
@@ -136,6 +148,19 @@ def _assessment(incoming_id, *, with_pairs: bool = False):
             else DeduplicationAssessmentOutcome.PROPOSE_CANONICAL
         ),
     )
+
+
+def _assessor(*, with_pairs: bool = False) -> AsyncMock:
+    """Assessor reporting back the retrieval configuration it was asked to run."""
+
+    async def evaluate(incoming, _selection, *, retrieval_policy, k):
+        return _assessment(
+            incoming.id, with_pairs=with_pairs, policy=retrieval_policy, k=k
+        )
+
+    assessor = AsyncMock()
+    assessor.evaluate_supplied = AsyncMock(side_effect=evaluate)
+    return assessor
 
 
 class _ChunkClient(GenericBlobStorageClient):
@@ -195,10 +220,7 @@ async def test_run_writes_complete_reviewable_bundle():
     )
     source = (_line("assessed") + "\nnot json\n").encode()
     repository, uploaded = _blob_repository(source)
-    assessor = AsyncMock()
-    assessor.evaluate_supplied.side_effect = lambda incoming, *_args, **_kwargs: (
-        _assessment(incoming.id, with_pairs=True)
-    )
+    assessor = _assessor(with_pairs=True)
 
     artifacts = await DeduplicationEvaluationRunner(assessor=assessor).run(
         run_id=run_id,
@@ -298,10 +320,7 @@ async def test_run_builds_yearless_and_union_assessment_inputs():
         + _line("labelled-fuzzy")
     ).encode()
     repository, _uploaded = _blob_repository(source)
-    assessor = AsyncMock()
-    assessor.evaluate_supplied.side_effect = lambda incoming, *_args, **_kwargs: (
-        _assessment(incoming.id)
-    )
+    assessor = _assessor()
     policy = RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1
 
     await DeduplicationEvaluationRunner(assessor=assessor).run(
@@ -366,10 +385,7 @@ async def test_run_splits_records_only_on_newline():
     )
     source = (separator_line + "\n" + _line("after") + "\n").encode()
     repository, uploaded = _blob_repository(source)
-    assessor = AsyncMock()
-    assessor.evaluate_supplied.side_effect = lambda incoming, *_args, **_kwargs: (
-        _assessment(incoming.id)
-    )
+    assessor = _assessor()
 
     artifacts = await DeduplicationEvaluationRunner(assessor=assessor).run(
         run_id=uuid7(),
@@ -486,6 +502,105 @@ async def test_run_preserves_completed_records_when_it_aborts():
     assert [(row["query_id"], row["status"]) for row in records] == [
         ("first", "assessed")
     ]
+
+
+_CONFIGURATION_FIELDS = (
+    "retrieval_policy",
+    "k",
+    "deduper",
+    "elasticsearch_index_version",
+)
+
+
+@pytest.mark.parametrize(
+    ("observed", "reported"),
+    [
+        (
+            {"policy": RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1},
+            ["retrieval_policy"],
+        ),
+        ({"k": 25}, ["k"]),
+        ({"index_version": "reference_v4"}, ["elasticsearch_index_version"]),
+        (
+            {
+                "deduper": DeduperMetadata(
+                    package_version="fake-2",
+                    configuration_hash="fake-config",
+                    threshold=0.85,
+                )
+            },
+            ["deduper"],
+        ),
+        (
+            {
+                "policy": RetrievalPolicyName.SOFT_YEAR_DECAY_YEAR_OPTIONAL_V1,
+                "index_version": "reference_v4",
+            },
+            ["retrieval_policy", "elasticsearch_index_version"],
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_run_aborts_when_a_record_contradicts_the_published_configuration(
+    observed, reported
+):
+    """Published provenance is checked against the run, not taken on the caller."""
+    source = "\n".join([_line("first"), _line("drifted")]).encode()
+    repository, uploaded = _blob_repository(source)
+    call_count = 0
+
+    async def evaluate(incoming, _selection, *, retrieval_policy, k):
+        nonlocal call_count
+        call_count += 1
+        asked = {"policy": retrieval_policy, "k": k}
+        return _assessment(
+            incoming.id, **(asked | observed if call_count == 2 else asked)
+        )
+
+    assessor = AsyncMock()
+    assessor.evaluate_supplied = AsyncMock(side_effect=evaluate)
+
+    with pytest.raises(EvaluationConfigurationMismatchError) as mismatch:
+        await DeduplicationEvaluationRunner(assessor=assessor).run(
+            run_id=uuid7(),
+            input_file=BlobStorageFile.from_uri("azure://dedup-evals/input.jsonl"),
+            blob_repository=repository,
+            configuration=_configuration(),
+        )
+
+    message = str(mismatch.value)
+    assert [
+        field for field in _CONFIGURATION_FIELDS if f"{field} asserted" in message
+    ] == reported
+    assert set(uploaded) == {"record-results.jsonl"}
+    records = [json.loads(row) for row in uploaded["record-results.jsonl"].splitlines()]
+    assert [(row["query_id"], row["status"]) for row in records] == [
+        ("first", "assessed")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_accepts_a_record_the_corpus_was_never_searched_for():
+    """An absent index version means the record was not searched, not a mismatch."""
+    repository, uploaded = _blob_repository(_line("unsearchable").encode())
+
+    async def evaluate(incoming, _selection, *, retrieval_policy, k):
+        return _assessment(
+            incoming.id, policy=retrieval_policy, k=k, index_version=None
+        )
+
+    assessor = AsyncMock()
+    assessor.evaluate_supplied = AsyncMock(side_effect=evaluate)
+
+    await DeduplicationEvaluationRunner(assessor=assessor).run(
+        run_id=uuid7(),
+        input_file=BlobStorageFile.from_uri("azure://dedup-evals/input.jsonl"),
+        blob_repository=repository,
+        configuration=_configuration(),
+    )
+
+    manifest = json.loads(uploaded["manifest.json"])
+    assert manifest["counts"]["record_statuses"]["assessed"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/domain/references/deduplication/test_evaluation_runner.py
+++ b/tests/unit/domain/references/deduplication/test_evaluation_runner.py
@@ -3,6 +3,7 @@
 import asyncio
 import hashlib
 import json
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from io import BytesIO
 from typing import cast
@@ -30,6 +31,7 @@ from app.domain.references.services.deduplication_evaluation_runner import (
     DeduplicationEvaluationRunner,
     EvaluationRunConfiguration,
 )
+from app.persistence.blob.client import GenericBlobStorageClient
 from app.persistence.blob.models import BlobStorageFile, BlobStorageLocation
 from app.persistence.blob.repository import BlobRepository
 
@@ -136,11 +138,34 @@ def _assessment(incoming_id, *, with_pairs: bool = False):
     )
 
 
-def _blob_repository(source: bytes) -> tuple[BlobRepository, dict[str, bytes]]:
-    async def chunks():
-        midpoint = len(source) // 2
-        for chunk in (source[:midpoint], source[midpoint:]):
+class _ChunkClient(GenericBlobStorageClient):
+    """Canned chunks behind the real line reader, so tests exercise the shared one."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    async def upload_file(self, content, file, content_type=None):
+        raise NotImplementedError
+
+    async def stream_chunks(self, file):
+        for chunk in self._chunks:
             yield chunk
+
+    async def generate_signed_url(self, file, interaction_type, content_disposition):
+        raise NotImplementedError
+
+
+def _blob_repository(source: bytes) -> tuple[BlobRepository, dict[str, bytes]]:
+    midpoint = len(source) // 2
+    chunks = [source[:midpoint], source[midpoint:]]
+
+    async def stream_chunks(_file):
+        for chunk in chunks:
+            yield chunk
+
+    @asynccontextmanager
+    async def stream_lines(file):
+        yield _ChunkClient(chunks).stream_file(file)
 
     uploaded: dict[str, bytes] = {}
 
@@ -155,7 +180,8 @@ def _blob_repository(source: bytes) -> tuple[BlobRepository, dict[str, bytes]]:
         )
 
     repository = MagicMock(spec=BlobRepository)
-    repository.stream_chunks_from_blob_storage.return_value = chunks()
+    repository.stream_chunks_from_blob_storage = stream_chunks
+    repository.stream_file_from_blob_storage = stream_lines
     repository.upload_file_to_blob_storage = AsyncMock(side_effect=upload)
     return repository, uploaded
 
@@ -318,6 +344,55 @@ async def test_run_builds_yearless_and_union_assessment_inputs():
         call.kwargs == {"retrieval_policy": policy, "k": 10}
         for call in assessor.evaluate_supplied.await_args_list
     )
+
+
+@pytest.mark.asyncio
+async def test_run_splits_records_only_on_newline():
+    """Unicode line separators are legal inside a JSON string, not record boundaries."""
+    separator_line = json.dumps(
+        {
+            "query_id": "line-separator",
+            "input_reference": {
+                "title": "Effects of X\u2028on Y",
+                "authors": ["First Author"],
+                "year": 2024,
+            },
+            "input_identifiers": ["open_alex:W1"],
+            "route_applicability": ["fuzzy"],
+            "excluded_reference_ids": [],
+            "dataset_version": "retrieval-query-set/v1",
+        },
+        ensure_ascii=False,
+    )
+    source = (separator_line + "\n" + _line("after") + "\n").encode()
+    repository, uploaded = _blob_repository(source)
+    assessor = AsyncMock()
+    assessor.evaluate_supplied.side_effect = lambda incoming, *_args, **_kwargs: (
+        _assessment(incoming.id)
+    )
+
+    artifacts = await DeduplicationEvaluationRunner(assessor=assessor).run(
+        run_id=uuid7(),
+        input_file=BlobStorageFile.from_uri("azure://dedup-evals/input.jsonl"),
+        blob_repository=repository,
+        configuration=_configuration(),
+    )
+
+    records = [json.loads(row) for row in uploaded["record-results.jsonl"].splitlines()]
+    assert [
+        (row["query_id"], row["line_number"], row["status"]) for row in records
+    ] == [
+        ("line-separator", 1, "assessed"),
+        ("after", 2, "assessed"),
+    ]
+    manifest = json.loads(uploaded["manifest.json"])
+    assert manifest["counts"]["record_statuses"] == {
+        "assessed": 2,
+        "input_invalid": 0,
+        "evaluation_failed": 0,
+    }
+    assert artifacts.input_byte_size == len(source)
+    assert artifacts.input_sha256 == hashlib.sha256(source).hexdigest()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/domain/references/deduplication/test_evaluation_runner.py
+++ b/tests/unit/domain/references/deduplication/test_evaluation_runner.py
@@ -586,8 +586,11 @@ async def test_run_aborts_when_a_record_contradicts_the_published_configuration(
     ] == reported
     assert set(uploaded) == {"record-results.jsonl"}
     records = [json.loads(row) for row in uploaded["record-results.jsonl"].splitlines()]
+    # The record that triggered the mismatch is kept, so the bundle shows what
+    # actually ran against what the configuration declared.
     assert [(row["query_id"], row["status"]) for row in records] == [
-        ("first", "assessed")
+        ("first", "assessed"),
+        ("drifted", "assessed"),
     ]
 
 
@@ -653,11 +656,21 @@ async def test_run_supplies_a_record_the_assessment_service_can_score():
 
 
 @pytest.mark.asyncio
-async def test_run_writes_nothing_when_cancelled():
-    """Cancellation unwinds without further blob I/O."""
-    repository, uploaded = _blob_repository(_line("failed").encode())
+async def test_run_keeps_completed_records_when_cancelled():
+    """A shutdown costs the same hours of retrieval as any other abort."""
+    source = "\n".join([_line("first"), _line("cancelled")]).encode()
+    repository, uploaded = _blob_repository(source)
+    call_count = 0
+
+    async def assess(incoming, *_args, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            raise asyncio.CancelledError
+        return _assessment(incoming.id)
+
     assessor = AsyncMock()
-    assessor.evaluate_supplied.side_effect = asyncio.CancelledError()
+    assessor.evaluate_supplied = AsyncMock(side_effect=assess)
 
     with pytest.raises(asyncio.CancelledError):
         await DeduplicationEvaluationRunner(assessor=assessor).run(
@@ -667,4 +680,47 @@ async def test_run_writes_nothing_when_cancelled():
             configuration=_configuration(),
         )
 
-    assert uploaded == {}
+    assert set(uploaded) == {"record-results.jsonl"}
+    records = [json.loads(row) for row in uploaded["record-results.jsonl"].splitlines()]
+    assert [(row["query_id"], row["status"]) for row in records] == [
+        ("first", "assessed")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_keeps_completed_records_when_its_task_is_cancelled():
+    """Cancelling the task, not raising the sentinel: the salvage still has to run."""
+    source = "\n".join([_line("first"), _line("blocked")]).encode()
+    repository, uploaded = _blob_repository(source)
+    reached_second = asyncio.Event()
+    call_count = 0
+
+    async def assess(incoming, *_args, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            reached_second.set()
+            await asyncio.Event().wait()
+        return _assessment(incoming.id)
+
+    assessor = AsyncMock()
+    assessor.evaluate_supplied = AsyncMock(side_effect=assess)
+
+    task = asyncio.create_task(
+        DeduplicationEvaluationRunner(assessor=assessor).run(
+            run_id=uuid7(),
+            input_file=BlobStorageFile.from_uri("azure://dedup-evals/input.jsonl"),
+            blob_repository=repository,
+            configuration=_configuration(),
+        )
+    )
+    await reached_second.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert set(uploaded) == {"record-results.jsonl"}
+    records = [json.loads(row) for row in uploaded["record-results.jsonl"].splitlines()]
+    assert [(row["query_id"], row["status"]) for row in records] == [
+        ("first", "assessed")
+    ]

--- a/tests/unit/persistence/blob/test_blob.py
+++ b/tests/unit/persistence/blob/test_blob.py
@@ -352,6 +352,37 @@ async def test_copy_rejects_destination_on_other_backend():
         await repo.copy(source, destination)
 
 
+@pytest.mark.asyncio
+async def test_digest_returns_size_and_sha256_without_uploading():
+    """A digest reads the source only, so immutable input stays untouched."""
+    payload_chunks = [b'{"query_id": "a"}\n', b'{"query_id": "b"}\n']
+    payload = b"".join(payload_chunks)
+    source = BlobStorageFile.from_uri("azure://dedup-evals/input.jsonl")
+    client = _RecordingClient(chunks=payload_chunks)
+
+    repo = BlobRepository()
+    with patch.object(repo, "_preload_config", return_value=client):
+        result = await repo.digest(source)
+
+    assert result.byte_size == len(payload)
+    assert result.sha256_checksum == hashlib.sha256(payload).hexdigest()
+    assert client.uploaded_to is None
+
+
+@pytest.mark.asyncio
+async def test_digest_aborts_when_max_bytes_exceeded():
+    """The cap rejects oversized input before a caller spends work on it."""
+    source = BlobStorageFile.from_uri("azure://dedup-evals/big.jsonl")
+    client = _RecordingClient(chunks=[b"a" * 100, b"b" * 100])
+
+    repo = BlobRepository()
+    with (
+        patch.object(repo, "_preload_config", return_value=client),
+        pytest.raises(BlobSizeExceededError, match="max_bytes=150"),
+    ):
+        await repo.digest(source, max_bytes=150)
+
+
 _STREAM_FILE = BlobStorageFile(
     location=BlobStorageLocation.MINIO,
     container="c",

--- a/tests/unit/test_run_evaluation.py
+++ b/tests/unit/test_run_evaluation.py
@@ -1,0 +1,360 @@
+import argparse
+import contextlib
+import datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid7
+
+import pytest
+
+from app import run_evaluation
+from app.domain.references.models.models import (
+    CandidateSelectionInput,
+    DeduperMetadata,
+    RetrievalPolicyName,
+)
+from app.persistence.blob.repository import BlobRepository
+from app.run_evaluation import (
+    EvaluationAssessor,
+    aware_datetime,
+    current_index_version,
+    resolve_pair_scorer,
+)
+from tests.factories import ReferenceFactory
+
+NAMED_SCORER = object()
+STAMPED_METADATA = DeduperMetadata(
+    package_version="1.2.3", configuration_hash="cfg-hash", threshold=0.8
+)
+STAMPED_INDEX = "reference-000042"
+_REQUIRED_ARGUMENTS = [
+    "--input",
+    "minio://operations/set/queries.jsonl",
+    "--dataset-version",
+    "retrieval-query-set/v1",
+    "--corpus-observed-at",
+    "2026-08-17T00:00:00+00:00",
+    "--code-commit",
+    "abc123",
+    "--pair-scorer",
+    "module:factory",
+]
+
+
+def build_named_scorer():
+    """Factory the scorer-resolution test names by import path."""
+    return NAMED_SCORER
+
+
+def build_stamped_scorer():
+    """Factory the run tests name, carrying identifiable scorer metadata."""
+    scorer = MagicMock()
+    scorer.metadata = STAMPED_METADATA
+    return scorer
+
+
+class _RecordingSession:
+    """Stand-in session keeping the statements the assessor issued."""
+
+    def __init__(self):
+        self.statements: list[str] = []
+
+    async def execute(self, statement):
+        self.statements.append(str(statement))
+
+    async def close(self):
+        pass
+
+    async def rollback(self):
+        pass
+
+
+@contextlib.asynccontextmanager
+async def _yielding(value):
+    yield value
+
+
+def _selection_input():
+    return CandidateSelectionInput(title="A title", authors=["Ann Author"])
+
+
+def _assessor_under_test(monkeypatch, session_source, assessment=None):
+    """Wire an assessor whose only real collaborator is the session it opens."""
+    monkeypatch.setattr(run_evaluation.db_manager, "session", session_source)
+    monkeypatch.setattr(
+        run_evaluation.es_manager, "client", lambda: _yielding(MagicMock())
+    )
+    service = MagicMock()
+    service.evaluate_supplied = AsyncMock(return_value=assessment or MagicMock())
+    monkeypatch.setattr(
+        run_evaluation,
+        "DeduplicationAssessmentService",
+        MagicMock(return_value=service),
+    )
+    return EvaluationAssessor(
+        blob_repository=MagicMock(spec=BlobRepository),
+        pair_scorer=MagicMock(),
+    )
+
+
+def test_aware_datetime_rejects_a_naive_timestamp():
+    """A corpus observation with no offset cannot be compared across runs."""
+    with pytest.raises(argparse.ArgumentTypeError, match="needs a UTC offset"):
+        aware_datetime("2026-08-17T00:00:00")
+
+
+def test_aware_datetime_keeps_the_supplied_offset():
+    """The offset is preserved rather than normalised, so the manifest is literal."""
+    parsed = aware_datetime("2026-08-17T10:30:00+10:00")
+
+    assert parsed.utcoffset().total_seconds() == 10 * 60 * 60
+
+
+@pytest.mark.parametrize(
+    "factory_path",
+    ["module.without.a.factory", ":factory", "module:", ""],
+)
+def test_resolve_pair_scorer_rejects_a_path_missing_either_half(factory_path):
+    """Without both halves the remainder imports as nonsense, not as an error."""
+    with pytest.raises(RuntimeError, match="must be given as 'module:factory'"):
+        resolve_pair_scorer(factory_path)
+
+
+def test_resolve_pair_scorer_builds_the_named_factory():
+    """The scorer comes from the path given, so no stand-in is chosen for it."""
+    assert resolve_pair_scorer(f"{__name__}:build_named_scorer") is NAMED_SCORER
+
+
+@pytest.mark.asyncio
+async def test_current_index_version_refuses_an_absent_alias(monkeypatch):
+    """Without an index version the manifest cannot say what the run searched."""
+    es_uow = MagicMock()
+    es_uow.references.get_current_index_name = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        run_evaluation, "AsyncESUnitOfWork", MagicMock(return_value=es_uow)
+    )
+    monkeypatch.setattr(
+        run_evaluation.es_manager, "client", lambda: _yielding(MagicMock())
+    )
+
+    with pytest.raises(RuntimeError, match="resolves to no index"):
+        await current_index_version()
+
+
+@pytest.mark.asyncio
+async def test_assessor_makes_the_transaction_read_only_before_assessing(monkeypatch):
+    """The run cannot mutate the corpus it measures."""
+    session = _RecordingSession()
+    statements_when_assessed: list[str] = []
+    assessment = MagicMock()
+    assessor = _assessor_under_test(
+        monkeypatch, lambda: _yielding(session), assessment=assessment
+    )
+
+    def record_statements_seen(*_args, **_kwargs):
+        statements_when_assessed.extend(session.statements)
+        return assessment
+
+    service = run_evaluation.DeduplicationAssessmentService.return_value
+    service.evaluate_supplied.side_effect = record_statements_seen
+
+    result = await assessor.evaluate_supplied(
+        ReferenceFactory.build(), _selection_input()
+    )
+
+    assert statements_when_assessed == ["SET TRANSACTION READ ONLY"]
+    assert result is assessment
+
+
+@pytest.mark.asyncio
+async def test_assessor_holds_no_session_between_records(monkeypatch):
+    """A run of up to an hour must not pin one snapshot open for its duration."""
+    sessions: list[_RecordingSession] = []
+
+    def new_session():
+        sessions.append(_RecordingSession())
+        return _yielding(sessions[-1])
+
+    assessor = _assessor_under_test(monkeypatch, new_session)
+
+    for _ in range(2):
+        await assessor.evaluate_supplied(ReferenceFactory.build(), _selection_input())
+
+    assert len(sessions) == 2
+
+
+@pytest.mark.asyncio
+async def test_assessor_passes_the_run_configuration_through(monkeypatch):
+    """A per-record override must reach the assessment, or the manifest lies."""
+    assessor = _assessor_under_test(monkeypatch, lambda: _yielding(_RecordingSession()))
+    policy = run_evaluation.RetrievalPolicyName.CURRENT_FUZZY_V1
+
+    await assessor.evaluate_supplied(
+        ReferenceFactory.build(),
+        _selection_input(),
+        retrieval_policy=policy,
+        k=25,
+    )
+
+    service = run_evaluation.DeduplicationAssessmentService.return_value
+    assert service.evaluate_supplied.await_args.kwargs == {
+        "retrieval_policy": policy,
+        "k": 25,
+    }
+
+
+def test_argument_parser_defaults_no_provenance_field():
+    """A bundle whose provenance is partly defaulted cannot be compared to another."""
+    parser = run_evaluation.argument_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--input", "minio://operations/set/queries.jsonl"])
+
+
+def test_argument_parser_takes_the_retrieval_defaults_from_settings():
+    """An unstated policy is the one production runs, not a per-script choice."""
+    args = run_evaluation.argument_parser().parse_args(_REQUIRED_ARGUMENTS)
+
+    scoring = run_evaluation.settings.dedup_scoring
+    assert args.retrieval_policy == scoring.default_retrieval_policy
+    assert args.k == scoring.candidate_k
+
+
+def _run_arguments(**overrides):
+    """Build the parsed arguments of a run, without going through the parser."""
+    return argparse.Namespace(
+        **{
+            "input": "minio://operations/set/queries.jsonl",
+            "dataset_version": "retrieval-query-set/v1",
+            "corpus_observed_at": datetime.datetime(2026, 8, 17, tzinfo=datetime.UTC),
+            "code_commit": "abc123",
+            "pair_scorer": f"{__name__}:build_stamped_scorer",
+            "retrieval_policy": RetrievalPolicyName.CURRENT_FUZZY_V1,
+            "k": 7,
+            "run_id": None,
+            **overrides,
+        }
+    )
+
+
+def _stub_infrastructure(monkeypatch):
+    """
+    Replace every client the run opens, recording the order they are released.
+
+    :return: The release log and the stubbed runner the driver will drive.
+    """
+    released: list[str] = []
+    monkeypatch.setattr(run_evaluation, "BlobRepository", MagicMock())
+    monkeypatch.setattr(run_evaluation.db_manager, "init", MagicMock())
+    monkeypatch.setattr(
+        run_evaluation.db_manager,
+        "close",
+        AsyncMock(side_effect=lambda: released.append("db")),
+    )
+    monkeypatch.setattr(run_evaluation.es_manager, "init", AsyncMock())
+    monkeypatch.setattr(
+        run_evaluation.es_manager,
+        "close",
+        AsyncMock(side_effect=lambda: released.append("es")),
+    )
+    monkeypatch.setattr(
+        run_evaluation,
+        "close_blob_clients",
+        AsyncMock(side_effect=lambda: released.append("blob")),
+    )
+    monkeypatch.setattr(
+        run_evaluation, "current_index_version", AsyncMock(return_value=STAMPED_INDEX)
+    )
+    monkeypatch.setattr(run_evaluation, "DeduplicationEvaluationRunner", MagicMock())
+    runner = run_evaluation.DeduplicationEvaluationRunner.return_value
+    # An AsyncMock's own return value is another AsyncMock, whose artifact fields
+    # would then be coroutines the driver logs instead of the bundle's URIs.
+    runner.run = AsyncMock(return_value=MagicMock())
+    return released, runner
+
+
+@pytest.mark.asyncio
+async def test_run_evaluation_releases_its_clients_when_the_run_fails(monkeypatch):
+    """A failed run must not leave the environment's pooled clients open."""
+    released, runner = _stub_infrastructure(monkeypatch)
+    runner.run.side_effect = RuntimeError("assessment exploded")
+
+    with pytest.raises(RuntimeError, match="assessment exploded"):
+        await run_evaluation.run_evaluation(_run_arguments())
+
+    assert released == ["db", "es", "blob"]
+
+
+@pytest.mark.asyncio
+async def test_run_evaluation_stamps_a_run_id_when_none_is_supplied(monkeypatch):
+    """The bundle is written under the run id, so a run cannot proceed without one."""
+    _released, runner = _stub_infrastructure(monkeypatch)
+
+    await run_evaluation.run_evaluation(_run_arguments(run_id=None))
+
+    assert isinstance(runner.run.await_args.kwargs["run_id"], UUID)
+
+
+@pytest.mark.asyncio
+async def test_run_evaluation_releases_the_database_when_search_will_not_start(
+    monkeypatch,
+):
+    """Initialisation is partial when it fails, and the earlier client still leaks."""
+    released, _runner = _stub_infrastructure(monkeypatch)
+    monkeypatch.setattr(
+        run_evaluation.es_manager,
+        "init",
+        AsyncMock(side_effect=ConnectionError("no cluster")),
+    )
+
+    with pytest.raises(ConnectionError, match="no cluster"):
+        await run_evaluation.run_evaluation(_run_arguments())
+
+    assert released == ["db", "es", "blob"]
+
+
+@pytest.mark.asyncio
+async def test_run_evaluation_caps_the_input_it_will_read(monkeypatch):
+    """An unbounded input would be digested and buffered before anything checks it."""
+    _released, runner = _stub_infrastructure(monkeypatch)
+
+    await run_evaluation.run_evaluation(_run_arguments())
+
+    assert (
+        runner.run.await_args.kwargs["max_input_bytes"]
+        == run_evaluation.settings.evaluation_input_max_byte_size
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_evaluation_mints_a_distinct_run_id_each_time(monkeypatch):
+    """The runner restarts at line one, so a reused id would overwrite a bundle."""
+    _released, runner = _stub_infrastructure(monkeypatch)
+
+    await run_evaluation.run_evaluation(_run_arguments())
+    await run_evaluation.run_evaluation(_run_arguments())
+
+    first, second = (call.kwargs["run_id"] for call in runner.run.await_args_list)
+    assert first != second
+
+
+def test_argument_parser_refuses_a_caller_supplied_run_id():
+    """An operator cannot name a path that already holds a finished bundle."""
+    parser = run_evaluation.argument_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args([*_REQUIRED_ARGUMENTS, "--run-id", str(uuid7())])
+
+
+@pytest.mark.asyncio
+async def test_run_evaluation_stamps_the_observed_provenance(monkeypatch):
+    """The manifest has to name what ran, not what the operator hoped would run."""
+    _released, runner = _stub_infrastructure(monkeypatch)
+
+    await run_evaluation.run_evaluation(_run_arguments())
+
+    configuration = runner.run.await_args.kwargs["configuration"]
+    assert configuration.elasticsearch_index_version == STAMPED_INDEX
+    assert configuration.deduper == STAMPED_METADATA
+    assert configuration.environment == run_evaluation.settings.env.value
+    assert configuration.retrieval_policy == RetrievalPolicyName.CURRENT_FUZZY_V1
+    assert configuration.k == 7


### PR DESCRIPTION
Closes #915. Assess a supplied JSONL set of records against the corpus and write a reviewable artifact bundle, plus a driver to run one.

Base `main`. Seven source files, five test files.

Four implementation notes:

- A record that contradicts the run's configuration aborts with `EvaluationConfigurationMismatchError`, so a manifest never misdescribes what ran. The completed records are still written, and the missing manifest marks the bundle incomplete. That error deliberately does not subclass `DeduplicationError`, which the per-record handler catches and would turn into an envelope.
- A record declaring a different `dataset_version` than the configuration aborts the same way, but is checked before the assessment rather than after it. The input can contradict the manifest on its face, so there is no reason to spend retrieval on it first.
- The manifest records a SHA-256 of the input, and it has to hash the exact bytes held on the blob. The line reader hands back decoded strings, so it cannot produce that hash, and the input is streamed a second time as raw bytes. That pass is `BlobRepository.digest()`, which shares `copy()`'s chunk handling, and it carries the input size cap so an oversized input aborts before any record is assessed.
- The driver holds a read-only session per record rather than one for the run. That costs connection churn and buys interruptibility: no transaction spans records, so a stopped run still uploads what it completed. Postgres refuses a write from those transactions; on Elasticsearch the guarantee is only that the assembled services take read paths.

## Validation performed

- Ran the full `retrieval-query-set/v1` known-match set against local Postgres, Elasticsearch and MinIO: about 6,000 searchable records, about 41,000 scored pairs, complete bundle in around 90 seconds, no failed records.
- Ran the same set a second time through the released deduper wheel via a local adapter, exercising the real scorer path end to end. Both runs retrieved identically, which is what should happen when only the scorer changes.
- Verified bundles by reading them back out of MinIO: input SHA-256 against the stored bytes, one envelope per non-blank line in order, manifest counts and artifact checksums, pair rows against the scored candidates.
- The set carries a record with a raw U+2028. The runner read 6,042 lines where `splitlines()` on the same bytes gives 6,043, so line numbering held.
- Declared `reference_v9` against a live `reference_v1` and got the abort, the completed envelopes and no manifest.
- Declared a record from another dataset at line 3 of four and got the abort, the two completed envelopes and no manifest. The assessor was called exactly twice, so the guard ran before the offending record reached it.
- Yearless rows returned 0 candidates under `candidate_selection_v1`, which requires publication year, so the searchability gate rejects them before any query is issued. The same rows returned 7 to 10 each under `soft_year_decay_year_optional_v1`.
- Checked non-mutation by counting: nine tables, the latest decision timestamp and the Elasticsearch doc count unchanged either side of a run.
- Suite 1176 passed / 1 skipped, `tests/e2e` 29 passed, mypy and pre-commit clean.

Not covered: the deduper run above used a local wheel and a throwaway adapter, so wiring the released deduper into the repository is still #887.
