### PR TITLE
Add prod release notifications

### DIFF
--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -22,7 +22,6 @@ jobs:
   deploy:
     needs: build
     uses: ./.github/workflows/deploy.yml
-    secrets: inherit
     with:
       environment: development
       image_tag: ${{ needs.build.outputs.image_tag }}

--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -22,6 +22,7 @@ jobs:
   deploy:
     needs: build
     uses: ./.github/workflows/deploy.yml
+    secrets: inherit
     with:
       environment: development
       image_tag: ${{ needs.build.outputs.image_tag }}

--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -22,7 +22,6 @@ jobs:
   deploy:
     needs: build
     uses: ./.github/workflows/deploy.yml
-    secrets: inherit
     with:
       environment: development
-      image_tag: does-not-exist
+      image_tag: ${{ needs.build.outputs.image_tag }}

--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -22,6 +22,7 @@ jobs:
   deploy:
     needs: build
     uses: ./.github/workflows/deploy.yml
+    secrets: inherit
     with:
       environment: development
-      image_tag: ${{ needs.build.outputs.image_tag }}
+      image_tag: does-not-exist

--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -25,4 +25,4 @@ jobs:
     secrets: inherit
     with:
       environment: development
-      image_tag: does-not-exist
+      image_tag: ${{ needs.build.outputs.image_tag }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,9 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     steps:
-      # TESTING - remove. Forces the failure notification path.
-      - run: exit 1
-
       - name: "Az CLI login"
         uses: azure/login@v2.1.0
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -201,7 +201,7 @@ jobs:
               --resource-group ${{vars.RESOURCE_GROUP}}
 
   notify:
-    if: ${{ always() && inputs.environment == 'production' }}
+    if: ${{ always() && inputs.environment == 'development' }}
     needs:
       - verify-deployment
       - migrate-database

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -128,6 +128,58 @@ jobs:
           containerAppEnvironment: ${{vars.CONTAINER_APP_ENV}}
           imageToDeploy: ${{vars.REGISTRY_NAME}}.azurecr.io/${{vars.APP_NAME}}-ui:${{ inputs.image_tag }}
 
+  verify-deployment:
+    runs-on: ubuntu-latest
+    needs:
+      - deploy-application
+      - deploy-ui
+    environment: ${{ inputs.environment }}
+    strategy:
+      # Report every unhealthy app, not just the first.
+      fail-fast: false
+      matrix:
+        container_app:
+          - ${{ vars.CONTAINER_APP_NAME }}
+          - ${{ vars.CONTAINER_APP_TASKS_NAME }}
+          - ${{ vars.CONTAINER_APP_UI_NAME }}
+    steps:
+      - name: "Az CLI login"
+        uses: azure/login@v2.1.0
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Wait for latest revision to be running
+        uses: Azure/cli@v2.0.0
+        with:
+          inlineScript: |
+            APP_ID=$(az containerapp show \
+              --name "${{ matrix.container_app }}" \
+              --resource-group ${{vars.RESOURCE_GROUP}} \
+              --query id --output tsv)
+
+            REVISION=$(az containerapp show \
+              --name "${{ matrix.container_app }}" \
+              --resource-group ${{vars.RESOURCE_GROUP}} \
+              --query properties.latestRevisionName --output tsv)
+
+            echo "Waiting for revision $REVISION"
+            az resource wait \
+              --ids "$APP_ID/revisions/$REVISION" \
+              --custom "properties.runningState=='Running'" \
+              --interval 10 \
+              --timeout 300
+
+      - name: Show replica state on failure
+        if: failure()
+        uses: Azure/cli@v2.0.0
+        with:
+          inlineScript: |
+            az containerapp replica list \
+              --name "${{ matrix.container_app }}" \
+              --resource-group ${{vars.RESOURCE_GROUP}}
+
   migrate-database:
     runs-on: ubuntu-latest
     needs: deploy-container-apps-jobs
@@ -151,15 +203,14 @@ jobs:
   notify:
     if: ${{ always() && inputs.environment == 'production' }}
     needs:
-      - deploy-application
-      - deploy-container-apps-jobs
-      - deploy-ui
+      - verify-deployment
       - migrate-database
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     env:
       STATUS: >-
         ${{ (contains(needs.*.result, 'failure') && '🚨 DEPLOY FAILED')
+        || (contains(needs.*.result, 'skipped') && '🚨 DEPLOY FAILED')
         || (contains(needs.*.result, 'cancelled') && '⚠️ Deploy cancelled')
         || '✅ Deployed' }}
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -207,7 +207,7 @@ jobs:
               --resource-group ${{vars.RESOURCE_GROUP}}
 
   notify:
-    if: ${{ always() && inputs.environment == 'development' }}
+    if: ${{ always() && inputs.environment == 'production' }}
     needs:
       - verify-deployment
       - migrate-database

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -147,3 +147,45 @@ jobs:
             az containerapp job start \
               --name "db-migrator-${{ vars.ENVIRONMENT_NAME }}" \
               --resource-group ${{vars.RESOURCE_GROUP}}
+
+  notify-production:
+    # TESTING - revert to 'production' before merging.
+    if: ${{ always() && inputs.environment == 'development' }}
+    needs:
+      - deploy-application
+      - deploy-container-apps-jobs
+      - deploy-ui
+      - migrate-database
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    env:
+      STATUS: >-
+        ${{ (contains(needs.*.result, 'failure') && '🚨 PRODUCTION DEPLOY FAILED')
+        || (contains(needs.*.result, 'cancelled') && '⚠️ Production deploy cancelled')
+        || '✅ Production deployed' }}
+    steps:
+      - name: Notify Slack of production deploy result
+        uses: slackapi/slack-github-action@v4.0.0
+        with:
+          webhook: ${{ secrets.CI_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          # The action swallows delivery errors by default; fail loudly instead.
+          errors: true
+          # github.workflow distinguishes a promotion from a rollback.
+          payload: |
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  emoji: true
+                  text: "${{ env.STATUS }} - ${{ vars.APP_NAME }}"
+              - type: section
+                fields:
+                  - type: mrkdwn
+                    text: "*Image tag:*\n${{ inputs.image_tag }}"
+                  - type: mrkdwn
+                    text: "*Triggered by:*\n${{ github.triggering_actor }}"
+              - type: context
+                elements:
+                  - type: mrkdwn
+                    text: "${{ github.workflow }} · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     steps:
+      # TESTING - remove. Forces the failure notification path.
+      - run: exit 1
+
       - name: "Az CLI login"
         uses: azure/login@v2.1.0
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -207,7 +207,7 @@ jobs:
               --resource-group ${{vars.RESOURCE_GROUP}}
 
   notify:
-    if: ${{ always() && inputs.environment == 'production' }}
+    if: ${{ always() && inputs.environment == 'development' }}
     needs:
       - verify-deployment
       - migrate-database

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -149,8 +149,7 @@ jobs:
               --resource-group ${{vars.RESOURCE_GROUP}}
 
   notify:
-    # TESTING - revert to 'production' before merging.
-    if: ${{ always() && inputs.environment == 'development' }}
+    if: ${{ always() && inputs.environment == 'production' }}
     needs:
       - deploy-application
       - deploy-container-apps-jobs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -148,7 +148,7 @@ jobs:
               --name "db-migrator-${{ vars.ENVIRONMENT_NAME }}" \
               --resource-group ${{vars.RESOURCE_GROUP}}
 
-  notify-production:
+  notify:
     # TESTING - revert to 'production' before merging.
     if: ${{ always() && inputs.environment == 'development' }}
     needs:
@@ -160,11 +160,11 @@ jobs:
     environment: ${{ inputs.environment }}
     env:
       STATUS: >-
-        ${{ (contains(needs.*.result, 'failure') && '🚨 PRODUCTION DEPLOY FAILED')
-        || (contains(needs.*.result, 'cancelled') && '⚠️ Production deploy cancelled')
-        || '✅ Production deployed' }}
+        ${{ (contains(needs.*.result, 'failure') && '🚨 DEPLOY FAILED')
+        || (contains(needs.*.result, 'cancelled') && '⚠️ Deploy cancelled')
+        || '✅ Deployed' }}
     steps:
-      - name: Notify Slack of production deploy result
+      - name: Notify Slack of deploy result
         uses: slackapi/slack-github-action@v4.0.0
         with:
           webhook: ${{ secrets.CI_SLACK_WEBHOOK_URL }}
@@ -178,11 +178,11 @@ jobs:
                 text:
                   type: plain_text
                   emoji: true
-                  text: "${{ env.STATUS }} - ${{ vars.APP_NAME }}"
+                  text: "${{ env.STATUS }} - ${{ vars.APP_NAME }} (${{ inputs.environment }})"
               - type: section
                 fields:
                   - type: mrkdwn
-                    text: "*Image tag:*\n${{ inputs.image_tag }}"
+                    text: "*Image tag:*\n<${{ github.server_url }}/${{ github.repository }}/commit/${{ inputs.image_tag }}|${{ inputs.image_tag }}>"
                   - type: mrkdwn
                     text: "*Triggered by:*\n${{ github.triggering_actor }}"
               - type: context

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -201,7 +201,7 @@ jobs:
               --resource-group ${{vars.RESOURCE_GROUP}}
 
   notify:
-    if: ${{ always() && inputs.environment == 'development' }}
+    if: ${{ always() && inputs.environment == 'production' }}
     needs:
       - verify-deployment
       - migrate-database

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -138,10 +138,11 @@ jobs:
       # Report every unhealthy app, not just the first.
       fail-fast: false
       matrix:
-        container_app:
-          - ${{ vars.CONTAINER_APP_NAME }}
-          - ${{ vars.CONTAINER_APP_TASKS_NAME }}
-          - ${{ vars.CONTAINER_APP_UI_NAME }}
+        # We have to do this lookup as `strategy` cannot see ENV vars
+        app_var:
+          - CONTAINER_APP_NAME
+          - CONTAINER_APP_TASKS_NAME
+          - CONTAINER_APP_UI_NAME
     steps:
       - name: "Az CLI login"
         uses: azure/login@v2.1.0
@@ -150,21 +151,26 @@ jobs:
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
+      # The deploy jobs return once Azure accepts the new revision, not once it is
+      # serving, so a replica that never starts would otherwise report a green deploy.
       - name: Wait for latest revision to be running
         uses: Azure/cli@v2.0.0
         with:
           inlineScript: |
-            APP_ID=$(az containerapp show \
-              --name "${{ matrix.container_app }}" \
-              --resource-group ${{vars.RESOURCE_GROUP}} \
-              --query id --output tsv)
+            APP="${{ vars[matrix.app_var] }}"
 
-            REVISION=$(az containerapp show \
-              --name "${{ matrix.container_app }}" \
+            if [ -z "$APP" ]; then
+              echo "::error::${{ matrix.app_var }} is unset"
+              exit 1
+            fi
+
+            APP_ID=$(az containerapp show --name "$APP" \
+              --resource-group ${{vars.RESOURCE_GROUP}} --query id --output tsv)
+            REVISION=$(az containerapp show --name "$APP" \
               --resource-group ${{vars.RESOURCE_GROUP}} \
               --query properties.latestRevisionName --output tsv)
 
-            echo "Waiting for revision $REVISION"
+            echo "Waiting for $APP revision $REVISION"
             az resource wait \
               --ids "$APP_ID/revisions/$REVISION" \
               --custom "properties.runningState=='Running'" \
@@ -177,7 +183,7 @@ jobs:
         with:
           inlineScript: |
             az containerapp replica list \
-              --name "${{ matrix.container_app }}" \
+              --name "${{ vars[matrix.app_var] }}" \
               --resource-group ${{vars.RESOURCE_GROUP}}
 
   migrate-database:

--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -32,6 +32,7 @@ jobs:
     if: github.ref == 'refs/heads/main' # Only run on main, not strictly necessary but for safety
     uses: ./.github/workflows/deploy.yml
     needs: get-image-tag
+    secrets: inherit
     with:
       environment: production
       image_tag: ${{ needs.get-image-tag.outputs.image_tag }}

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -25,6 +25,7 @@ jobs:
   deploy:
     if: github.ref == 'refs/heads/main'
     uses: ./.github/workflows/deploy.yml
+    secrets: inherit
     with:
       environment: production
       image_tag: ${{ inputs.image_tag }}

--- a/infra/app/github_actions.tf
+++ b/infra/app/github_actions.tf
@@ -141,6 +141,14 @@ resource "github_actions_environment_secret" "azure_storage_account_name" {
   plaintext_value = azurerm_storage_account.this.name
 }
 
+resource "github_actions_environment_secret" "ci_slack_webhook_url" {
+  # Read by the notify step in deploy.yml to announce production deploys.
+  repository      = github_repository_environment.environment.repository
+  environment     = github_repository_environment.environment.environment
+  secret_name     = "CI_SLACK_WEBHOOK_URL"
+  plaintext_value = var.ci_slack_webhook_url
+}
+
 resource "github_actions_environment_secret" "destiny_api_endpoint" {
   # The eppi-import GitHub Action needs know the url to the Destiny API.
   repository      = github_repository_environment.environment.repository

--- a/infra/app/variables.tf
+++ b/infra/app/variables.tf
@@ -519,8 +519,7 @@ variable "alert_slack_webhook_url" {
 }
 
 variable "ci_slack_webhook_url" {
-  description = "Slack webhook URL for deploy notifications (optional)"
+  description = "Slack webhook URL for deploy notifications"
   type        = string
-  default     = ""
   sensitive   = true
 }

--- a/infra/app/variables.tf
+++ b/infra/app/variables.tf
@@ -517,3 +517,10 @@ variable "alert_slack_webhook_url" {
   default     = ""
   sensitive   = true
 }
+
+variable "ci_slack_webhook_url" {
+  description = "Slack webhook URL for deploy notifications (optional)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}


### PR DESCRIPTION
Closes #889

Delivers notifications to slack on successful/failed/cancelled production deploys.

Example messages are in `#testiny`.

The calling trigger (eg promote or rollback) is in the footer of the message.