### PR TITLE
Authenticate users with client roles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,7 @@ AZURE_LOGIN_URL=https://login.microsoftonline.com/<tenantId>
 # Keycloak config (when AUTH_PROVIDER=keycloak)
 KEYCLOAK_URL=http://localhost:8080
 KEYCLOAK_REALM=destiny
-KEYCLOAK_CLIENT_ID=destiny-repository-client
+KEYCLOAK_CLIENT_ID=destiny-repository-client-local
 
 MESSAGE_BROKER_URL=amqp://guest:guest@localhost:5672
 MESSAGE_BROKER_NAMESPACE=destiny-repository-staging.servicebus.windows.net

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ To get a token for use in a development environment, there is a utility module:
 uv run python -m app.utils.get_token
 ```
 
-### Keycloak Authentication (Experimental)
+### Keycloak Authentication
 
 Keycloak support is experimental as we transition from Azure AD to Keycloak. It is controlled by the `AUTH_PROVIDER` setting in `.env`:
 
@@ -205,8 +205,12 @@ Keycloak support is experimental as we transition from Azure AD to Keycloak. It 
 AUTH_PROVIDER=keycloak
 KEYCLOAK_URL=http://localhost:8080
 KEYCLOAK_REALM=destiny
-KEYCLOAK_CLIENT_ID=destiny-repository-client
+KEYCLOAK_CLIENT_ID=destiny-repository-client-local
 ```
+
+The client is named after the environment, and authorization is the set of client
+roles the principal holds on it (`resource_access["destiny-repository-client-local"]`
+in local development). Realm roles and the `scope` claim confer no access.
 
 When `ENV=local` (the default in `.env.example`), authentication is bypassed entirely regardless of the provider. To test with Keycloak auth enforced locally, start Keycloak and run the app via docker compose:
 

--- a/README.md
+++ b/README.md
@@ -212,13 +212,21 @@ The authorization is the set of client
 roles the principal holds on it (`resource_access["destiny-repository-client-local"]`
 in local development). Realm roles and the `scope` claim confer no access.
 
-When `ENV=local` (the default in `.env.example`), authentication is bypassed entirely regardless of the provider. To test with Keycloak auth enforced locally, start Keycloak and run the app via docker compose:
+When `ENV=local` (the default in `.env.example`), authentication is bypassed entirely regardless of the provider. To test with Keycloak auth enforced locally, set `BYPASS_AUTH=false` and configure the internal Keycloak URL (`http://keycloak:8080`) for token validation, while using `http://localhost:8080` as the issuer URL to match tokens obtained from the browser.
+
+```dotenv
+KEYCLOAK_URL=http://keycloak:8080
+KEYCLOAK_REALM=destiny
+KEYCLOAK_CLIENT_ID=destiny-repository-client-local
+KEYCLOAK_ISSUER_URL=http://localhost:8080
+BYPASS_AUTH=false
+```
+
+Then start Keycloak and run the app via docker compose:
 
 ```sh
 docker compose --profile keycloak --profile app up
 ```
-
-Set `BYPASS_AUTH=false` and configure the internal Keycloak URL (`http://keycloak:8080`) for token validation, while using `http://localhost:8080` as the issuer URL to match tokens obtained from the browser.
 
 The Keycloak realm is auto-imported from the [keycloak/](keycloak/) directory on startup. The admin console is available at <http://localhost:8080> with credentials `admin`/`admin`.
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ uv run python -m app.utils.get_token
 
 ### Keycloak Authentication
 
-Keycloak support is experimental as we transition from Azure AD to Keycloak. It is controlled by the `AUTH_PROVIDER` setting in `.env`:
+Keycloak support is controlled by the `AUTH_PROVIDER` setting in `.env`:
 
 ```dotenv
 AUTH_PROVIDER=keycloak

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ KEYCLOAK_REALM=destiny
 KEYCLOAK_CLIENT_ID=destiny-repository-client-local
 ```
 
-The client is named after the environment, and authorization is the set of client
+The authorization is the set of client
 roles the principal holds on it (`resource_access["destiny-repository-client-local"]`
 in local development). Realm roles and the `scope` claim confer no access.
 

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -114,7 +114,8 @@ def derive_entitlements(
     """
     Compute the entitlements granted to a JWT principal.
 
-    ``granted`` is the union of scope and role strings carried in the token.
+    ``granted`` is the set of grants carried in the token: scopes and
+    app roles on the Azure path, client roles on the Keycloak path.
     Robots authenticate via HMAC and source their entitlements from the
     ``Robot`` record directly, bypassing this function.
     """
@@ -469,6 +470,8 @@ class KeycloakJwtAuth(JwtAuth):
     Similar to AzureJwtAuth but configured for Keycloak's OIDC endpoints.
     Uses joserfc for JWT verification and JWKS handling.
 
+    Authorization is the set of client roles held on ``client_id``.
+
     Example:
         .. code-block:: python
 
@@ -477,7 +480,7 @@ class KeycloakJwtAuth(JwtAuth):
                     keycloak_url="http://localhost:8080",
                     realm="destiny",
                     client_id="destiny-repository-client",
-                    scope=AuthScope.REFERENCE_READER,
+                    role=AuthRole.REFERENCE_READER,
                 )
 
             caching_auth = CachingStrategyAuth(selector=auth_strategy)
@@ -506,9 +509,10 @@ class KeycloakJwtAuth(JwtAuth):
         Args:
             keycloak_url: The base URL of the Keycloak server (used for JWKS fetching)
             realm: The Keycloak realm name
-            client_id: The client ID (audience) for token validation
-            scope: The required scope in the token's `scope` claim
-            role: The required role in `realm_access.roles` or client roles
+            client_id: The client ID (audience) for token validation, and the
+                `resource_access` key authorization is read from.
+            scope: Accepted for parity with `AzureJwtAuth` and ignored.
+            role: The required role in `resource_access.{client_id}.roles`
             cache_ttl: Time to live for JWKS cache entries, defaults to 24 hours
             issuer_url: Optional separate URL for token issuer validation. Defaults to
                 keycloak_url if not provided. Useful when tokens are issued with a
@@ -598,39 +602,38 @@ class KeycloakJwtAuth(JwtAuth):
             return KeySet.import_key_set(response.json())
 
     def _extract_roles(self, verified_claims: dict[str, Any]) -> frozenset[str]:
-        """Collect all role strings from realm_access and resource_access."""
-        realm_roles = verified_claims.get("realm_access", {}).get("roles", [])
-        client_roles = (
+        """
+        Collect the client roles granted on this deployment's Keycloak client.
+
+        Take roles from its ``resource_access`` entry alone.
+        """
+        return frozenset(
             verified_claims.get("resource_access", {})
             .get(self.client_id, {})
             .get("roles", [])
         )
-        return frozenset(realm_roles) | frozenset(client_roles)
 
-    def _require_scope_or_role(self, verified_claims: dict[str, Any]) -> SubjectType:
+    def _subject_type(self, verified_claims: dict[str, Any]) -> SubjectType:
         """
-        Check for required scope or role in the Keycloak token.
+        Classify the authenticated principal, for telemetry only.
 
-        Keycloak tokens have:
-        - scope: space-separated string of scopes
-        - realm_access.roles: list of realm roles
-        - resource_access.{client_id}.roles: list of client roles
-
-        Keycloak tokens always contain a ``scope`` claim. We therefore check
-        scope first and fall back to roles, allowing service accounts that
-        have a realm/client role but no explicit scope.
+        Keycloak names a service account's principal ``service-account-{azp}``;
+        any other token carrying ``preferred_username`` belongs to a user.
         """
-        if self.scope and verified_claims.get("scope"):
-            scopes = verified_claims["scope"].split()
-            if self.scope.value in scopes:
-                return SubjectType.USER
+        username = verified_claims.get("preferred_username")
+        azp = verified_claims.get("azp")
+        if username and username != f"service-account-{azp}":
+            return SubjectType.USER
+        return SubjectType.SERVICE
 
+    def _require_role(self, verified_claims: dict[str, Any]) -> SubjectType:
+        """Check for the required client role in the Keycloak token."""
         if self.role and self.role.value in self._extract_roles(verified_claims):
-            return SubjectType.SERVICE
+            return self._subject_type(verified_claims)
 
         raise AuthError(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="The token does not contain the required scope or role.",
+            detail="The token does not contain the required role.",
         )
 
     async def __call__(
@@ -646,9 +649,8 @@ class KeycloakJwtAuth(JwtAuth):
             )
 
         verified_claims = await self.verify_token(credentials.credentials)
-        subject_type = self._require_scope_or_role(verified_claims)
+        subject_type = self._require_role(verified_claims)
 
-        scopes = set(verified_claims.get("scope", "").split())
         roles = self._extract_roles(verified_claims)
 
         span = trace.get_current_span()
@@ -659,7 +661,7 @@ class KeycloakJwtAuth(JwtAuth):
         if roles:
             span.set_attribute(Attributes.USER_ROLES, ",".join(roles))
 
-        return derive_entitlements(subject_type, frozenset(scopes | roles))
+        return derive_entitlements(subject_type, roles)
 
 
 class MultiIssuerJwtAuth(JwtAuth):

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -477,9 +477,9 @@ class KeycloakJwtAuth(JwtAuth):
 
             def auth_strategy():
                 return KeycloakJwtAuth(
-                    keycloak_url="http://localhost:8080",
+                    keycloak_url="https://keycloak-deployment.org",
                     realm="destiny",
-                    client_id="destiny-repository-client",
+                    client_id="destiny-repository-client-id",
                     role=AuthRole.REFERENCE_READER,
                 )
 

--- a/docs/procedures/oauth.rst
+++ b/docs/procedures/oauth.rst
@@ -46,7 +46,7 @@ Provisioning
 
 In order to obtain a token from the DESTINY authentication server, you will need to be enrolled in our auth server. Please reach out if you need access.
 
-Everyone will have ``reference.reader``, but please reach out if you need additional permission scopes. You can see the available scopes per API resource in `the API documentation <https://api.evidence-repository.org/redoc>`_ - it is listed under each sub-category.
+Everyone enrolled will have ``reference.reader``, but please reach out if you need additional permissions, naming the environments they apply to. You can see which permission each API resource requires in `the API documentation <https://api.evidence-repository.org/redoc>`_ - it is listed under each sub-category.
 
 
 Obtaining a token
@@ -88,14 +88,16 @@ If you are not using Python, or want to authenticate from a tool like Postman, y
     "Client ID (production)", ``destiny-auth-client-production``
     "Grant type", "Authorization Code (with PKCE)"
     "Code challenge method", ``S256``
-    "Default scopes", ``openid profile email``
+    "Scopes", ``openid profile email``
+
+Request no other scopes - your permissions are already carried in the token.
 
 The redirect URI you supply must be registered on the Keycloak client. At present we allow localhost and postman redirect URIs, but if you want to use a different one, please reach out so we can add it.
 
 Service-to-service authentication
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For backend services, scheduled jobs, or anything else that runs without a human user. Uses the OAuth 2.0 client credentials flow. This requires a dedicated Keycloak client with Service Accounts enabled — please reach out so we can provision one. Scopes for these clients are mapped from service account roles in Keycloak, not group membership.
+For backend services, scheduled jobs, or anything else that runs without a human user. Uses the OAuth 2.0 client credentials flow. This requires a dedicated Keycloak client with Service Accounts enabled — please reach out so we can provision one, telling us which environments it needs and what it needs to do there.
 
 Using the SDK
 """""""""""""
@@ -163,5 +165,7 @@ The tokens will expire after a certain period (usually two hours). After expirat
 
 Troubleshooting
 ---------------
+
+A ``401`` means the token was rejected - most often expired, or obtained for a different environment than the API you called. A ``403`` means you lack the permission that resource requires.
 
 Please reach out if you experience any issues either obtaining or using tokens - most likely, we need to update some permissions.

--- a/keycloak/local-destiny-realm.json
+++ b/keycloak/local-destiny-realm.json
@@ -15,109 +15,67 @@
   "ssoSessionMaxLifespan": 36000,
   "offlineSessionIdleTimeout": 2592000,
   "roles": {
-    "realm": [
-      {
-        "name": "administrator",
-        "description": "Can manage the repository itself"
-      },
-      {
-        "name": "import.writer",
-        "description": "Importers can import"
-      },
-      {
-        "name": "reference.reader",
-        "description": "Can view references"
-      },
-      {
-        "name": "reference.deduplicator",
-        "description": "Can deduplicate references"
-      },
-      {
-        "name": "enhancement_request.writer",
-        "description": "Can request enhancements"
-      },
-      {
-        "name": "robot.writer",
-        "description": "Can register robots and rotate robot client secrets"
-      }
-    ]
+    "client": {
+      "destiny-repository-client-local": [
+        {
+          "name": "administrator",
+          "description": "Can manage the repository itself"
+        },
+        {
+          "name": "import.writer",
+          "description": "Importers can import"
+        },
+        {
+          "name": "reference.reader",
+          "description": "Can view references"
+        },
+        {
+          "name": "reference.full_text.reader",
+          "description": "Can view reference full text"
+        },
+        {
+          "name": "reference.deduplicator",
+          "description": "Can deduplicate references"
+        },
+        {
+          "name": "enhancement_request.writer",
+          "description": "Can request enhancements"
+        },
+        {
+          "name": "robot.writer",
+          "description": "Can register robots and rotate robot client secrets"
+        },
+        {
+          "name": "robot.entitlement.writer",
+          "description": "Can manage robot entitlements"
+        }
+      ]
+    }
   },
   "groups": [
     {
-      "name": "consumers",
-      "realmRoles": ["reference.reader"]
-    },
-    {
-      "name": "developers",
-      "realmRoles": [
-        "administrator",
-        "import.writer",
-        "reference.reader",
-        "reference.deduplicator",
-        "enhancement_request.writer",
-        "robot.writer"
-      ]
-    }
-  ],
-  "clientScopes": [
-    {
-      "name": "administrator.all",
-      "description": "Full administrative access",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "true",
-        "display.on.consent.screen": "true"
+      "name": "consumers-local",
+      "clientRoles": {
+        "destiny-repository-client-local": ["reference.reader"]
       }
     },
     {
-      "name": "import.writer.all",
-      "description": "Import data access",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "true",
-        "display.on.consent.screen": "true"
-      }
-    },
-    {
-      "name": "reference.reader.all",
-      "description": "Reference read access",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "true",
-        "display.on.consent.screen": "true"
-      }
-    },
-    {
-      "name": "reference.deduplicator.all",
-      "description": "Reference deduplication access",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "true",
-        "display.on.consent.screen": "true"
-      }
-    },
-    {
-      "name": "enhancement_request.writer.all",
-      "description": "Enhancement request write access",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "true",
-        "display.on.consent.screen": "true"
-      }
-    },
-    {
-      "name": "robot.writer.all",
-      "description": "Robot management access",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "true",
-        "display.on.consent.screen": "true"
+      "name": "developers-local",
+      "clientRoles": {
+        "destiny-repository-client-local": [
+          "administrator",
+          "import.writer",
+          "reference.reader",
+          "reference.deduplicator",
+          "enhancement_request.writer",
+          "robot.writer"
+        ]
       }
     }
   ],
   "clients": [
     {
-      "clientId": "destiny-auth-client",
+      "clientId": "destiny-auth-client-local",
       "name": "DESTINY Repository Auth Client",
       "description": "Public client for all user authentication (UI, CLI, Postman, API testing tools)",
       "enabled": true,
@@ -135,14 +93,6 @@
         "https://oauth.pstmn.io/v1/callback"
       ],
       "webOrigins": ["http://localhost:3000", "https://oauth.pstmn.io"],
-      "optionalClientScopes": [
-        "administrator.all",
-        "import.writer.all",
-        "reference.reader.all",
-        "reference.deduplicator.all",
-        "enhancement_request.writer.all",
-        "robot.writer.all"
-      ],
       "attributes": {
         "oauth2.device.authorization.grant.enabled": "true",
         "pkce.code.challenge.method": "S256",
@@ -155,7 +105,7 @@
           "protocolMapper": "oidc-audience-mapper",
           "consentRequired": false,
           "config": {
-            "included.client.audience": "destiny-repository-client",
+            "included.client.audience": "destiny-repository-client-local",
             "id.token.claim": "false",
             "access.token.claim": "true"
           }
@@ -163,7 +113,7 @@
       ]
     },
     {
-      "clientId": "destiny-repository-client",
+      "clientId": "destiny-repository-client-local",
       "name": "DESTINY Repository API",
       "description": "Backend API resource server",
       "enabled": true,
@@ -191,33 +141,7 @@
           "temporary": false
         }
       ],
-      "groups": ["developers"]
-    }
-  ],
-  "scopeMappings": [
-    {
-      "clientScope": "administrator.all",
-      "roles": ["administrator"]
-    },
-    {
-      "clientScope": "import.writer.all",
-      "roles": ["import.writer"]
-    },
-    {
-      "clientScope": "reference.reader.all",
-      "roles": ["reference.reader"]
-    },
-    {
-      "clientScope": "reference.deduplicator.all",
-      "roles": ["reference.deduplicator"]
-    },
-    {
-      "clientScope": "enhancement_request.writer.all",
-      "roles": ["enhancement_request.writer"]
-    },
-    {
-      "clientScope": "robot.writer.all",
-      "roles": ["robot.writer"]
+      "groups": ["developers-local"]
     }
   ]
 }

--- a/keycloak/local-destiny-realm.json
+++ b/keycloak/local-destiny-realm.json
@@ -83,6 +83,7 @@
       "directAccessGrantsEnabled": false,
       "standardFlowEnabled": true,
       "implicitFlowEnabled": false,
+      "fullScopeAllowed": false,
       "protocol": "openid-connect",
       "rootUrl": "http://localhost:3000",
       "baseUrl": "/",
@@ -159,5 +160,22 @@
       ],
       "groups": ["consumers-local"]
     }
-  ]
+  ],
+  "clientScopeMappings": {
+    "destiny-repository-client-local": [
+      {
+        "client": "destiny-auth-client-local",
+        "roles": [
+          "administrator",
+          "import.writer",
+          "reference.reader",
+          "reference.full_text.reader",
+          "reference.deduplicator",
+          "enhancement_request.writer",
+          "robot.writer",
+          "robot.entitlement.writer"
+        ]
+      }
+    ]
+  }
 }

--- a/keycloak/local-destiny-realm.json
+++ b/keycloak/local-destiny-realm.json
@@ -142,6 +142,22 @@
         }
       ],
       "groups": ["developers-local"]
+    },
+    {
+      "username": "consumeruser",
+      "email": "consumeruser@localhost",
+      "emailVerified": true,
+      "enabled": true,
+      "firstName": "Consumer",
+      "lastName": "User",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "testpass",
+          "temporary": false
+        }
+      ],
+      "groups": ["consumers-local"]
     }
   ]
 }

--- a/libs/sdk/pyproject.toml
+++ b/libs/sdk/pyproject.toml
@@ -36,7 +36,7 @@ license = "Apache-2.0"
 name = "destiny_sdk"
 readme = "README.md"
 requires-python = ">=3.12, <4"
-version = "0.15.0"
+version = "0.16.0"
 
 [project.optional-dependencies]
 labs = []

--- a/libs/sdk/src/destiny_sdk/client.py
+++ b/libs/sdk/src/destiny_sdk/client.py
@@ -499,12 +499,16 @@ class KeycloakOAuthMiddleware(httpx.Auth):
     Initial login will be interactive through a browser window. Subsequent token
     retrievals will use cached tokens and refreshes where possible.
 
+    Authorization is the set of client roles held on the repository client of the
+    environment being accessed, so the client ID names an environment and no
+    scopes are requested.
+
     .. code-block:: python
 
         auth = KeycloakOAuthMiddleware(
-            keycloak_url="http://localhost:8080",
+            keycloak_url="https://auth.evidence-repository.org",
             realm="destiny",
-            client_id="destiny-auth-client",
+            client_id="destiny-auth-client-staging",
         )
 
     **Confidential Client (machine-to-machine)**
@@ -515,7 +519,7 @@ class KeycloakOAuthMiddleware(httpx.Auth):
     .. code-block:: python
 
         auth = KeycloakOAuthMiddleware(
-            keycloak_url="http://localhost:8080",
+            keycloak_url="https://auth.evidence-repository.org",
             realm="destiny",
             client_id="my-service-client",
             client_secret="my-secret",
@@ -523,13 +527,12 @@ class KeycloakOAuthMiddleware(httpx.Auth):
 
     """
 
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         keycloak_url: str,
         realm: str,
-        client_id: str = "destiny-auth-client",
+        client_id: str,
         client_secret: SecretStr | None = None,
-        scopes: list[str] | None = None,
         callback_port: int = 8400,
     ) -> None:
         """
@@ -539,13 +542,11 @@ class KeycloakOAuthMiddleware(httpx.Auth):
         :type keycloak_url: str
         :param realm: The Keycloak realm name.
         :type realm: str
-        :param client_id: The OAuth2 client ID.
+        :param client_id: The OAuth2 client ID, e.g. destiny-auth-client-staging.
         :type client_id: str
         :param client_secret: The OAuth2 client secret. When provided, uses
             client credentials flow instead of authorization code flow.
         :type client_secret: SecretStr | None
-        :param scopes: Optional list of scopes to request.
-        :type scopes: list[str] | None
         :param callback_port: Port for local callback server during auth code flow.
         :type callback_port: int
         """
@@ -566,7 +567,6 @@ class KeycloakOAuthMiddleware(httpx.Auth):
                 callback_port=callback_port,
             )
             self._get_token = self._get_token_from_auth_code
-        self._scopes = scopes
         self._token: TokenResponse | None = None
 
     def _get_token_from_auth_code(self, *, force_refresh: bool = False) -> str:
@@ -594,7 +594,7 @@ class KeycloakOAuthMiddleware(httpx.Auth):
             return self._token.access_token
 
         # Perform full authentication flow
-        self._token = self._auth_flow.authenticate(scopes=self._scopes)
+        self._token = self._auth_flow.authenticate()
         return self._token.access_token
 
     def _get_token_from_client_credentials(
@@ -616,7 +616,7 @@ class KeycloakOAuthMiddleware(httpx.Auth):
         if self._token and not force_refresh:
             return self._token.access_token
 
-        self._token = self._auth_flow.authenticate(scopes=self._scopes)
+        self._token = self._auth_flow.authenticate()
         return self._token.access_token
 
     def auth_flow(
@@ -685,7 +685,6 @@ class OAuthMiddleware(httpx.Auth):
         realm: str = "destiny",
         client_id: str | None = None,
         client_secret: SecretStr | None = None,
-        scopes: list[str] | None = None,
         callback_port: int = 8400,
         azure_client_id: str | None = None,
         azure_application_id: str | None = None,
@@ -738,7 +737,6 @@ class OAuthMiddleware(httpx.Auth):
                 realm=realm,
                 client_id=client_id,
                 client_secret=client_secret,
-                scopes=scopes,
                 callback_port=callback_port,
             )
 

--- a/libs/sdk/src/destiny_sdk/keycloak_auth.py
+++ b/libs/sdk/src/destiny_sdk/keycloak_auth.py
@@ -28,6 +28,8 @@ class KeycloakClientCredentialsFlow:
     Uses a confidential client (client_id + client_secret) to obtain tokens
     without user interaction.
 
+    Authorization is the set of client roles assigned to the service account.
+
     Example usage:
         flow = KeycloakClientCredentialsFlow(
             keycloak_url="http://localhost:8080",
@@ -35,7 +37,7 @@ class KeycloakClientCredentialsFlow:
             client_id="my-service-client",
             client_secret="my-secret",
         )
-        token = flow.authenticate(scopes=["import.writer.all"])
+        token = flow.authenticate()
     """
 
     def __init__(
@@ -63,15 +65,9 @@ class KeycloakClientCredentialsFlow:
         base = f"{self.keycloak_url}/realms/{self.realm}/protocol/openid-connect"
         self.token_endpoint = f"{base}/token"
 
-    def authenticate(
-        self,
-        scopes: list[str] | None = None,
-    ) -> TokenResponse:
+    def authenticate(self) -> TokenResponse:
         """
         Obtain an access token using client credentials.
-
-        Args:
-            scopes: Optional list of scopes to request
 
         Returns:
             TokenResponse with access token (refresh_token will be None)
@@ -83,14 +79,10 @@ class KeycloakClientCredentialsFlow:
             token_endpoint_auth_method="client_secret_post",  # noqa: S106
         )
 
-        scope_str = "openid"
-        if scopes:
-            scope_str = f"{scope_str} {' '.join(scopes)}"
-
         token = client.fetch_token(
             self.token_endpoint,
             grant_type="client_credentials",
-            scope=scope_str,
+            scope="openid",
         )
 
         return TokenResponse(
@@ -109,22 +101,23 @@ class KeycloakAuthCodeFlow:
     Uses authlib for OAuth2/OIDC handling, which provides built-in support for
     PKCE, token refresh, and error handling.
 
-    Uses the same `destiny-auth-client` as all other human users.
-    Scopes are determined by the user's group membership (consumers vs developers).
+    Authorization is the set of client roles the user's group membership grants;
+    there is nothing to request.
 
     Example usage:
         flow = KeycloakAuthCodeFlow(
             keycloak_url="http://localhost:8080",
             realm="destiny",
+            client_id="destiny-auth-client",
         )
-        token = flow.authenticate(scopes=["reference.reader.all"])
+        token = flow.authenticate()
     """
 
     def __init__(
         self,
         keycloak_url: str,
         realm: str,
-        client_id: str = "destiny-auth-client",
+        client_id: str,
         callback_port: int = 8400,
     ) -> None:
         """
@@ -133,7 +126,7 @@ class KeycloakAuthCodeFlow:
         Args:
             keycloak_url: Base URL of the Keycloak server
             realm: Keycloak realm name
-            client_id: OIDC client ID (defaults to destiny-auth-client)
+            client_id: OIDC client ID
             callback_port: Port for local callback server
 
         """
@@ -182,7 +175,6 @@ class KeycloakAuthCodeFlow:
 
     def authenticate(
         self,
-        scopes: list[str] | None = None,
         *,
         open_browser: bool = True,
     ) -> TokenResponse:
@@ -193,7 +185,6 @@ class KeycloakAuthCodeFlow:
         the authorization code for tokens.
 
         Args:
-            scopes: Optional list of scopes to request
             open_browser: Whether to automatically open the browser
 
         Returns:
@@ -202,10 +193,7 @@ class KeycloakAuthCodeFlow:
         """
         client = self._create_client()
 
-        # Build scope string
         scope_str = "openid profile email"
-        if scopes:
-            scope_str = f"{scope_str} {' '.join(scopes)}"
 
         # Generate PKCE code_verifier. authlib derives the S256 code_challenge
         # from this for the authorization request, and sends it back with the

--- a/libs/sdk/src/destiny_sdk/keycloak_auth.py
+++ b/libs/sdk/src/destiny_sdk/keycloak_auth.py
@@ -32,7 +32,7 @@ class KeycloakClientCredentialsFlow:
 
     Example usage:
         flow = KeycloakClientCredentialsFlow(
-            keycloak_url="http://localhost:8080",
+            keycloak_url="https://keycloak-deployment.org",
             realm="destiny",
             client_id="my-service-client",
             client_secret="my-secret",
@@ -106,9 +106,9 @@ class KeycloakAuthCodeFlow:
 
     Example usage:
         flow = KeycloakAuthCodeFlow(
-            keycloak_url="http://localhost:8080",
+            keycloak_url="https://keycloak-deployment.org",
             realm="destiny",
-            client_id="destiny-auth-client",
+            client_id="destiny-auth-client-id",
         )
         token = flow.authenticate()
     """

--- a/libs/sdk/tests/unit/test_client.py
+++ b/libs/sdk/tests/unit/test_client.py
@@ -631,7 +631,7 @@ class TestKeycloakOAuthMiddleware:
                 "access_token": mock_token,
                 "expires_in": 300,
                 "token_type": "Bearer",
-                "scope": "openid import.writer.all",
+                "scope": "openid",
             },
         )
 
@@ -640,7 +640,6 @@ class TestKeycloakOAuthMiddleware:
             realm="destiny",
             client_id="test-service-client",
             client_secret=SecretStr("test-secret"),
-            scopes=["import.writer.all"],
         )
 
         request = httpx.Request("GET", "https://api.example.com/test")

--- a/tests/core/test_keycloak_auth.py
+++ b/tests/core/test_keycloak_auth.py
@@ -11,7 +11,8 @@ from joserfc import jwt as joserfc_jwt
 from joserfc.jwk import KeySet, RSAKey
 from pytest_httpx import HTTPXMock
 
-from app.api.auth import KeycloakJwtAuth
+from app.api.auth import KeycloakJwtAuth, SubjectType
+from app.core.entitlements import Entitlement
 
 
 class FakeAuthScopes(StrEnum):
@@ -24,6 +25,7 @@ class FakeAuthRoles(StrEnum):
     """Fake authentication roles used for testing."""
 
     READER = "reference.reader"
+    FULL_TEXT_READER = "reference.full_text.reader"
 
 
 class TokenGenerator(Protocol):
@@ -33,7 +35,9 @@ class TokenGenerator(Protocol):
         self,
         user_payload: dict | None = None,
         scope: str | None = None,
-        role: str | None = None,
+        roles: list[str] | None = None,
+        realm_roles: list[str] | None = None,
+        roles_client_id: str | None = None,
     ) -> str:
         """Generate a fake Keycloak token for testing."""
         ...
@@ -79,7 +83,7 @@ def fake_realm() -> str:
 @pytest.fixture
 def fake_client_id() -> str:
     """Return a fake client ID for testing."""
-    return "destiny-repository-client"
+    return "destiny-repository-client-test"
 
 
 @pytest.fixture
@@ -101,26 +105,17 @@ def auth(
     fake_realm: str,
     fake_client_id: str,
 ) -> KeycloakJwtAuth:
-    """Create a KeycloakJwtAuth instance for testing with scope."""
+    """
+    Create a KeycloakJwtAuth instance for testing.
+
+    Configured as the routes configure it: with both a scope and a role, of
+    which only the role is honoured.
+    """
     return KeycloakJwtAuth(
         keycloak_url=fake_keycloak_url,
         realm=fake_realm,
         client_id=fake_client_id,
         scope=FakeAuthScopes.READ_ALL,
-    )
-
-
-@pytest.fixture
-def auth_with_role(
-    fake_keycloak_url: str,
-    fake_realm: str,
-    fake_client_id: str,
-) -> KeycloakJwtAuth:
-    """Create a KeycloakJwtAuth instance for testing with role."""
-    return KeycloakJwtAuth(
-        keycloak_url=fake_keycloak_url,
-        realm=fake_realm,
-        client_id=fake_client_id,
         role=FakeAuthRoles.READER,
     )
 
@@ -143,7 +138,9 @@ def generate_keycloak_token(
     def __generate_token(
         user_payload: dict | None = None,
         scope: str | None = None,
-        role: str | None = None,
+        roles: list[str] | None = None,
+        realm_roles: list[str] | None = None,
+        roles_client_id: str | None = None,
     ) -> str:
         if user_payload is None:
             user_payload = {}
@@ -155,7 +152,8 @@ def generate_keycloak_token(
             "exp": int((now + datetime.timedelta(minutes=10)).timestamp()),
             "aud": fake_client_id,
             "iss": f"{fake_keycloak_url}/realms/{fake_realm}",
-            "azp": "destiny-auth-client",
+            "azp": "destiny-auth-client-test",
+            "preferred_username": "testuser",
             "typ": "Bearer",
         }
 
@@ -163,8 +161,12 @@ def generate_keycloak_token(
 
         if scope:
             payload["scope"] = f"openid profile email {scope}"
-        if role:
-            payload["realm_access"] = {"roles": [role]}
+        if roles:
+            payload["resource_access"] = {
+                roles_client_id or fake_client_id: {"roles": roles}
+            }
+        if realm_roles:
+            payload["realm_access"] = {"roles": realm_roles}
 
         header = {"alg": "RS256", "kid": _test_private_key["kid"]}
         return joserfc_jwt.encode(header, payload, private_key)
@@ -305,60 +307,25 @@ async def test_verify_token_parse_failure_after_retry(
     assert "Unable to parse authentication token" in excinfo.value.detail
 
 
-async def test_requires_scope_success(
+async def test_requires_role_success(
     httpx_mock: HTTPXMock,
     auth: KeycloakJwtAuth,
     fake_public_key: dict,
     generate_keycloak_token: TokenGenerator,
     fake_request: Request,
 ):
-    """Test that we successfully validate a token with the requested scope."""
+    """Test that a client role on the configured client grants access."""
     httpx_mock.add_response(json={"keys": [fake_public_key]})
 
-    token = generate_keycloak_token(scope=FakeAuthScopes.READ_ALL.value)
+    token = generate_keycloak_token(roles=[FakeAuthRoles.READER.value])
     credentials = Mock()
     credentials.credentials = token
     assert isinstance(await auth(fake_request, credentials), frozenset)
 
 
-async def test_requires_role_success(
-    httpx_mock: HTTPXMock,
-    auth_with_role: KeycloakJwtAuth,
-    fake_public_key: dict,
-    generate_keycloak_token: TokenGenerator,
-    fake_request: Request,
-):
-    """Test that we successfully validate a token with the requested role."""
-    httpx_mock.add_response(json={"keys": [fake_public_key]})
-
-    token = generate_keycloak_token(role=FakeAuthRoles.READER.value)
-    credentials = Mock()
-    credentials.credentials = token
-    assert isinstance(await auth_with_role(fake_request, credentials), frozenset)
-
-
-async def test_requires_scope_not_found(
-    httpx_mock: HTTPXMock,
-    auth: KeycloakJwtAuth,
-    fake_public_key: dict,
-    generate_keycloak_token: TokenGenerator,
-    fake_request: Request,
-):
-    """Test that we raise an exception with a token without the appropriate scope."""
-    httpx_mock.add_response(json={"keys": [fake_public_key]})
-
-    token = generate_keycloak_token(scope="wrong.scope")
-    credentials = Mock()
-    credentials.credentials = token
-    with pytest.raises(HTTPException) as excinfo:
-        await auth(fake_request, credentials)
-    assert excinfo.value.status_code == status.HTTP_403_FORBIDDEN
-    assert "required scope or role" in excinfo.value.detail
-
-
 async def test_requires_role_not_found(
     httpx_mock: HTTPXMock,
-    auth_with_role: KeycloakJwtAuth,
+    auth: KeycloakJwtAuth,
     fake_public_key: dict,
     generate_keycloak_token: TokenGenerator,
     fake_request: Request,
@@ -366,39 +333,120 @@ async def test_requires_role_not_found(
     """Test that we raise an exception with a token without the appropriate role."""
     httpx_mock.add_response(json={"keys": [fake_public_key]})
 
-    token = generate_keycloak_token(role="wrong.role")
+    token = generate_keycloak_token(roles=["wrong.role"])
     credentials = Mock()
     credentials.credentials = token
     with pytest.raises(HTTPException) as excinfo:
-        await auth_with_role(fake_request, credentials)
+        await auth(fake_request, credentials)
     assert excinfo.value.status_code == status.HTTP_403_FORBIDDEN
-    assert "required scope or role" in excinfo.value.detail
+    assert "required role" in excinfo.value.detail
 
 
-async def test_scope_fallback_to_role(  # noqa: PLR0913
+async def test_scope_confers_no_access(
     httpx_mock: HTTPXMock,
-    fake_keycloak_url: str,
-    fake_realm: str,
-    fake_client_id: str,
+    auth: KeycloakJwtAuth,
     fake_public_key: dict,
     generate_keycloak_token: TokenGenerator,
     fake_request: Request,
 ):
-    """Test that role check is used when scope is missing but role is present."""
-    auth = KeycloakJwtAuth(
-        keycloak_url=fake_keycloak_url,
-        realm=fake_realm,
-        client_id=fake_client_id,
-        scope=FakeAuthScopes.READ_ALL,
-        role=FakeAuthRoles.READER,
-    )
+    """Test that the scope claim alone does not authorize a request."""
     httpx_mock.add_response(json={"keys": [fake_public_key]})
 
-    # Token has wrong scope but correct role
-    token = generate_keycloak_token(scope="openid", role=FakeAuthRoles.READER.value)
+    token = generate_keycloak_token(scope=FakeAuthScopes.READ_ALL.value)
     credentials = Mock()
     credentials.credentials = token
-    assert isinstance(await auth(fake_request, credentials), frozenset)
+    with pytest.raises(HTTPException) as excinfo:
+        await auth(fake_request, credentials)
+    assert excinfo.value.status_code == status.HTTP_403_FORBIDDEN
+
+
+async def test_realm_role_confers_no_access(
+    httpx_mock: HTTPXMock,
+    auth: KeycloakJwtAuth,
+    fake_public_key: dict,
+    generate_keycloak_token: TokenGenerator,
+    fake_request: Request,
+):
+    """Test that a realm role of the same name does not authorize a request."""
+    httpx_mock.add_response(json={"keys": [fake_public_key]})
+
+    token = generate_keycloak_token(realm_roles=[FakeAuthRoles.READER.value])
+    credentials = Mock()
+    credentials.credentials = token
+    with pytest.raises(HTTPException) as excinfo:
+        await auth(fake_request, credentials)
+    assert excinfo.value.status_code == status.HTTP_403_FORBIDDEN
+
+
+async def test_role_on_another_client_confers_no_access(
+    httpx_mock: HTTPXMock,
+    auth: KeycloakJwtAuth,
+    fake_public_key: dict,
+    generate_keycloak_token: TokenGenerator,
+    fake_request: Request,
+):
+    """Test that another environment's client roles do not authorize a request."""
+    httpx_mock.add_response(json={"keys": [fake_public_key]})
+
+    token = generate_keycloak_token(
+        roles=[FakeAuthRoles.READER.value],
+        roles_client_id="destiny-repository-client-production",
+    )
+    credentials = Mock()
+    credentials.credentials = token
+    with pytest.raises(HTTPException) as excinfo:
+        await auth(fake_request, credentials)
+    assert excinfo.value.status_code == status.HTTP_403_FORBIDDEN
+
+
+async def test_entitlements_derive_from_client_roles_only(
+    httpx_mock: HTTPXMock,
+    auth: KeycloakJwtAuth,
+    fake_public_key: dict,
+    generate_keycloak_token: TokenGenerator,
+    fake_request: Request,
+):
+    """Test that entitlements come from client roles and not from scopes."""
+    httpx_mock.add_response(json={"keys": [fake_public_key]})
+    credentials = Mock()
+
+    credentials.credentials = generate_keycloak_token(
+        roles=[FakeAuthRoles.READER.value, FakeAuthRoles.FULL_TEXT_READER.value],
+    )
+    assert Entitlement.FULL_TEXT in await auth(fake_request, credentials)
+
+    # The equivalent scope grants nothing, even alongside a role that authorizes.
+    credentials.credentials = generate_keycloak_token(
+        roles=[FakeAuthRoles.READER.value],
+        scope="reference.full_text.reader.all",
+    )
+    assert Entitlement.FULL_TEXT not in await auth(fake_request, credentials)
+
+
+@pytest.mark.parametrize(
+    ("claims", "expected"),
+    [
+        (
+            {"preferred_username": "testuser", "azp": "destiny-auth-client-test"},
+            SubjectType.USER,
+        ),
+        (
+            {
+                "preferred_username": "service-account-some-robot",
+                "azp": "some-robot",
+            },
+            SubjectType.SERVICE,
+        ),
+        ({"azp": "some-robot"}, SubjectType.SERVICE),
+    ],
+)
+def test_subject_type(
+    auth: KeycloakJwtAuth,
+    claims: dict,
+    expected: SubjectType,
+):
+    """Test that the subject type is derived from the principal's username."""
+    assert auth._subject_type(claims) is expected  # noqa: SLF001
 
 
 async def test_missing_credentials(
@@ -443,7 +491,7 @@ async def test_custom_issuer_url(
         keycloak_url=keycloak_url,
         realm=fake_realm,
         client_id=fake_client_id,
-        scope=FakeAuthScopes.READ_ALL,
+        role=FakeAuthRoles.READER,
         issuer_url=issuer_url,
     )
 
@@ -462,7 +510,7 @@ async def test_custom_issuer_url(
         "exp": int((now + datetime.timedelta(minutes=10)).timestamp()),
         "aud": fake_client_id,
         "iss": f"{issuer_url}/realms/{fake_realm}",  # Using issuer_url
-        "scope": f"openid {FakeAuthScopes.READ_ALL.value}",
+        "resource_access": {fake_client_id: {"roles": [FakeAuthRoles.READER.value]}},
     }
     header = {"alg": "RS256", "kid": _test_private_key["kid"]}
     token = joserfc_jwt.encode(header, payload, private_key)

--- a/tests/core/test_multi_issuer_auth.py
+++ b/tests/core/test_multi_issuer_auth.py
@@ -39,7 +39,7 @@ _test_private_key = {
 
 FAKE_KEYCLOAK_URL = "http://localhost:8080"
 FAKE_KEYCLOAK_REALM = "destiny"
-FAKE_KEYCLOAK_CLIENT_ID = "destiny-repository-client"
+FAKE_KEYCLOAK_CLIENT_ID = "destiny-repository-client-test"
 FAKE_KEYCLOAK_ISSUER = f"{FAKE_KEYCLOAK_URL}/realms/{FAKE_KEYCLOAK_REALM}"
 
 FAKE_AZURE_APP_ID = "test_application_id"
@@ -129,7 +129,6 @@ def _generate_azure_token(
 
 def _generate_keycloak_token(
     user_payload: dict | None = None,
-    scope: str | None = None,
     role: str | None = None,
 ) -> str:
     """Generate a fake Keycloak token."""
@@ -140,15 +139,14 @@ def _generate_keycloak_token(
         "exp": int((now + datetime.timedelta(minutes=10)).timestamp()),
         "aud": FAKE_KEYCLOAK_CLIENT_ID,
         "iss": FAKE_KEYCLOAK_ISSUER,
-        "azp": "destiny-auth-client",
+        "azp": "destiny-auth-client-test",
+        "preferred_username": "testuser",
         "typ": "Bearer",
     }
     if user_payload:
         payload.update(user_payload)
-    if scope:
-        payload["scope"] = f"openid profile email {scope}"
     if role:
-        payload["realm_access"] = {"roles": [role]}
+        payload["resource_access"] = {FAKE_KEYCLOAK_CLIENT_ID: {"roles": [role]}}
     private_key = RSAKey.import_key(_test_private_key)
     header = {"alg": "RS256", "kid": _test_private_key["kid"]}
     return joserfc_jwt.encode(header, payload, private_key)
@@ -195,8 +193,8 @@ class TestMultiIssuerAuth:
         fake_request: Request,
         stub_keycloak_jwks: None,  # noqa: ARG002
     ) -> None:
-        """Keycloak token with correct scope is accepted."""
-        token = _generate_keycloak_token(scope=AuthScope.REFERENCE_READER)
+        """Keycloak token with correct client role is accepted."""
+        token = _generate_keycloak_token(role=AuthRole.REFERENCE_READER)
         credentials = Mock()
         credentials.credentials = token
         assert isinstance(await multi_issuer_auth(fake_request, credentials), frozenset)

--- a/tests/e2e/auth/conftest.py
+++ b/tests/e2e/auth/conftest.py
@@ -68,13 +68,16 @@ def keycloak_internal_url(keycloak: DockerContainer) -> str:
     return f"http://{host_name}:{port}"
 
 
-async def _get_keycloak_token(keycloak_url: str, scopes: str) -> str:
+async def get_keycloak_token(keycloak_url: str, username: str) -> str:
     """
-    Get a token from Keycloak.
+    Get a token from Keycloak for the given test user.
+
+    Authorization comes from the client roles the user holds on
+    ``destiny-repository-client-test``, so no scope is requested.
 
     Args:
         keycloak_url: Base URL for Keycloak (e.g., http://localhost:8080)
-        scopes: Space-separated list of scopes to request
+        username: The realm user to authenticate as
 
     Returns:
         The access token string
@@ -87,10 +90,10 @@ async def _get_keycloak_token(keycloak_url: str, scopes: str) -> str:
             token_url,
             data={
                 "grant_type": "password",
-                "client_id": "destiny-auth-client",
-                "username": "testuser",
+                "client_id": "destiny-auth-client-test",
+                "username": username,
                 "password": "testpass",
-                "scope": scopes,
+                "scope": "openid",
             },
             timeout=5.0,
         )
@@ -100,18 +103,20 @@ async def _get_keycloak_token(keycloak_url: str, scopes: str) -> str:
 
 @pytest.fixture(scope="session")
 async def keycloak_token(keycloak_url: str) -> str:
-    """Get a token from Keycloak with reference.reader.all scope."""
-    return await _get_keycloak_token(keycloak_url, "openid reference.reader.all")
+    """Get a token for testuser, who holds the developers-test client roles."""
+    return await get_keycloak_token(keycloak_url, "testuser")
 
 
 @pytest.fixture(scope="session")
-async def keycloak_token_all_scopes(keycloak_url: str) -> str:
-    """Get a token from Keycloak with all available scopes."""
-    return await _get_keycloak_token(
-        keycloak_url,
-        "openid reference.reader.all administrator.all import.writer.all "
-        "reference.deduplicator.all enhancement_request.writer.all robot.writer.all",
-    )
+async def keycloak_restricted_token(keycloak_url: str) -> str:
+    """Get a token for restricteduser, who holds reference.reader alone."""
+    return await get_keycloak_token(keycloak_url, "restricteduser")
+
+
+@pytest.fixture(scope="session")
+async def keycloak_legacy_realm_role_token(keycloak_url: str) -> str:
+    """Get a token for legacyuser, who holds robot.writer as a realm role."""
+    return await get_keycloak_token(keycloak_url, "legacyuser")
 
 
 def add_keycloak_env(
@@ -130,7 +135,7 @@ def add_keycloak_env(
         .with_env("KEYCLOAK_URL", keycloak_internal)
         .with_env("KEYCLOAK_ISSUER_URL", keycloak_external)
         .with_env("KEYCLOAK_REALM", "destiny")
-        .with_env("KEYCLOAK_CLIENT_ID", "destiny-repository-client")
+        .with_env("KEYCLOAK_CLIENT_ID", "destiny-repository-client-test")
     )
 
 

--- a/tests/e2e/auth/keycloak-import/test-destiny-realm.json
+++ b/tests/e2e/auth/keycloak-import/test-destiny-realm.json
@@ -93,6 +93,7 @@
       "directAccessGrantsEnabled": true,
       "standardFlowEnabled": true,
       "implicitFlowEnabled": false,
+      "fullScopeAllowed": false,
       "protocol": "openid-connect",
       "rootUrl": "",
       "baseUrl": "/",
@@ -179,6 +180,29 @@
         }
       ],
       "groups": ["legacy-realm-role-holders"]
+    }
+  ],
+  "clientScopeMappings": {
+    "destiny-repository-client-test": [
+      {
+        "client": "destiny-auth-client-test",
+        "roles": [
+          "administrator",
+          "import.writer",
+          "reference.reader",
+          "reference.full_text.reader",
+          "reference.deduplicator",
+          "enhancement_request.writer",
+          "robot.writer",
+          "robot.entitlement.writer"
+        ]
+      }
+    ]
+  },
+  "scopeMappings": [
+    {
+      "client": "destiny-auth-client-test",
+      "roles": ["robot.writer"]
     }
   ]
 }

--- a/tests/e2e/auth/keycloak-import/test-destiny-realm.json
+++ b/tests/e2e/auth/keycloak-import/test-destiny-realm.json
@@ -17,107 +17,75 @@
   "roles": {
     "realm": [
       {
-        "name": "administrator",
-        "description": "Can manage the repository itself"
-      },
-      {
-        "name": "import.writer",
-        "description": "Importers can import"
-      },
-      {
-        "name": "reference.reader",
-        "description": "Can view references"
-      },
-      {
-        "name": "reference.deduplicator",
-        "description": "Can deduplicate references"
-      },
-      {
-        "name": "enhancement_request.writer",
-        "description": "Can request enhancements"
-      },
-      {
         "name": "robot.writer",
-        "description": "Can register robots and rotate robot client secrets"
+        "description": "Legacy realm role, retained to prove it grants nothing"
       }
-    ]
+    ],
+    "client": {
+      "destiny-repository-client-test": [
+        {
+          "name": "administrator",
+          "description": "Can manage the repository itself"
+        },
+        {
+          "name": "import.writer",
+          "description": "Importers can import"
+        },
+        {
+          "name": "reference.reader",
+          "description": "Can view references"
+        },
+        {
+          "name": "reference.full_text.reader",
+          "description": "Can view reference full text"
+        },
+        {
+          "name": "reference.deduplicator",
+          "description": "Can deduplicate references"
+        },
+        {
+          "name": "enhancement_request.writer",
+          "description": "Can request enhancements"
+        },
+        {
+          "name": "robot.writer",
+          "description": "Can register robots and rotate robot client secrets"
+        },
+        {
+          "name": "robot.entitlement.writer",
+          "description": "Can manage robot entitlements"
+        }
+      ]
+    }
   },
   "groups": [
     {
-      "name": "consumers",
-      "realmRoles": ["reference.reader"]
-    },
-    {
-      "name": "developers",
-      "realmRoles": [
-        "administrator",
-        "import.writer",
-        "reference.reader",
-        "reference.deduplicator",
-        "enhancement_request.writer",
-        "robot.writer"
-      ]
-    }
-  ],
-  "clientScopes": [
-    {
-      "name": "administrator.all",
-      "description": "Full administrative access",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "true",
-        "display.on.consent.screen": "true"
+      "name": "consumers-test",
+      "clientRoles": {
+        "destiny-repository-client-test": ["reference.reader"]
       }
     },
     {
-      "name": "import.writer.all",
-      "description": "Import data access",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "true",
-        "display.on.consent.screen": "true"
+      "name": "developers-test",
+      "clientRoles": {
+        "destiny-repository-client-test": [
+          "administrator",
+          "import.writer",
+          "reference.reader",
+          "reference.deduplicator",
+          "enhancement_request.writer",
+          "robot.writer"
+        ]
       }
     },
     {
-      "name": "reference.reader.all",
-      "description": "Reference read access",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "true",
-        "display.on.consent.screen": "true"
-      }
-    },
-    {
-      "name": "reference.deduplicator.all",
-      "description": "Reference deduplication access",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "true",
-        "display.on.consent.screen": "true"
-      }
-    },
-    {
-      "name": "enhancement_request.writer.all",
-      "description": "Enhancement request write access",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "true",
-        "display.on.consent.screen": "true"
-      }
-    },
-    {
-      "name": "robot.writer.all",
-      "description": "Robot management access",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "true",
-        "display.on.consent.screen": "true"
-      }
+      "name": "legacy-realm-role-holders",
+      "realmRoles": ["robot.writer"]
     }
   ],
   "clients": [
     {
-      "clientId": "destiny-auth-client",
+      "clientId": "destiny-auth-client-test",
       "name": "DESTINY Repository Auth Client",
       "description": "Public client for all user authentication (UI, CLI, Postman, API testing tools)",
       "enabled": true,
@@ -130,14 +98,6 @@
       "baseUrl": "/",
       "redirectUris": ["*"],
       "webOrigins": ["*"],
-      "optionalClientScopes": [
-        "administrator.all",
-        "import.writer.all",
-        "reference.reader.all",
-        "reference.deduplicator.all",
-        "enhancement_request.writer.all",
-        "robot.writer.all"
-      ],
       "attributes": {
         "oauth2.device.authorization.grant.enabled": "true",
         "pkce.code.challenge.method": "S256",
@@ -150,7 +110,7 @@
           "protocolMapper": "oidc-audience-mapper",
           "consentRequired": false,
           "config": {
-            "included.client.audience": "destiny-repository-client",
+            "included.client.audience": "destiny-repository-client-test",
             "id.token.claim": "false",
             "access.token.claim": "true"
           }
@@ -158,7 +118,7 @@
       ]
     },
     {
-      "clientId": "destiny-repository-client",
+      "clientId": "destiny-repository-client-test",
       "name": "DESTINY Repository API",
       "description": "Backend API resource server",
       "enabled": true,
@@ -186,7 +146,7 @@
           "temporary": false
         }
       ],
-      "groups": ["developers"]
+      "groups": ["developers-test"]
     },
     {
       "username": "restricteduser",
@@ -202,33 +162,23 @@
           "temporary": false
         }
       ],
-      "groups": ["consumers"]
-    }
-  ],
-  "scopeMappings": [
-    {
-      "clientScope": "administrator.all",
-      "roles": ["administrator"]
+      "groups": ["consumers-test"]
     },
     {
-      "clientScope": "import.writer.all",
-      "roles": ["import.writer"]
-    },
-    {
-      "clientScope": "reference.reader.all",
-      "roles": ["reference.reader"]
-    },
-    {
-      "clientScope": "reference.deduplicator.all",
-      "roles": ["reference.deduplicator"]
-    },
-    {
-      "clientScope": "enhancement_request.writer.all",
-      "roles": ["enhancement_request.writer"]
-    },
-    {
-      "clientScope": "robot.writer.all",
-      "roles": ["robot.writer"]
+      "username": "legacyuser",
+      "email": "legacyuser@localhost",
+      "emailVerified": true,
+      "enabled": true,
+      "firstName": "Legacy",
+      "lastName": "User",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "testpass",
+          "temporary": false
+        }
+      ],
+      "groups": ["legacy-realm-role-holders"]
     }
   ]
 }

--- a/tests/e2e/auth/test_keycloak_auth.py
+++ b/tests/e2e/auth/test_keycloak_auth.py
@@ -28,37 +28,6 @@ class TestKeycloakAuth:
         # 200 for success (search returns empty list)
         assert response.status_code == 200
 
-    async def test_token_with_wrong_scope_fails(
-        self,
-        keycloak_api_client: httpx.AsyncClient,
-        keycloak_url: str,
-    ):
-        """Test that a token without required scope fails authorization."""
-        # Get a token with only openid scope (no reference.reader.all)
-        token_url = f"{keycloak_url}/realms/destiny/protocol/openid-connect/token"
-
-        async with httpx.AsyncClient() as client:
-            response = await client.post(
-                token_url,
-                data={
-                    "grant_type": "password",
-                    "client_id": "destiny-auth-client",
-                    "username": "testuser",
-                    "password": "testpass",
-                    "scope": "openid",  # Missing reference.reader.all
-                },
-            )
-            response.raise_for_status()
-            minimal_token = response.json()["access_token"]
-
-        # Try to access references endpoint
-        response = await keycloak_api_client.get(
-            "references/search/?q=test",
-            headers={"Authorization": f"Bearer {minimal_token}"},
-        )
-        # Should fail with 403 Forbidden (token is valid but lacks scope)
-        assert response.status_code == 403
-
     async def test_expired_token_fails(
         self,
         keycloak_api_client: httpx.AsyncClient,
@@ -71,20 +40,20 @@ class TestKeycloakAuth:
         )
         assert response.status_code == 401
 
-    async def test_requesting_assigned_scope_is_granted(
+    async def test_client_role_grants_access(
         self,
         keycloak_api_client: httpx.AsyncClient,
-        keycloak_token_all_scopes: str,
+        keycloak_token: str,
     ):
         """
-        Test that a user can access an endpoint when they have the required scope.
+        Test that a client role held on the repository's client grants access.
 
-        testuser has robot.writer.all via the developers group, which holds the
-        robot.writer role. The scopeMapping for robot.writer.all requires that role.
+        testuser holds robot.writer on destiny-repository-client-test via the
+        developers-test group.
         """
         response = await keycloak_api_client.post(
             "robots/",
-            headers={"Authorization": f"Bearer {keycloak_token_all_scopes}"},
+            headers={"Authorization": f"Bearer {keycloak_token}"},
             json={
                 "name": "Test Robot",
                 "description": "A robot created during e2e test",
@@ -98,41 +67,45 @@ class TestKeycloakAuth:
         assert "id" in robot_data
         assert "client_secret" in robot_data
 
-    async def test_requesting_unassigned_scope_is_denied(
+    async def test_unheld_client_role_is_denied(
         self,
         keycloak_api_client: httpx.AsyncClient,
-        keycloak_url: str,
+        keycloak_restricted_token: str,
     ):
         """
-        Test that a user cannot gain access by requesting a scope they don't have.
+        Test that a role the principal does not hold denies access.
 
-        The restricteduser does not have robot.writer.all assigned.
-        Even though they explicitly request it in the token, Keycloak should
-        not include it, and the API should deny access.
+        restricteduser holds reference.reader alone via consumers-test.
         """
-        token_url = f"{keycloak_url}/realms/destiny/protocol/openid-connect/token"
-
-        async with httpx.AsyncClient() as client:
-            response = await client.post(
-                token_url,
-                data={
-                    "grant_type": "password",
-                    "client_id": "destiny-auth-client",
-                    "username": "restricteduser",
-                    "password": "testpass",
-                    "scope": "openid robot.writer.all",
-                },
-            )
-            response.raise_for_status()
-            token = response.json()["access_token"]
-
         response = await keycloak_api_client.post(
             "robots/",
-            headers={"Authorization": f"Bearer {token}"},
+            headers={"Authorization": f"Bearer {keycloak_restricted_token}"},
             json={
                 "name": "Unauthorized Robot",
                 "description": "Should not be created",
                 "owner": "restricted@example.com",
+            },
+        )
+        assert response.status_code == 403
+
+    async def test_realm_role_confers_no_access(
+        self,
+        keycloak_api_client: httpx.AsyncClient,
+        keycloak_legacy_realm_role_token: str,
+    ):
+        """
+        Test that a realm role of the same name confers nothing.
+
+        legacyuser holds robot.writer as a realm role only. Realm roles are
+        realm-global and so cannot express an environment-scoped grant.
+        """
+        response = await keycloak_api_client.post(
+            "robots/",
+            headers={"Authorization": f"Bearer {keycloak_legacy_realm_role_token}"},
+            json={
+                "name": "Realm Role Robot",
+                "description": "Should not be created",
+                "owner": "legacy@example.com",
             },
         )
         assert response.status_code == 403

--- a/tests/e2e/auth/test_keycloak_auth.py
+++ b/tests/e2e/auth/test_keycloak_auth.py
@@ -1,6 +1,15 @@
 """End-to-end tests for Keycloak authentication."""
 
+import base64
+import json
+
 import httpx
+
+
+def _claims(token: str) -> dict:
+    """Decode a JWT payload without verifying it."""
+    body = token.split(".")[1]
+    return json.loads(base64.urlsafe_b64decode(body + "=" * (-len(body) % 4)))
 
 
 class TestKeycloakAuth:
@@ -99,6 +108,14 @@ class TestKeycloakAuth:
         legacyuser holds robot.writer as a realm role only. Realm roles are
         realm-global and so cannot express an environment-scoped grant.
         """
+        # Assert the role is in the token, so this tests that the API ignores
+        # realm_access rather than that Keycloak withheld the role.
+        claims = _claims(keycloak_legacy_realm_role_token)
+        assert "robot.writer" in claims["realm_access"]["roles"]
+        assert "robot.writer" not in claims.get("resource_access", {}).get(
+            "destiny-repository-client-test", {}
+        ).get("roles", [])
+
         response = await keycloak_api_client.post(
             "robots/",
             headers={"Authorization": f"Bearer {keycloak_legacy_realm_role_token}"},

--- a/ui/lib/authConfig.ts
+++ b/ui/lib/authConfig.ts
@@ -92,7 +92,7 @@ export async function createKeycloakConfig(): Promise<AuthProviderProps> {
   const clientId =
     runtime.KEYCLOAK_CLIENT_ID ||
     process.env.KEYCLOAK_CLIENT_ID ||
-    "destiny-auth-client";
+    "destiny-auth-client-local";
 
   return {
     authority: `${keycloakUrl}/realms/${realm}`,

--- a/ui/public/runtime-config.json.example
+++ b/ui/public/runtime-config.json.example
@@ -10,5 +10,5 @@
 
     "KEYCLOAK_URL": "http://localhost:8080",
     "KEYCLOAK_REALM": "destiny",
-    "KEYCLOAK_CLIENT_ID": "destiny-auth-client"
+    "KEYCLOAK_CLIENT_ID": "destiny-auth-client-local"
 }

--- a/uv.lock
+++ b/uv.lock
@@ -705,7 +705,7 @@ test = [
 
 [[package]]
 name = "destiny-sdk"
-version = "0.15.0"
+version = "0.16.0"
 source = { editable = "libs/sdk" }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
### Context

Cut over the repository to per-env authentication #67 

Will want to deploy this to development and test once https://github.com/destiny-evidence/destiny-shared-infra/pull/69 has landed

### What's changed

- Access is no longer gated on realm roles, but on client roles which are assigned per-environment. 
- Local and test keycloak realms use client roles 
- Procedure documentation updated 
- Scope requests removed from SDK and SDK auth supports client role auth
    - This is a breaking change for clients, we will need to update the bulk-abstract-ingest-robot as it is the only one using the keycloak flow. 

### Testing 

Unit tests/e2e tests updated

Tried this out locally with the client roles deployed from https://github.com/destiny-evidence/destiny-shared-infra/pull/69 after assigning myself to the groups. Also updated the keycloak realms to hold the new way of doing things for local testing. 

Deployed this branch to development after merging and applying https://github.com/destiny-evidence/destiny-shared-infra/pull/69 under the following scenarios 

* User with no `consumers-development` or `developers-development` group membership 
    * User was unable to use https://data.dev.evidence-repository.org/hpv to execute a search against dev destiny repository, receiving a 403 forbidden [expected] despite having realm roles which previously conveyed reference reader access. 
* User with `consumers-development` group membership (allows reference reads) 
    * User was able to use https://data.dev.evidence-repository.org/hpv to execute a search against dev destiny-repository
    * User was unable to get the status of an import batch [expected] despite having realm roles which previously conveyed import writer access. 
* User with `developers-development` but no `consumers-development` group membership (allows import writer and reference reads through the developers-development group)
    * User was able to use https://data.dev.evidence-repository.org/hpv to execute a search against dev destiny-repository
    * User was able to get the status of an import batch from dev destiny repository. 
* User with `developers-development` but no `developers` (old group) group membership was able to authenticate against dev-destiny repository with expected access.

Realm role access for AI summaries and vocabulary builder/reader behavior is unchanged.  
    
### What must we do when this is merged and deployed?

- Release the new SDK version and update https://github.com/destiny-evidence/bulk-abstract-ingest-robot/blob/eb2aa53fc9b37fd56c032d648f8af779561f3327/app/util/repository.py#L7
- Clean up the old realm-roles from destiny shared infra