### PR TITLE
Add managed identity auth for research mapper

### DIFF
--- a/infra/app/auth.tf
+++ b/infra/app/auth.tf
@@ -175,3 +175,17 @@ resource "azuread_app_role_assignment" "ai_evidence_summariser_to_reference_full
   principal_object_id = data.azurerm_user_assigned_identity.ai_evidence_summariser[0].principal_id
   resource_object_id  = azuread_service_principal.destiny_repository.object_id
 }
+
+# Agentic mapping (research-mapper) role assignments
+data "azurerm_user_assigned_identity" "research_mapper" {
+  count               = var.research_mapper_app_name != null ? 1 : 0
+  name                = "${var.research_mapper_app_name}-${var.environment}"
+  resource_group_name = "rg-${var.research_mapper_app_name}-${var.environment}"
+}
+
+resource "azuread_app_role_assignment" "research_mapper_to_reference_reader" {
+  count               = length(data.azurerm_user_assigned_identity.research_mapper)
+  app_role_id         = azuread_application_app_role.reference_reader.role_id
+  principal_object_id = data.azurerm_user_assigned_identity.research_mapper[0].principal_id
+  resource_object_id  = azuread_service_principal.destiny_repository.object_id
+}

--- a/infra/app/auth.tf
+++ b/infra/app/auth.tf
@@ -179,8 +179,8 @@ resource "azuread_app_role_assignment" "ai_evidence_summariser_to_reference_full
 # Agentic mapping (research-mapper) role assignments
 data "azurerm_user_assigned_identity" "research_mapper" {
   count               = var.research_mapper_app_name != null ? 1 : 0
-  name                = "${var.research_mapper_app_name}-${var.environment}"
-  resource_group_name = "rg-${var.research_mapper_app_name}-${var.environment}"
+  name                = var.research_mapper_app_name
+  resource_group_name = "rg-${var.research_mapper_app_name}"
 }
 
 resource "azuread_app_role_assignment" "research_mapper_to_reference_reader" {

--- a/infra/app/variables.tf
+++ b/infra/app/variables.tf
@@ -240,6 +240,12 @@ variable "ai_evidence_summariser_app_name" {
   default     = null
 }
 
+variable "research_mapper_app_name" {
+  description = "The name of the Research Mapper application. Set to null to disable its role assignments."
+  type        = string
+  default     = null
+}
+
 # elasticsearch is not available in all regions, see https://www.elastic.co/cloud/regions
 variable "elasticsearch_region" {
   description = "Region for the Elasticsearch cluster"


### PR DESCRIPTION
Does what it says on the tin

Partner PR to https://github.com/destiny-evidence/research-mapper/pull/27