### PR TITLE
Remove subnet delegations from container app subnets

### DIFF
--- a/infra/app/network.tf
+++ b/infra/app/network.tf
@@ -60,15 +60,17 @@ resource "azurerm_subnet" "app" {
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = ["10.0.4.0/23"]
 
-  delegation {
-    name = "app"
-    service_delegation {
-      name = "Microsoft.App/environments"
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-      ]
-    }
-  }
+  # If spinning up a new environment you will need to uncomment this block
+  # https://github.com/destiny-evidence/destiny-repository/issues/925
+  # delegation {
+  #   name = "app"
+  #   service_delegation {
+  #     name = "Microsoft.App/environments"
+  #     actions = [
+  #       "Microsoft.Network/virtualNetworks/subnets/join/action",
+  #     ]
+  #   }
+  # }
 }
 
 resource "azurerm_subnet" "tasks" {
@@ -77,15 +79,17 @@ resource "azurerm_subnet" "tasks" {
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = ["10.0.6.0/23"]
 
-  delegation {
-    name = "tasks"
-    service_delegation {
-      name = "Microsoft.App/environments"
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-      ]
-    }
-  }
+  # If spinning up a new environment you will need to uncomment this block
+  # https://github.com/destiny-evidence/destiny-repository/issues/925
+  # delegation {
+  #   name = "tasks"
+  #   service_delegation {
+  #     name = "Microsoft.App/environments"
+  #     actions = [
+  #       "Microsoft.Network/virtualNetworks/subnets/join/action",
+  #     ]
+  #   }
+  # }
 }
 
 resource "azurerm_subnet" "ui" {
@@ -94,13 +98,15 @@ resource "azurerm_subnet" "ui" {
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = ["10.0.8.0/23"]
 
-  delegation {
-    name = "ui"
-    service_delegation {
-      name = "Microsoft.App/environments"
-      actions = [
-        "Microsoft.Network/virtualNetworks/subnets/join/action",
-      ]
-    }
-  }
+  # If spinning up a new environment you will need to uncomment this block
+  # https://github.com/destiny-evidence/destiny-repository/issues/925
+  # delegation {
+  #   name = "ui"
+  #   service_delegation {
+  #     name = "Microsoft.App/environments"
+  #     actions = [
+  #       "Microsoft.Network/virtualNetworks/subnets/join/action",
+  #     ]
+  #   }
+  # }
 }


### PR DESCRIPTION
## Context 

https://futureevidence.slack.com/archives/C0810ARPCRG/p1786916602523009

Temporary fix for https://github.com/destiny-evidence/destiny-repository/issues/925

Container app environments on the legacy consumption-only environment type cannot have subnet delegations attached. 

## What's changed?
Subnet delegations have been removed from the container app subnets 

## Deployment plan
Apply the terraform changes, then go add and remove a tag from the container app environment so that it refreshes.