### PR TITLE
Trace deduplication candidate retrieval and the decision route

### DIFF
--- a/app/core/telemetry/attributes.py
+++ b/app/core/telemetry/attributes.py
@@ -135,6 +135,15 @@ class Attributes(StrEnum):
     )
     DEDUPLICATION_DECISION_CHANGED = "app.deduplication.decision_changed"
 
+    # The two switches deciding whether deduplication runs. Route cannot separate a
+    # disabled shortcut from one that did not match this reference.
+    DEDUPLICATION_CANDIDATE_SEARCH_ENABLED = (
+        "app.deduplication.candidate_search_enabled"
+    )
+    DEDUPLICATION_TRUSTED_IDENTIFIER_SHORTCUT_ENABLED = (
+        "app.deduplication.trusted_identifier_shortcut_enabled"
+    )
+
     # Other
     FILE_LINE_NO = "app.file.line_number"
 

--- a/app/core/telemetry/attributes.py
+++ b/app/core/telemetry/attributes.py
@@ -102,6 +102,39 @@ class Attributes(StrEnum):
         "app.robot_automation.pending_enhancement_count"
     )
 
+    # Deduplication candidate retrieval
+    CANDIDATE_SELECTION_RETRIEVAL_POLICY = "app.candidate_selection.retrieval_policy"
+    CANDIDATE_SELECTION_K_REQUESTED = "app.candidate_selection.k_requested"
+    CANDIDATE_SELECTION_INDEX_VERSION = "app.candidate_selection.index_version"
+    CANDIDATE_SELECTION_SEARCHABLE = "app.candidate_selection.searchable"
+    # Input presence, not policy opinion: these read the same under every policy.
+    CANDIDATE_SELECTION_TITLE_PRESENT = "app.candidate_selection.title_present"
+    CANDIDATE_SELECTION_AUTHORS_PRESENT = "app.candidate_selection.authors_present"
+    CANDIDATE_SELECTION_PUBLICATION_YEAR_PRESENT = (
+        "app.candidate_selection.publication_year_present"
+    )
+    CANDIDATE_SELECTION_ES_TOOK_MS = "app.candidate_selection.es_took_ms"
+    CANDIDATE_SELECTION_ES_TOTAL_HITS = "app.candidate_selection.es_total_hits"
+    CANDIDATE_SELECTION_ES_RETURNED = "app.candidate_selection.es_returned"
+    CANDIDATE_SELECTION_IDENTIFIER_RETURNED = (
+        "app.candidate_selection.identifier_returned"
+    )
+    # Identifier-only candidates sort ahead of ES ones, so a non-zero value means
+    # rank 1 came from the identifier route.
+    CANDIDATE_SELECTION_IDENTIFIER_ONLY_RETURNED = (
+        "app.candidate_selection.identifier_only_returned"
+    )
+    CANDIDATE_SELECTION_CANDIDATE_COUNT = "app.candidate_selection.candidate_count"
+    CANDIDATE_SELECTION_TRUNCATED = "app.candidate_selection.truncated"
+
+    # Deduplication decisions
+    DEDUPLICATION_ROUTE = "app.deduplication.route"
+    DEDUPLICATION_DETERMINATION = "app.deduplication.determination"
+    DEDUPLICATION_SIDE_EFFECT_DECISION_COUNT = (
+        "app.deduplication.side_effect_decision_count"
+    )
+    DEDUPLICATION_DECISION_CHANGED = "app.deduplication.decision_changed"
+
     # Other
     FILE_LINE_NO = "app.file.line_number"
 

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -134,7 +134,7 @@ class Visibility(StrEnum):
 
 
 class DeduplicationRoute(StrEnum):
-    """Which path decided a reference, for telemetry."""
+    """How deduplication resolved a reference."""
 
     IDENTIFIER_SHORTCUT = auto()
     """A configured trusted identifier type matched, so Elasticsearch was never

--- a/app/domain/references/models/models.py
+++ b/app/domain/references/models/models.py
@@ -133,6 +133,18 @@ class Visibility(StrEnum):
     """Is not visible, but may be passed to data mining processes."""
 
 
+class DeduplicationRoute(StrEnum):
+    """Which path decided a reference, for telemetry."""
+
+    IDENTIFIER_SHORTCUT = auto()
+    """A configured trusted identifier type matched, so Elasticsearch was never
+    consulted."""
+    CANDIDATE_SEARCH = auto()
+    """Candidates were retrieved and handed to the determinator."""
+    DISABLED = auto()
+    """Candidate search is switched off in this environment."""
+
+
 class DuplicateDetermination(StrEnum):
     """
     The determination of whether a reference is a duplicate.

--- a/app/domain/references/service.py
+++ b/app/domain/references/service.py
@@ -1283,6 +1283,14 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
         trace_attribute(
             Attributes.REFERENCE_ID, str(reference_duplicate_decision.reference_id)
         )
+        trace_attribute(
+            Attributes.DEDUPLICATION_CANDIDATE_SEARCH_ENABLED,
+            settings.feature_flags.enable_canonical_candidate_search,
+        )
+        trace_attribute(
+            Attributes.DEDUPLICATION_TRUSTED_IDENTIFIER_SHORTCUT_ENABLED,
+            bool(settings.trusted_unique_identifier_types),
+        )
         if settings.trusted_unique_identifier_types:
             shortcutted_decisions = await self._deduplication_service.shortcut_deduplication_using_identifiers(  # noqa: E501
                 reference_duplicate_decision,
@@ -1337,10 +1345,6 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
             reference_duplicate_decision.detail = (
                 "Canonical candidate search is disabled."
             )
-        trace_attribute(
-            Attributes.DEDUPLICATION_DETERMINATION,
-            reference_duplicate_decision.duplicate_determination.value,
-        )
 
         (
             reference_duplicate_decision,
@@ -1349,8 +1353,12 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
         ) = await self._deduplication_service.map_duplicate_decision(
             reference_duplicate_decision
         )
-        # False means the decision was refused and parked as DECOUPLED, which is
-        # otherwise only visible in the detail prose.
+        # Read after mapping, which can rewrite the determination to DECOUPLED.
+        trace_attribute(
+            Attributes.DEDUPLICATION_DETERMINATION,
+            reference_duplicate_decision.duplicate_determination.value,
+        )
+        # False when the outcome matched the active decision, or DECOUPLED replaced it.
         trace_attribute(Attributes.DEDUPLICATION_DECISION_CHANGED, decision_changed)
 
         await self.apply_reference_duplicate_decision_side_effects(

--- a/app/domain/references/service.py
+++ b/app/domain/references/service.py
@@ -1358,7 +1358,8 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
             Attributes.DEDUPLICATION_DETERMINATION,
             reference_duplicate_decision.duplicate_determination.value,
         )
-        # False when the outcome matched the active decision, or DECOUPLED replaced it.
+        # False when the outcome matched or a person's decision blocked it. The other
+        # two decoupling branches leave it true, so a decoupling can read as changed.
         trace_attribute(Attributes.DEDUPLICATION_DECISION_CHANGED, decision_changed)
 
         await self.apply_reference_duplicate_decision_side_effects(

--- a/app/domain/references/service.py
+++ b/app/domain/references/service.py
@@ -27,6 +27,7 @@ from app.domain.references.models.models import (
     CandidateSelectionRequest,
     CandidateSelectionResult,
     CrossFacetResult,
+    DeduplicationRoute,
     DuplicateDecisionAuthority,
     DuplicateDecisionTrigger,
     DuplicateDetermination,
@@ -1272,17 +1273,35 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
 
     @sql_unit_of_work
     @es_unit_of_work
+    # Innermost, so the unit-of-work spans do not take the attributes set below.
+    @tracer.start_as_current_span("Deduplicate reference")
     async def process_reference_duplicate_decision(
         self,
         reference_duplicate_decision: ReferenceDuplicateDecision,
     ) -> None:
         """Process a reference duplicate decision."""
+        trace_attribute(
+            Attributes.REFERENCE_ID, str(reference_duplicate_decision.reference_id)
+        )
         if settings.trusted_unique_identifier_types:
             shortcutted_decisions = await self._deduplication_service.shortcut_deduplication_using_identifiers(  # noqa: E501
                 reference_duplicate_decision,
                 settings.trusted_unique_identifier_types,
             )
             if shortcutted_decisions:
+                subject_decision, *side_effect_decisions = shortcutted_decisions
+                trace_attribute(
+                    Attributes.DEDUPLICATION_ROUTE,
+                    DeduplicationRoute.IDENTIFIER_SHORTCUT.value,
+                )
+                trace_attribute(
+                    Attributes.DEDUPLICATION_DETERMINATION,
+                    subject_decision.duplicate_determination.value,
+                )
+                trace_attribute(
+                    Attributes.DEDUPLICATION_SIDE_EFFECT_DECISION_COUNT,
+                    len(side_effect_decisions),
+                )
                 for decision in shortcutted_decisions:
                     await self.apply_reference_duplicate_decision_side_effects(
                         decision,
@@ -1291,6 +1310,12 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
                 return
 
         if settings.feature_flags.enable_canonical_candidate_search:
+            # Set before retrieval so an errored span without a determination
+            # separates a deduplication failure from a side-effect one.
+            trace_attribute(
+                Attributes.DEDUPLICATION_ROUTE,
+                DeduplicationRoute.CANDIDATE_SEARCH.value,
+            )
             candidate_selection = (
                 await self._deduplication_service.select_candidate_canonicals(
                     reference_duplicate_decision.reference_id
@@ -1303,12 +1328,19 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
                 )
             )
         else:
+            trace_attribute(
+                Attributes.DEDUPLICATION_ROUTE, DeduplicationRoute.DISABLED.value
+            )
             reference_duplicate_decision.duplicate_determination = (
                 DuplicateDetermination.UNSEARCHABLE
             )
             reference_duplicate_decision.detail = (
                 "Canonical candidate search is disabled."
             )
+        trace_attribute(
+            Attributes.DEDUPLICATION_DETERMINATION,
+            reference_duplicate_decision.duplicate_determination.value,
+        )
 
         (
             reference_duplicate_decision,
@@ -1317,6 +1349,9 @@ class ReferenceService(GenericService[ReferenceAntiCorruptionService]):
         ) = await self._deduplication_service.map_duplicate_decision(
             reference_duplicate_decision
         )
+        # False means the decision was refused and parked as DECOUPLED, which is
+        # otherwise only visible in the detail prose.
+        trace_attribute(Attributes.DEDUPLICATION_DECISION_CHANGED, decision_changed)
 
         await self.apply_reference_duplicate_decision_side_effects(
             reference_duplicate_decision,

--- a/app/domain/references/services/deduplication_service.py
+++ b/app/domain/references/services/deduplication_service.py
@@ -7,6 +7,7 @@ from opentelemetry import trace
 
 from app.core.config import DedupCandidateScoringConfig, Environment, get_settings
 from app.core.exceptions import DeduplicationError, DeduplicationValueError
+from app.core.telemetry.attributes import Attributes, trace_attribute
 from app.core.telemetry.logger import get_logger
 from app.domain.references.models.models import (
     Candidate,
@@ -186,6 +187,59 @@ def _searchability_reason(
     return "ok"
 
 
+def _trace_candidate_selection(
+    result: CandidateSelectionResult,
+    search_fields: CandidateCanonicalSearchFields,
+    *,
+    identifier_only_returned: int,
+) -> None:
+    """Record the retrieval diagnostics as bounded span attributes."""
+    diagnostics = result.diagnostics
+    trace_attribute(
+        Attributes.CANDIDATE_SELECTION_RETRIEVAL_POLICY, result.retrieval_policy.value
+    )
+    trace_attribute(Attributes.CANDIDATE_SELECTION_K_REQUESTED, result.k_requested)
+    trace_attribute(
+        Attributes.CANDIDATE_SELECTION_SEARCHABLE, result.input_searchability.searchable
+    )
+    # Truthiness throughout, matching the searchability gate where a 0 year is absent.
+    trace_attribute(
+        Attributes.CANDIDATE_SELECTION_TITLE_PRESENT, bool(search_fields.title)
+    )
+    trace_attribute(
+        Attributes.CANDIDATE_SELECTION_AUTHORS_PRESENT, bool(search_fields.authors)
+    )
+    trace_attribute(
+        Attributes.CANDIDATE_SELECTION_PUBLICATION_YEAR_PRESENT,
+        bool(search_fields.publication_year),
+    )
+    if result.index_version is not None:
+        trace_attribute(
+            Attributes.CANDIDATE_SELECTION_INDEX_VERSION, result.index_version
+        )
+    if diagnostics.es_took_ms is not None:
+        trace_attribute(
+            Attributes.CANDIDATE_SELECTION_ES_TOOK_MS, diagnostics.es_took_ms
+        )
+    if diagnostics.es_total_hits is not None:
+        trace_attribute(
+            Attributes.CANDIDATE_SELECTION_ES_TOTAL_HITS, diagnostics.es_total_hits
+        )
+    trace_attribute(Attributes.CANDIDATE_SELECTION_ES_RETURNED, diagnostics.es_returned)
+    trace_attribute(
+        Attributes.CANDIDATE_SELECTION_IDENTIFIER_RETURNED,
+        diagnostics.identifier_returned,
+    )
+    trace_attribute(
+        Attributes.CANDIDATE_SELECTION_IDENTIFIER_ONLY_RETURNED,
+        identifier_only_returned,
+    )
+    trace_attribute(
+        Attributes.CANDIDATE_SELECTION_CANDIDATE_COUNT, diagnostics.candidate_count
+    )
+    trace_attribute(Attributes.CANDIDATE_SELECTION_TRUNCATED, diagnostics.truncated)
+
+
 class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
     """Service for managing reference duplicate detection."""
 
@@ -198,6 +252,7 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
         """Initialize the service with a unit of work."""
         super().__init__(anti_corruption_service, sql_uow, es_uow)
 
+    @tracer.start_as_current_span("Select deduplication candidates")
     async def get_deduplication_candidates(
         self, request: CandidateSelectionRequest
     ) -> CandidateSelectionResult:
@@ -289,7 +344,7 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
             )
 
         es_returned = len(es_hits)
-        return CandidateSelectionResult(
+        result = CandidateSelectionResult(
             retrieval_policy=policy.name,
             index_version=index_version,
             k_requested=k,
@@ -311,6 +366,10 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
             ),
             candidates=candidates,
         )
+        _trace_candidate_selection(
+            result, search_fields, identifier_only_returned=len(identifier_only_ids)
+        )
+        return result
 
     async def _resolve_candidate_selection_input(
         self, selection_input: CandidateSelectionInput

--- a/app/domain/references/services/deduplication_service.py
+++ b/app/domain/references/services/deduplication_service.py
@@ -196,10 +196,6 @@ def _trace_candidate_selection(
     """Record the retrieval diagnostics as bounded span attributes."""
     diagnostics = result.diagnostics
     trace_attribute(
-        Attributes.CANDIDATE_SELECTION_RETRIEVAL_POLICY, result.retrieval_policy.value
-    )
-    trace_attribute(Attributes.CANDIDATE_SELECTION_K_REQUESTED, result.k_requested)
-    trace_attribute(
         Attributes.CANDIDATE_SELECTION_SEARCHABLE, result.input_searchability.searchable
     )
     # Truthiness throughout, matching the searchability gate where a 0 year is absent.
@@ -262,6 +258,11 @@ class DeduplicationService(GenericService[ReferenceAntiCorruptionService]):
             request.retrieval_policy or settings.dedup_scoring.default_retrieval_policy
         )
         policy = resolve_retrieval_policy(policy_name)
+        # Set before any I/O: an errored span is still groupable by what it was running.
+        trace_attribute(
+            Attributes.CANDIDATE_SELECTION_RETRIEVAL_POLICY, policy_name.value
+        )
+        trace_attribute(Attributes.CANDIDATE_SELECTION_K_REQUESTED, k)
 
         (
             search_fields,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,13 +4,19 @@ import asyncio
 import datetime
 import logging
 import re
-from collections.abc import AsyncGenerator, Callable
+from collections.abc import AsyncGenerator, Callable, Generator
 from typing import Any
 
 import pytest
 from alembic.command import upgrade
 from elasticsearch import AsyncElasticsearch
 from jose import jwt
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
 from pytest_httpx import HTTPXMock
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -33,6 +39,36 @@ settings = get_settings()
 MIGRATION_TASK: asyncio.Task | None = None
 
 logging.getLogger("asyncio").setLevel("DEBUG")
+
+
+@pytest.fixture(scope="session")
+def _span_exporter() -> InMemorySpanExporter:
+    """Attach to the installed provider: OTel honours set_tracer_provider once."""
+    exporter = InMemorySpanExporter()
+    trace.set_tracer_provider(TracerProvider())
+    provider = trace.get_tracer_provider()
+    assert isinstance(provider, TracerProvider)
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return exporter
+
+
+@pytest.fixture
+def span_attributes(
+    _span_exporter: InMemorySpanExporter,
+) -> Generator[Callable[[str], dict[str, Any]]]:
+    """Read the attributes of the most recent span with a given name."""
+    _span_exporter.clear()
+
+    def _attributes_of(name: str) -> dict[str, Any]:
+        spans = [s for s in _span_exporter.get_finished_spans() if s.name == name]
+        if not spans:
+            seen = sorted({s.name for s in _span_exporter.get_finished_spans()})
+            msg = f"No span named {name!r}. Recorded spans: {seen}"
+            raise AssertionError(msg)
+        return dict(spans[-1].attributes or {})
+
+    yield _attributes_of
+    _span_exporter.clear()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/unit/domain/references/deduplication/test_candidate_selection.py
+++ b/tests/unit/domain/references/deduplication/test_candidate_selection.py
@@ -405,6 +405,37 @@ async def test_inline_input_excludes_held_reference_from_identifier_candidates(
 
 
 @pytest.mark.asyncio
+async def test_failed_retrieval_still_records_what_it_was_running(
+    build_service, span_attributes
+):
+    service, es_refs, _, _ = build_service()
+    es_refs.search_for_candidate_canonicals = AsyncMock(
+        side_effect=RuntimeError("Elasticsearch is down")
+    )
+
+    with pytest.raises(RuntimeError):
+        await service.get_deduplication_candidates(
+            CandidateSelectionRequest(
+                input=CandidateSelectionInput(
+                    title="A study", authors=["Jane Doe"], publication_year=2025
+                ),
+                k=25,
+                hydrate=False,
+            )
+        )
+
+    attributes = span_attributes("Select deduplication candidates")
+    assert attributes["app.candidate_selection.k_requested"] == 25
+    assert (
+        attributes["app.candidate_selection.retrieval_policy"]
+        == "candidate_selection_v1"
+    )
+    # Everything the search would have produced is absent, so a failure is legible.
+    assert "app.candidate_selection.es_total_hits" not in attributes
+    assert "app.candidate_selection.candidate_count" not in attributes
+
+
+@pytest.mark.asyncio
 async def test_k_override_is_forwarded_to_elasticsearch(build_service):
     service, es_refs, _, _ = build_service()
 

--- a/tests/unit/domain/references/deduplication/test_candidate_selection.py
+++ b/tests/unit/domain/references/deduplication/test_candidate_selection.py
@@ -424,7 +424,9 @@ async def test_k_override_is_forwarded_to_elasticsearch(build_service):
 
 
 @pytest.mark.asyncio
-async def test_identifier_only_match_ranks_ahead_of_es_candidates(build_service):
+async def test_identifier_only_match_ranks_ahead_of_es_candidates(
+    build_service, span_attributes
+):
     doi = DOIIdentifierFactory.build()
     identifier_ref = ReferenceFactory.build(visibility="public")
     identifier_ref = identifier_ref.model_copy(
@@ -479,9 +481,15 @@ async def test_identifier_only_match_ranks_ahead_of_es_candidates(build_service)
     assert result.diagnostics.candidate_count == 11
     assert result.diagnostics.candidate_count > result.k_requested
 
+    attributes = span_attributes("Select deduplication candidates")
+    assert attributes["app.candidate_selection.identifier_returned"] == 1
+    assert attributes["app.candidate_selection.identifier_only_returned"] == 1
+
 
 @pytest.mark.asyncio
-async def test_same_canonical_from_both_routes_is_returned_once(build_service):
+async def test_same_canonical_from_both_routes_is_returned_once(
+    build_service, span_attributes
+):
     doi = DOIIdentifierFactory.build()
     matched = ReferenceFactory.build(visibility="public")
     matched = matched.model_copy(
@@ -521,6 +529,10 @@ async def test_same_canonical_from_both_routes_is_returned_once(build_service):
         "elasticsearch",
         "identifier",
     }
+
+    attributes = span_attributes("Select deduplication candidates")
+    assert attributes["app.candidate_selection.identifier_returned"] == 1
+    assert attributes["app.candidate_selection.identifier_only_returned"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/domain/references/services/test_deduplication_service.py
+++ b/tests/unit/domain/references/services/test_deduplication_service.py
@@ -1599,3 +1599,102 @@ class TestShortcutDeduplication:
         assert results_decision_2[0].detail == (
             "Shortcutted with trusted identifier(s)"
         )
+
+
+class TestCandidateSelectionTelemetry:
+    """Retrieval diagnostics reaching the trace, not just the response body."""
+
+    SPAN = "Select deduplication candidates"
+
+    @pytest.mark.asyncio
+    async def test_searchable_selection_records_retrieval_diagnostics(
+        self,
+        searchable_reference,
+        anti_corruption_service,
+        fake_uow,
+        fake_repository,
+        span_attributes,
+    ):
+        service = DeduplicationService(
+            anti_corruption_service,
+            fake_uow(references=fake_repository([searchable_reference])),
+            fake_uow(),
+        )
+        _mock_candidate_selection(service, uuid7())
+
+        await service.select_candidate_canonicals(searchable_reference.id)
+
+        assert span_attributes(self.SPAN) == {
+            "app.candidate_selection.retrieval_policy": "candidate_selection_v1",
+            "app.candidate_selection.k_requested": 10,
+            "app.candidate_selection.index_version": "reference_v3",
+            "app.candidate_selection.searchable": True,
+            "app.candidate_selection.title_present": True,
+            "app.candidate_selection.authors_present": True,
+            "app.candidate_selection.publication_year_present": True,
+            "app.candidate_selection.es_took_ms": 1,
+            "app.candidate_selection.es_total_hits": 1,
+            "app.candidate_selection.es_returned": 1,
+            "app.candidate_selection.identifier_returned": 0,
+            "app.candidate_selection.identifier_only_returned": 0,
+            "app.candidate_selection.candidate_count": 1,
+            "app.candidate_selection.truncated": False,
+        }
+
+    @pytest.mark.asyncio
+    async def test_truncation_is_recorded_when_hits_exceed_returned(
+        self,
+        searchable_reference,
+        anti_corruption_service,
+        fake_uow,
+        fake_repository,
+        span_attributes,
+    ):
+        service = DeduplicationService(
+            anti_corruption_service,
+            fake_uow(references=fake_repository([searchable_reference])),
+            fake_uow(),
+        )
+        _mock_candidate_selection(service, uuid7())
+        service.es_uow.references.search_for_candidate_canonicals = AsyncMock(
+            return_value=CandidateCanonicalSearchResult(
+                hits=[ESScoreResult(id=uuid7(), score=1.0)],
+                total=ESSearchTotal(value=64, relation="eq"),
+                took_ms=137,
+            )
+        )
+
+        await service.select_candidate_canonicals(searchable_reference.id)
+
+        attributes = span_attributes(self.SPAN)
+        assert attributes["app.candidate_selection.truncated"] is True
+        assert attributes["app.candidate_selection.es_total_hits"] == 64
+        assert attributes["app.candidate_selection.es_returned"] == 1
+
+    @pytest.mark.asyncio
+    async def test_unsearchable_selection_records_the_missing_fields(
+        self,
+        reference,
+        anti_corruption_service,
+        fake_uow,
+        fake_repository,
+        span_attributes,
+    ):
+        reference.enhancements = []
+        service = DeduplicationService(
+            anti_corruption_service,
+            fake_uow(references=fake_repository([reference])),
+            fake_uow(),
+        )
+        _mock_candidate_selection(service)
+
+        await service.select_candidate_canonicals(reference.id)
+
+        attributes = span_attributes(self.SPAN)
+        assert attributes["app.candidate_selection.searchable"] is False
+        assert attributes["app.candidate_selection.title_present"] is False
+        assert attributes["app.candidate_selection.authors_present"] is False
+        assert attributes["app.candidate_selection.publication_year_present"] is False
+        assert "app.candidate_selection.es_took_ms" not in attributes
+        assert "app.candidate_selection.es_total_hits" not in attributes
+        assert "app.candidate_selection.index_version" not in attributes

--- a/tests/unit/domain/references/test_service.py
+++ b/tests/unit/domain/references/test_service.py
@@ -1651,3 +1651,149 @@ async def test_collect_search_enhancement_request_marks_failed_on_error(
     stored = fake_requests.get_first_record()
     assert stored.search_status == EnhancementRequestSearchStatus.FAILED
     assert "boom" in stored.error
+
+
+class TestDeduplicationDecisionTelemetry:
+    """Which route decided a reference, and what it decided, reaching the trace."""
+
+    SPAN = "Deduplicate reference"
+
+    @pytest.mark.asyncio
+    async def test_candidate_search_route_records_the_determination(
+        self, duplicate_processing_service, monkeypatch, span_attributes
+    ):
+        from app.domain.references import service as reference_service_module
+
+        monkeypatch.setattr(
+            reference_service_module.settings.feature_flags,
+            "enable_canonical_candidate_search",
+            True,
+        )
+        service, decision = duplicate_processing_service
+        determined = decision.model_copy(
+            update={"duplicate_determination": DuplicateDetermination.CANONICAL}
+        )
+        service._deduplication_service.determine_canonical_from_candidates = AsyncMock(  # noqa: SLF001
+            return_value=determined
+        )
+        service._deduplication_service.map_duplicate_decision = AsyncMock(  # noqa: SLF001
+            return_value=(determined, True, None)
+        )
+
+        await service.process_reference_duplicate_decision(decision)
+
+        assert span_attributes(self.SPAN) == {
+            "app.reference.id": str(decision.reference_id),
+            "app.deduplication.route": "candidate_search",
+            "app.deduplication.determination": "canonical",
+            "app.deduplication.decision_changed": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_a_refused_decision_records_that_nothing_changed(
+        self, duplicate_processing_service, monkeypatch, span_attributes
+    ):
+        from app.domain.references import service as reference_service_module
+
+        monkeypatch.setattr(
+            reference_service_module.settings.feature_flags,
+            "enable_canonical_candidate_search",
+            True,
+        )
+        service, decision = duplicate_processing_service
+        decoupled = decision.model_copy(
+            update={"duplicate_determination": DuplicateDetermination.DECOUPLED}
+        )
+        service._deduplication_service.determine_canonical_from_candidates = AsyncMock(  # noqa: SLF001
+            return_value=decoupled
+        )
+        service._deduplication_service.map_duplicate_decision = AsyncMock(  # noqa: SLF001
+            return_value=(decoupled, False, None)
+        )
+
+        await service.process_reference_duplicate_decision(decision)
+
+        attributes = span_attributes(self.SPAN)
+        assert attributes["app.deduplication.decision_changed"] is False
+        assert attributes["app.deduplication.determination"] == "decoupled"
+
+    @pytest.mark.asyncio
+    async def test_identifier_shortcut_route_records_its_side_effects(
+        self, duplicate_processing_service, monkeypatch, span_attributes
+    ):
+        from app.domain.references import service as reference_service_module
+
+        monkeypatch.setattr(
+            reference_service_module.settings,
+            "trusted_unique_identifier_types",
+            {"open_alex"},
+        )
+        service, decision = duplicate_processing_service
+        canonical_id = uuid7()
+        shortcutted = decision.model_copy(
+            update={
+                "duplicate_determination": DuplicateDetermination.DUPLICATE,
+                "canonical_reference_id": canonical_id,
+            }
+        )
+        side_effect = ReferenceDuplicateDecision(
+            reference_id=uuid7(),
+            duplicate_determination=DuplicateDetermination.DUPLICATE,
+            canonical_reference_id=canonical_id,
+        )
+        service._deduplication_service.shortcut_deduplication_using_identifiers = (  # noqa: SLF001
+            AsyncMock(return_value=[shortcutted, side_effect])
+        )
+
+        await service.process_reference_duplicate_decision(decision)
+
+        assert span_attributes(self.SPAN) == {
+            "app.reference.id": str(decision.reference_id),
+            "app.deduplication.route": "identifier_shortcut",
+            "app.deduplication.determination": "duplicate",
+            "app.deduplication.side_effect_decision_count": 1,
+        }
+
+    @pytest.mark.asyncio
+    async def test_disabled_candidate_search_records_a_disabled_route(
+        self, duplicate_processing_service, monkeypatch, span_attributes
+    ):
+        # Both branches end at unsearchable, so the route is the only thing
+        # separating "never searched" from "searched and found nothing".
+        from app.domain.references import service as reference_service_module
+
+        monkeypatch.setattr(
+            reference_service_module.settings.feature_flags,
+            "enable_canonical_candidate_search",
+            False,
+        )
+        service, decision = duplicate_processing_service
+
+        await service.process_reference_duplicate_decision(decision)
+
+        attributes = span_attributes(self.SPAN)
+        assert attributes["app.deduplication.route"] == "disabled"
+        assert attributes["app.deduplication.determination"] == "unsearchable"
+
+    @pytest.mark.asyncio
+    async def test_failure_before_a_determination_leaves_it_unset(
+        self, duplicate_processing_service, monkeypatch, span_attributes
+    ):
+        from app.domain.references import service as reference_service_module
+
+        monkeypatch.setattr(
+            reference_service_module.settings.feature_flags,
+            "enable_canonical_candidate_search",
+            True,
+        )
+        service, decision = duplicate_processing_service
+        service._deduplication_service.select_candidate_canonicals = AsyncMock(  # noqa: SLF001
+            side_effect=RuntimeError("Elasticsearch is down")
+        )
+
+        with pytest.raises(RuntimeError):
+            await service.process_reference_duplicate_decision(decision)
+
+        attributes = span_attributes(self.SPAN)
+        assert attributes["app.deduplication.route"] == "candidate_search"
+        assert "app.deduplication.determination" not in attributes

--- a/tests/unit/domain/references/test_service.py
+++ b/tests/unit/domain/references/test_service.py
@@ -1684,13 +1684,15 @@ class TestDeduplicationDecisionTelemetry:
 
         assert span_attributes(self.SPAN) == {
             "app.reference.id": str(decision.reference_id),
+            "app.deduplication.candidate_search_enabled": True,
+            "app.deduplication.trusted_identifier_shortcut_enabled": False,
             "app.deduplication.route": "candidate_search",
             "app.deduplication.determination": "canonical",
             "app.deduplication.decision_changed": True,
         }
 
     @pytest.mark.asyncio
-    async def test_a_refused_decision_records_that_nothing_changed(
+    async def test_a_refused_decision_records_what_persisted_not_what_was_proposed(
         self, duplicate_processing_service, monkeypatch, span_attributes
     ):
         from app.domain.references import service as reference_service_module
@@ -1701,11 +1703,14 @@ class TestDeduplicationDecisionTelemetry:
             True,
         )
         service, decision = duplicate_processing_service
+        proposed = decision.model_copy(
+            update={"duplicate_determination": DuplicateDetermination.DUPLICATE}
+        )
         decoupled = decision.model_copy(
             update={"duplicate_determination": DuplicateDetermination.DECOUPLED}
         )
         service._deduplication_service.determine_canonical_from_candidates = AsyncMock(  # noqa: SLF001
-            return_value=decoupled
+            return_value=proposed
         )
         service._deduplication_service.map_duplicate_decision = AsyncMock(  # noqa: SLF001
             return_value=(decoupled, False, None)
@@ -1728,6 +1733,12 @@ class TestDeduplicationDecisionTelemetry:
             "trusted_unique_identifier_types",
             {"open_alex"},
         )
+        # Production's shape: the shortcut carries the stream, candidate search is off.
+        monkeypatch.setattr(
+            reference_service_module.settings.feature_flags,
+            "enable_canonical_candidate_search",
+            False,
+        )
         service, decision = duplicate_processing_service
         canonical_id = uuid7()
         shortcutted = decision.model_copy(
@@ -1749,6 +1760,8 @@ class TestDeduplicationDecisionTelemetry:
 
         assert span_attributes(self.SPAN) == {
             "app.reference.id": str(decision.reference_id),
+            "app.deduplication.candidate_search_enabled": False,
+            "app.deduplication.trusted_identifier_shortcut_enabled": True,
             "app.deduplication.route": "identifier_shortcut",
             "app.deduplication.determination": "duplicate",
             "app.deduplication.side_effect_decision_count": 1,


### PR DESCRIPTION
Closes #937. The spans are `Select deduplication candidates` and `Deduplicate reference`.

## Two departures from the issue text

**Field presence, not a list of missing fields.** A joined string needs substring matching
to filter, and it shifts with the policy: a missing year only counts as missing if the
policy wants one. So the three booleans are always set, and `searchable` carries the
verdict separately. They test truthiness like the searchability gate, so a `0` year is
absent in both.

**Rollout settings on the decision span, not the resource.** The resource is the
conventional home for process config, but it would put deduplication vocabulary on every
span the service emits and change the shared `configure_otel` signature.
`service.instance.id` is already on this span's resource, so a half-landed rolling restart
is still visible by instance. Config columns for the whole platform would be a separate
change.

Route alone does not cover it: `route=candidate_search` looks the same whether the shortcut
was off, or on and unmatched.

## Also in here

**A defect fixed.** `app.deduplication.determination` is now read after
`map_duplicate_decision`, not before. Three branches in there rewrite the determination to
`DECOUPLED`, so the span reported a verdict that never reached the database. The
identifier-shortcut route already read its post-mapping decision, so the same attribute
meant different things depending on the route.

**Slightly wider than the issue.** `route` is needed to make the staged rollout
readable. The decision span also carries `determination`, `decision_changed` and the
shortcut's side-effect count, which belong to the scoring-and-decision telemetry tracked
in #938; those values were already available at the same orchestration point.

`decision_changed` is false only on the person-protected branch and the exact no-op, so
the other two decoupling branches read as changed. It overstates effective changes and
understates held ones; the decision-telemetry semantics belong to #938.

## Validation performed

- Ran the deduplication path locally with the app and worker up, and read both spans off
  the wire rather than out of a test. Every attribute agreed with the endpoint's own
  diagnostics block.
- Forced the `DECOUPLED` rewrite by hand, making a person-authority decision through the
  manual API and then invoking automatic deduplication. The span reports what persisted;
  before the ordering fix it reported the proposal.
- Confirmed absent reads as absent rather than zero: unsearchable input carries the
  retrieval policy but no `index_version`, `es_took_ms` or `es_total_hits`.
- A failed retrieval keeps the policy and `k`, which are set before any I/O, so an
  Elasticsearch failure is still groupable by what it was running.
- Drove a sweep through the candidates endpoint into Honeycomb, where all fifteen
  retrieval attributes arrive as their own groupable columns.
- Full suite green in CI collection order at 1,198 passed and 1 skipped, end-to-end suite
  green at 29, pre-commit clean including mypy and vulture.

